### PR TITLE
Add show-skipped flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # autogitpull
-Automatic Git Puller &amp; Monitor
+Automatic Git Puller & Monitor
 
-By default, repositories whose `origin` remote does not point to GitHub or require
-authentication are skipped during scanning. Pass `--include-private` after the
-root folder to include these repositories.
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped]`
+
+By default, repositories whose `origin` remote does not point to GitHub or require authentication are skipped during scanning. Pass `--include-private` after the root folder to include these repositories. Skipped repositories are hidden from the TUI unless you also pass `--show-skipped`.

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -160,7 +160,8 @@ struct RepoInfo {
     std::string last_pull_log;
 };
 
-void draw_tui(const std::vector<fs::path>& all_repos, const std::map<fs::path, RepoInfo>& repo_infos, int interval, int seconds_left, bool scanning) {
+void draw_tui(const std::vector<fs::path>& all_repos, const std::map<fs::path, RepoInfo>& repo_infos,
+              int interval, int seconds_left, bool scanning, bool show_skipped) {
     std::ostringstream out;
     out << "\033[2J\033[H";
     out << COLOR_BOLD << "AutoGitPull TUI   " << COLOR_RESET
@@ -181,6 +182,8 @@ void draw_tui(const std::vector<fs::path>& all_repos, const std::map<fs::path, R
             ri.status = RS_CHECKING;
             ri.message = "Pending...";
         }
+        if (ri.status == RS_SKIPPED && !show_skipped)
+            continue;
         std::string color = COLOR_GRAY, status_s = "CHECK    ";
         switch (ri.status) {
             case RS_CHECKING:      color = COLOR_CYAN;   status_s = "Checking "; break;
@@ -307,14 +310,25 @@ int main(int argc, char* argv[]) {
     enable_win_ansi();
     std::cout << "\033[?1049h"; // enter alternate buffer
     try {
-        if (argc < 2 || argc > 3) {
-            std::cerr << "Usage: " << argv[0] << " <root-folder> [--include-private]\n";
+        if (argc < 2 || argc > 4) {
+            std::cerr << "Usage: " << argv[0] << " <root-folder> [--include-private] [--show-skipped]\n";
             std::cout << "\033[?1049l" << std::flush; // leave alt buffer
             return 1;
         }
         bool include_private = false;
-        if (argc == 3 && std::string(argv[2]) == "--include-private")
-            include_private = true;
+        bool show_skipped = false;
+        for (int i = 2; i < argc; ++i) {
+            std::string arg = argv[i];
+            if (arg == "--include-private")
+                include_private = true;
+            else if (arg == "--show-skipped")
+                show_skipped = true;
+            else {
+                std::cerr << "Unknown option: " << arg << "\n";
+                std::cout << "\033[?1049l" << std::flush;
+                return 1;
+            }
+        }
         fs::path root = argv[1];
         if (!fs::exists(root) || !fs::is_directory(root)) {
             std::cerr << "Root path does not exist or is not a directory.\n";
@@ -347,7 +361,7 @@ int main(int argc, char* argv[]) {
             }
             {
                 std::lock_guard<std::mutex> lk(mtx);
-                draw_tui(all_repos, repo_infos, interval, countdown, scanning);
+                draw_tui(all_repos, repo_infos, interval, countdown, scanning, show_skipped);
             }
             std::this_thread::sleep_for(std::chrono::seconds(1));
             countdown--;


### PR DESCRIPTION
## Summary
- add `--show-skipped` option
- support new flag when drawing TUI
- hide skipped repos unless requested
- document new behaviour in README

## Testing
- `g++ -std=c++17 autogitpull.cpp -o autogitpull && echo "compiled"`

------
https://chatgpt.com/codex/tasks/task_e_687520b48f448325aaddab4bdb4e0d95