### PR TITLE
Add option to include private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # autogitpull
 Automatic Git Puller &amp; Monitor
+
+By default, repositories whose `origin` remote does not point to GitHub or require
+authentication are skipped during scanning. Pass `--include-private` after the
+root folder to include these repositories.


### PR DESCRIPTION
## Summary
- default to skipping private or non-GitHub repositories
- add `--include-private` switch to scan them
- document new behaviour

## Testing
- `g++ -std=c++17 autogitpull.cpp -o autogitpull`


------
https://chatgpt.com/codex/tasks/task_e_6875191a5c188325bbf8c2cde4800abf