### PR TITLE
Implement quote_path helper

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -78,33 +78,38 @@ std::string run_cmd(const std::string& cmd, int timeout_sec = 0) {
     return data;
 }
 
+// Quote a filesystem path for safe command usage
+std::string quote_path(const fs::path& p) {
+    return std::string(QUOTE) + p.string() + std::string(QUOTE);
+}
+
 bool is_git_repo(const fs::path& p) {
     return fs::exists(p / ".git") && fs::is_directory(p / ".git");
 }
 
 std::string get_local_hash(const fs::path& repo) {
-    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+    std::string cmd = "cd " + quote_path(repo)
         + " && git rev-parse HEAD 2>&1";
     return run_cmd(cmd, 30);
 }
 
 std::string get_current_branch(const fs::path& repo) {
-    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+    std::string cmd = "cd " + quote_path(repo)
         + " && git rev-parse --abbrev-ref HEAD 2>&1";
     return run_cmd(cmd, 30);
 }
 
 std::string get_remote_hash(const fs::path& repo, const std::string& branch) {
-    std::string fetch_cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+    std::string fetch_cmd = "cd " + quote_path(repo)
         + " && git fetch --quiet 2>&1";
     run_cmd(fetch_cmd, 30);
-    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+    std::string cmd = "cd " + quote_path(repo)
         + " && git rev-parse origin/" + branch + " 2>&1";
     return run_cmd(cmd, 30);
 }
 
 std::string get_origin_url(const fs::path& repo) {
-    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+    std::string cmd = "cd " + quote_path(repo)
         + " && git config --get remote.origin.url 2>&1";
     return run_cmd(cmd, 15);
 }
@@ -114,7 +119,7 @@ bool is_github_url(const std::string& url) {
 }
 
 bool remote_accessible(const fs::path& repo) {
-    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+    std::string cmd = "cd " + quote_path(repo)
         + " && git ls-remote -h origin HEAD 2>&1";
     std::string out = run_cmd(cmd, 30);
     if (out.find("fatal") != std::string::npos || out.find("Permission denied") != std::string::npos
@@ -125,11 +130,11 @@ bool remote_accessible(const fs::path& repo) {
 
 // Return codes: 0 = ok, 1 = package-lock reset+pull, 2 = error
 int try_pull(const fs::path& repo, std::string& out_pull_log) {
-    std::string pull = run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git pull 2>&1", 30);
+    std::string pull = run_cmd("cd " + quote_path(repo) + " && git pull 2>&1", 30);
     out_pull_log = pull;
     if (pull.find("package-lock.json") != std::string::npos && pull.find("Please commit your changes or stash them before you merge") != std::string::npos) {
-        run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git checkout -- package-lock.json", 30);
-        pull = run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git pull 2>&1", 30);
+        run_cmd("cd " + quote_path(repo) + " && git checkout -- package-lock.json", 30);
+        pull = run_cmd("cd " + quote_path(repo) + " && git pull 2>&1", 30);
         out_pull_log += "\n[Auto-discarded package-lock.json]\n" + pull;
         if (pull.find("Already up to date") != std::string::npos || pull.find("Updating") != std::string::npos)
             return 1;


### PR DESCRIPTION
## Summary
- add `quote_path()` to quote filesystem paths
- replace explicit path quoting uses with `quote_path` helper

## Testing
- `g++ -std=c++17 -pthread autogitpull.cpp -o autogitpull_test`
- `./autogitpull_test` *(fails: Usage)*

------
https://chatgpt.com/codex/tasks/task_e_6875209faaac8325874c4a7ad49e1034