### PR TITLE
Add command timeout for git operations

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -53,10 +53,20 @@ std::string timestamp() {
     return std::string(buf);
 }
 
-std::string run_cmd(const std::string& cmd) {
+std::string run_cmd(const std::string& cmd, int timeout_sec = 0) {
+#ifndef _WIN32
+    std::string final_cmd = cmd;
+    if (timeout_sec > 0) {
+        final_cmd = "timeout " + std::to_string(timeout_sec) + " " + cmd;
+    }
+#else
+    std::string final_cmd = cmd; // Timeout not supported on Windows fallback
+    (void)timeout_sec;
+#endif
+
     std::string data;
     char buffer[256];
-    FILE* stream = popen(cmd.c_str(), "r");
+    FILE* stream = popen(final_cmd.c_str(), "r");
     if (stream) {
         while (fgets(buffer, sizeof(buffer), stream)) {
             data.append(buffer);
@@ -74,31 +84,31 @@ bool is_git_repo(const fs::path& p) {
 std::string get_local_hash(const fs::path& repo) {
     std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
         + " && git rev-parse HEAD 2>&1";
-    return run_cmd(cmd);
+    return run_cmd(cmd, 30);
 }
 
 std::string get_current_branch(const fs::path& repo) {
     std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
         + " && git rev-parse --abbrev-ref HEAD 2>&1";
-    return run_cmd(cmd);
+    return run_cmd(cmd, 30);
 }
 
 std::string get_remote_hash(const fs::path& repo, const std::string& branch) {
     std::string fetch_cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
         + " && git fetch --quiet 2>&1";
-    run_cmd(fetch_cmd);
+    run_cmd(fetch_cmd, 30);
     std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
         + " && git rev-parse origin/" + branch + " 2>&1";
-    return run_cmd(cmd);
+    return run_cmd(cmd, 30);
 }
 
 // Return codes: 0 = ok, 1 = package-lock reset+pull, 2 = error
 int try_pull(const fs::path& repo, std::string& out_pull_log) {
-    std::string pull = run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git pull 2>&1");
+    std::string pull = run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git pull 2>&1", 30);
     out_pull_log = pull;
     if (pull.find("package-lock.json") != std::string::npos && pull.find("Please commit your changes or stash them before you merge") != std::string::npos) {
-        run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git checkout -- package-lock.json");
-        pull = run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git pull 2>&1");
+        run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git checkout -- package-lock.json", 30);
+        pull = run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git pull 2>&1", 30);
         out_pull_log += "\n[Auto-discarded package-lock.json]\n" + pull;
         if (pull.find("Already up to date") != std::string::npos || pull.find("Updating") != std::string::npos)
             return 1;


### PR DESCRIPTION
## Summary
- add optional timeout to `run_cmd`
- use 30 second timeout for git operations

## Testing
- `g++ -std=c++17 -o autogitpull autogitpull.cpp`


------
https://chatgpt.com/codex/tasks/task_e_687516b303a0832596f9fcf7f957f877