### PR TITLE
Refactor autogitpull into modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # autogitpull
-Automatic Git Puller &amp; Monitor
+Automatic Git Puller & Monitor
 
 By default, repositories whose `origin` remote does not point to GitHub or require
 authentication are skipped during scanning. Pass `--include-private` after the
 root folder to include these repositories.
+
+Use `--show-skipped` to display repositories that were skipped in the TUI.

--- a/arg_parser.cpp
+++ b/arg_parser.cpp
@@ -1,0 +1,21 @@
+#include "arg_parser.h"
+#include <iostream>
+
+ParsedArgs ArgParser::parse(int argc, char* argv[]) {
+    ParsedArgs args;
+    if (argc < 2) {
+        return args;
+    }
+    args.root = argv[1];
+    for (int i = 2; i < argc; ++i) {
+        std::string opt = argv[i];
+        if (opt == "--include-private") {
+            args.include_private = true;
+        } else if (opt == "--show-skipped") {
+            args.show_skipped = true;
+        } else {
+            std::cerr << "Unknown option: " << opt << "\n";
+        }
+    }
+    return args;
+}

--- a/arg_parser.h
+++ b/arg_parser.h
@@ -1,0 +1,18 @@
+#ifndef ARG_PARSER_H
+#define ARG_PARSER_H
+
+#include <string>
+#include <vector>
+
+struct ParsedArgs {
+    std::string root;
+    bool include_private = false;
+    bool show_skipped = false;
+};
+
+class ArgParser {
+public:
+    ParsedArgs parse(int argc, char* argv[]);
+};
+
+#endif // ARG_PARSER_H

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -1,299 +1,113 @@
 #include <iostream>
-#include <iomanip>
 #include <filesystem>
 #include <vector>
 #include <string>
 #include <thread>
 #include <chrono>
-#include <ctime>
 #include <set>
 #include <map>
 #include <mutex>
 #include <atomic>
-#include <sstream>
-#include <cstdlib>
 
-#ifdef _WIN32
-#include <windows.h>
-#define popen _popen
-#define pclose _pclose
-const char* QUOTE = "\"";
-#else
-const char* QUOTE = "'";
-#endif
+#include "git_utils.h"
+#include "repo_info.h"
+#include "tui.h"
+#include "arg_parser.h"
 
 namespace fs = std::filesystem;
-
-// ANSI color codes
-const char* COLOR_RESET = "\033[0m";
-const char* COLOR_GREEN = "\033[32m";
-const char* COLOR_YELLOW = "\033[33m";
-const char* COLOR_RED = "\033[31m";
-const char* COLOR_CYAN = "\033[36m";
-const char* COLOR_GRAY = "\033[90m";
-const char* COLOR_BOLD = "\033[1m";
-
-#ifdef _WIN32
-void enable_win_ansi() {
-    // Enable ANSI color on Windows 10+ console
-    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-    if (hOut == INVALID_HANDLE_VALUE) return;
-    DWORD dwMode = 0;
-    if (!GetConsoleMode(hOut, &dwMode)) return;
-    dwMode |= 0x0004; // ENABLE_VIRTUAL_TERMINAL_PROCESSING
-    SetConsoleMode(hOut, dwMode);
-}
-#else
-void enable_win_ansi() {} // No-op on non-Windows
-#endif
-
-std::string timestamp() {
-    std::time_t now = std::time(nullptr);
-    char buf[32];
-    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
-    return std::string(buf);
-}
-
-std::string run_cmd(const std::string& cmd, int timeout_sec = 0) {
-#ifndef _WIN32
-    std::string final_cmd = cmd;
-    if (timeout_sec > 0) {
-        final_cmd = "timeout " + std::to_string(timeout_sec) + " " + cmd;
-    }
-#else
-    std::string final_cmd = cmd; // Timeout not supported on Windows fallback
-    (void)timeout_sec;
-#endif
-
-    std::string data;
-    char buffer[256];
-    FILE* stream = popen(final_cmd.c_str(), "r");
-    if (stream) {
-        while (fgets(buffer, sizeof(buffer), stream)) {
-            data.append(buffer);
-        }
-        pclose(stream);
-    }
-    if (!data.empty() && data.back() == '\n') data.pop_back();
-    return data;
-}
-
-bool is_git_repo(const fs::path& p) {
-    return fs::exists(p / ".git") && fs::is_directory(p / ".git");
-}
-
-std::string get_local_hash(const fs::path& repo) {
-    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
-        + " && git rev-parse HEAD 2>&1";
-    return run_cmd(cmd, 30);
-}
-
-std::string get_current_branch(const fs::path& repo) {
-    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
-        + " && git rev-parse --abbrev-ref HEAD 2>&1";
-    return run_cmd(cmd, 30);
-}
-
-std::string get_remote_hash(const fs::path& repo, const std::string& branch) {
-    std::string fetch_cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
-        + " && git fetch --quiet 2>&1";
-    run_cmd(fetch_cmd, 30);
-    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
-        + " && git rev-parse origin/" + branch + " 2>&1";
-    return run_cmd(cmd, 30);
-}
-
-std::string get_origin_url(const fs::path& repo) {
-    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
-        + " && git config --get remote.origin.url 2>&1";
-    return run_cmd(cmd, 15);
-}
-
-bool is_github_url(const std::string& url) {
-    return url.find("github.com") != std::string::npos;
-}
-
-bool remote_accessible(const fs::path& repo) {
-    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
-        + " && git ls-remote -h origin HEAD 2>&1";
-    std::string out = run_cmd(cmd, 30);
-    if (out.find("fatal") != std::string::npos || out.find("Permission denied") != std::string::npos
-        || out.find("ERROR") != std::string::npos)
-        return false;
-    return true;
-}
-
-// Return codes: 0 = ok, 1 = package-lock reset+pull, 2 = error
-int try_pull(const fs::path& repo, std::string& out_pull_log) {
-    std::string pull = run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git pull 2>&1", 30);
-    out_pull_log = pull;
-    if (pull.find("package-lock.json") != std::string::npos && pull.find("Please commit your changes or stash them before you merge") != std::string::npos) {
-        run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git checkout -- package-lock.json", 30);
-        pull = run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git pull 2>&1", 30);
-        out_pull_log += "\n[Auto-discarded package-lock.json]\n" + pull;
-        if (pull.find("Already up to date") != std::string::npos || pull.find("Updating") != std::string::npos)
-            return 1;
-        else
-            return 2;
-    }
-    if (pull.find("Already up to date") != std::string::npos || pull.find("Updating") != std::string::npos)
-        return 0;
-    return 2;
-}
-
-enum RepoStatus {
-    RS_CHECKING,
-    RS_UP_TO_DATE,
-    RS_PULLING,
-    RS_PULL_OK,
-    RS_PKGLOCK_FIXED,
-    RS_ERROR,
-    RS_SKIPPED,
-    RS_HEAD_PROBLEM
-};
-
-struct RepoInfo {
-    fs::path path;
-    RepoStatus status = RS_CHECKING;
-    std::string message;
-    std::string branch;
-    std::string last_pull_log;
-};
-
-void draw_tui(const std::vector<fs::path>& all_repos, const std::map<fs::path, RepoInfo>& repo_infos, int interval, int seconds_left, bool scanning) {
-    std::ostringstream out;
-    out << "\033[2J\033[H";
-    out << COLOR_BOLD << "AutoGitPull TUI   " << COLOR_RESET
-        << COLOR_CYAN << timestamp() << COLOR_RESET
-        << "   Monitoring: " << COLOR_YELLOW << (all_repos.empty() ? "" : all_repos[0].parent_path().string()) << COLOR_RESET << "\n";
-    out << "Interval: " << interval << "s    (Ctrl+C to exit)\n";
-    if (scanning) out << COLOR_YELLOW << "Scan in progress...\n" << COLOR_RESET;
-    out << "---------------------------------------------------------------------\n";
-    out << COLOR_BOLD << "  Status     Repo" << COLOR_RESET << "\n";
-    out << "---------------------------------------------------------------------\n";
-    for (const auto& p : all_repos) {
-        RepoInfo ri;
-        auto it = repo_infos.find(p);
-        if (it != repo_infos.end())
-            ri = it->second;
-        else {
-            ri.path = p;
-            ri.status = RS_CHECKING;
-            ri.message = "Pending...";
-        }
-        std::string color = COLOR_GRAY, status_s = "CHECK    ";
-        switch (ri.status) {
-            case RS_CHECKING:      color = COLOR_CYAN;   status_s = "Checking "; break;
-            case RS_UP_TO_DATE:    color = COLOR_GREEN;  status_s = "UpToDate "; break;
-            case RS_PULLING:       color = COLOR_YELLOW; status_s = "Pulling  "; break;
-            case RS_PULL_OK:       color = COLOR_GREEN;  status_s = "Pulled   "; break;
-            case RS_PKGLOCK_FIXED: color = COLOR_YELLOW; status_s = "PkgLockOk"; break;
-            case RS_ERROR:         color = COLOR_RED;    status_s = "Error    "; break;
-            case RS_SKIPPED:       color = COLOR_GRAY;   status_s = "Skipped  "; break;
-            case RS_HEAD_PROBLEM:  color = COLOR_RED;    status_s = "HEAD/BR  "; break;
-        }
-        out << color << " [" << std::left << std::setw(9) << status_s << "]  " << p.filename().string() << COLOR_RESET;
-        if (!ri.branch.empty()) out << "  (" << ri.branch << ")";
-        if (!ri.message.empty()) out << " - " << ri.message;
-        out << "\n";
-    }
-    out << "---------------------------------------------------------------------\n";
-    out << COLOR_CYAN << "Next scan in " << seconds_left << " seconds..." << COLOR_RESET;
-    std::cout << out.str() << std::flush;
-}
 
 // Background thread: scan and update info
 void scan_repos(
     const std::vector<fs::path>& all_repos,
-    std::map<fs::path, RepoInfo>& repo_infos,
+    std::map<fs::path, git::RepoInfo>& repo_infos,
     std::set<fs::path>& skip_repos,
     std::mutex& mtx,
     std::atomic<bool>& scanning_flag,
-    bool include_private
-) {
+    bool include_private)
+{
     for (const auto& p : all_repos) {
-        RepoInfo ri;
+        git::RepoInfo ri;
         ri.path = p;
         if (!fs::exists(p)) {
-            ri.status = RS_ERROR;
+            ri.status = git::RS_ERROR;
             ri.message = "Missing";
             std::lock_guard<std::mutex> lk(mtx);
             repo_infos[p] = ri;
             continue;
         }
         if (skip_repos.count(p)) {
-            ri.status = RS_SKIPPED;
+            ri.status = git::RS_SKIPPED;
             ri.message = "Skipped after fatal error";
             std::lock_guard<std::mutex> lk(mtx);
             repo_infos[p] = ri;
             continue;
         }
         try {
-            ri.status = RS_CHECKING;
+            ri.status = git::RS_CHECKING;
             ri.message = "";
-            if (fs::is_directory(p) && is_git_repo(p)) {
-                std::string origin = get_origin_url(p);
+            if (fs::is_directory(p) && git::is_git_repo(p)) {
+                std::string origin = git::get_origin_url(p);
                 if (!include_private) {
-                    if (!is_github_url(origin)) {
-                        ri.status = RS_SKIPPED;
+                    if (!git::is_github_url(origin)) {
+                        ri.status = git::RS_SKIPPED;
                         ri.message = "Non-GitHub repo (skipped)";
                         std::lock_guard<std::mutex> lk(mtx);
                         repo_infos[p] = ri;
                         continue;
                     }
-                    if (!remote_accessible(p)) {
-                        ri.status = RS_SKIPPED;
+                    if (!git::remote_accessible(p)) {
+                        ri.status = git::RS_SKIPPED;
                         ri.message = "Private or inaccessible repo";
                         std::lock_guard<std::mutex> lk(mtx);
                         repo_infos[p] = ri;
                         continue;
                     }
                 }
-                ri.branch = get_current_branch(p);
+                ri.branch = git::get_current_branch(p);
                 if (ri.branch.empty() || ri.branch == "HEAD") {
-                    ri.status = RS_HEAD_PROBLEM;
+                    ri.status = git::RS_HEAD_PROBLEM;
                     ri.message = "Detached HEAD or branch error";
                     skip_repos.insert(p);
                 } else {
-                    std::string local = get_local_hash(p);
-                    std::string remote = get_remote_hash(p, ri.branch);
+                    std::string local = git::get_local_hash(p);
+                    std::string remote = git::get_remote_hash(p, ri.branch);
                     if (local.empty() || remote.empty()) {
-                        ri.status = RS_ERROR;
+                        ri.status = git::RS_ERROR;
                         ri.message = "Error getting hashes or remote";
                         skip_repos.insert(p);
                     } else if (local != remote) {
-                        ri.status = RS_PULLING;
+                        ri.status = git::RS_PULLING;
                         ri.message = "Remote ahead, pulling...";
                         {
                             std::lock_guard<std::mutex> lk(mtx);
                             repo_infos[p] = ri;
                         }
                         std::string pull_log;
-                        int code = try_pull(p, pull_log);
+                        int code = git::try_pull(p, pull_log);
                         ri.last_pull_log = pull_log;
                         if (code == 0) {
-                            ri.status = RS_PULL_OK;
+                            ri.status = git::RS_PULL_OK;
                             ri.message = "Pulled successfully";
                         } else if (code == 1) {
-                            ri.status = RS_PKGLOCK_FIXED;
+                            ri.status = git::RS_PKGLOCK_FIXED;
                             ri.message = "package-lock.json auto-reset & pulled";
                         } else {
-                            ri.status = RS_ERROR;
+                            ri.status = git::RS_ERROR;
                             ri.message = "Pull failed (see log)";
                             skip_repos.insert(p);
                         }
                     } else {
-                        ri.status = RS_UP_TO_DATE;
+                        ri.status = git::RS_UP_TO_DATE;
                         ri.message = "Up to date";
                     }
                 }
             } else {
-                ri.status = RS_SKIPPED;
+                ri.status = git::RS_SKIPPED;
                 ri.message = "Not a git repo (skipped)";
                 skip_repos.insert(p);
             }
         } catch (const fs::filesystem_error& e) {
-            ri.status = RS_ERROR;
+            ri.status = git::RS_ERROR;
             ri.message = e.what();
             skip_repos.insert(p);
         }
@@ -304,32 +118,32 @@ void scan_repos(
 }
 
 int main(int argc, char* argv[]) {
-    enable_win_ansi();
+    tui::enable_win_ansi();
+    ArgParser parser;
+    ParsedArgs args = parser.parse(argc, argv);
+
     std::cout << "\033[?1049h"; // enter alternate buffer
+
     try {
-        if (argc < 2 || argc > 3) {
-            std::cerr << "Usage: " << argv[0] << " <root-folder> [--include-private]\n";
-            std::cout << "\033[?1049l" << std::flush; // leave alt buffer
+        if (args.root.empty()) {
+            std::cerr << "Usage: " << argv[0] << " <root-folder> [--include-private] [--show-skipped]\n";
+            std::cout << "\033[?1049l" << std::flush;
             return 1;
         }
-        bool include_private = false;
-        if (argc == 3 && std::string(argv[2]) == "--include-private")
-            include_private = true;
-        fs::path root = argv[1];
+        fs::path root = args.root;
         if (!fs::exists(root) || !fs::is_directory(root)) {
             std::cerr << "Root path does not exist or is not a directory.\n";
-            std::cout << "\033[?1049l" << std::flush; // leave alt buffer
+            std::cout << "\033[?1049l" << std::flush;
             return 1;
         }
 
-        // Grab all first-level subdirs at startup (fixed list)
         std::vector<fs::path> all_repos;
         for (const auto& entry : fs::directory_iterator(root)) {
             all_repos.push_back(entry.path());
         }
-        std::map<fs::path, RepoInfo> repo_infos;
+        std::map<fs::path, git::RepoInfo> repo_infos;
         for (const auto& p : all_repos) {
-            repo_infos[p] = RepoInfo{p, RS_CHECKING, "Pending..."};
+            repo_infos[p] = git::RepoInfo{p, git::RS_CHECKING, "Pending..."};
         }
 
         const int interval = 60; // seconds
@@ -342,20 +156,24 @@ int main(int argc, char* argv[]) {
         while (true) {
             if (countdown <= 0 && !scanning) {
                 scanning = true;
-                std::thread(scan_repos, std::cref(all_repos), std::ref(repo_infos), std::ref(skip_repos), std::ref(mtx), std::ref(scanning), include_private).detach();
+                std::thread(scan_repos, std::cref(all_repos), std::ref(repo_infos),
+                            std::ref(skip_repos), std::ref(mtx), std::ref(scanning),
+                            args.include_private)
+                    .detach();
                 countdown = interval;
             }
             {
                 std::lock_guard<std::mutex> lk(mtx);
-                draw_tui(all_repos, repo_infos, interval, countdown, scanning);
+                tui::draw_tui(all_repos, repo_infos, interval, countdown, scanning,
+                              args.show_skipped);
             }
             std::this_thread::sleep_for(std::chrono::seconds(1));
             countdown--;
         }
     } catch (...) {
-        std::cout << "\033[?1049l" << std::flush; // leave alt buffer on any error
+        std::cout << "\033[?1049l" << std::flush;
         throw;
     }
-    std::cout << "\033[?1049l" << std::flush; // leave alt buffer on normal exit
+    std::cout << "\033[?1049l" << std::flush;
     return 0;
 }

--- a/compile-cl.bat
+++ b/compile-cl.bat
@@ -1,1 +1,1 @@
-cl /std:c++17 /EHsc git_auto_pull_all.cpp
+cl /std:c++17 /EHsc autogitpull.cpp git_utils.cpp tui.cpp arg_parser.cpp

--- a/compile.bat
+++ b/compile.bat
@@ -1,1 +1,1 @@
- g++ -std=c++17 -o git_auto_pull_all.exe autogitpull.cpp
+ g++ -std=c++17 -o git_auto_pull_all.exe autogitpull.cpp git_utils.cpp tui.cpp arg_parser.cpp

--- a/git_utils.cpp
+++ b/git_utils.cpp
@@ -1,0 +1,103 @@
+#include "git_utils.h"
+#include <cstdio>
+#include <array>
+#include <cstdlib>
+
+#ifdef _WIN32
+#include <windows.h>
+#define popen _popen
+#define pclose _pclose
+const char* QUOTE = "\"";
+#else
+const char* QUOTE = "'";
+#endif
+
+namespace git {
+
+std::string run_cmd(const std::string& cmd, int timeout_sec) {
+#ifndef _WIN32
+    std::string final_cmd = cmd;
+    if (timeout_sec > 0) {
+        final_cmd = "timeout " + std::to_string(timeout_sec) + " " + cmd;
+    }
+#else
+    std::string final_cmd = cmd;
+    (void)timeout_sec;
+#endif
+
+    std::string data;
+    char buffer[256];
+    FILE* stream = popen(final_cmd.c_str(), "r");
+    if (stream) {
+        while (fgets(buffer, sizeof(buffer), stream)) {
+            data.append(buffer);
+        }
+        pclose(stream);
+    }
+    if (!data.empty() && data.back() == '\n') data.pop_back();
+    return data;
+}
+
+bool is_git_repo(const fs::path& p) {
+    return fs::exists(p / ".git") && fs::is_directory(p / ".git");
+}
+
+std::string get_local_hash(const fs::path& repo) {
+    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+        + " && git rev-parse HEAD 2>&1";
+    return run_cmd(cmd, 30);
+}
+
+std::string get_current_branch(const fs::path& repo) {
+    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+        + " && git rev-parse --abbrev-ref HEAD 2>&1";
+    return run_cmd(cmd, 30);
+}
+
+std::string get_remote_hash(const fs::path& repo, const std::string& branch) {
+    std::string fetch_cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+        + " && git fetch --quiet 2>&1";
+    run_cmd(fetch_cmd, 30);
+    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+        + " && git rev-parse origin/" + branch + " 2>&1";
+    return run_cmd(cmd, 30);
+}
+
+std::string get_origin_url(const fs::path& repo) {
+    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+        + " && git config --get remote.origin.url 2>&1";
+    return run_cmd(cmd, 15);
+}
+
+bool is_github_url(const std::string& url) {
+    return url.find("github.com") != std::string::npos;
+}
+
+bool remote_accessible(const fs::path& repo) {
+    std::string cmd = "cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE)
+        + " && git ls-remote -h origin HEAD 2>&1";
+    std::string out = run_cmd(cmd, 30);
+    if (out.find("fatal") != std::string::npos || out.find("Permission denied") != std::string::npos
+        || out.find("ERROR") != std::string::npos)
+        return false;
+    return true;
+}
+
+int try_pull(const fs::path& repo, std::string& out_pull_log) {
+    std::string pull = run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git pull 2>&1", 30);
+    out_pull_log = pull;
+    if (pull.find("package-lock.json") != std::string::npos && pull.find("Please commit your changes or stash them before you merge") != std::string::npos) {
+        run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git checkout -- package-lock.json", 30);
+        pull = run_cmd("cd " + std::string(QUOTE) + repo.string() + std::string(QUOTE) + " && git pull 2>&1", 30);
+        out_pull_log += "\n[Auto-discarded package-lock.json]\n" + pull;
+        if (pull.find("Already up to date") != std::string::npos || pull.find("Updating") != std::string::npos)
+            return 1;
+        else
+            return 2;
+    }
+    if (pull.find("Already up to date") != std::string::npos || pull.find("Updating") != std::string::npos)
+        return 0;
+    return 2;
+}
+
+} // namespace git

--- a/git_utils.h
+++ b/git_utils.h
@@ -1,0 +1,22 @@
+#ifndef GIT_UTILS_H
+#define GIT_UTILS_H
+
+#include <filesystem>
+#include <string>
+
+namespace git {
+namespace fs = std::filesystem;
+
+std::string run_cmd(const std::string& cmd, int timeout_sec = 0);
+bool is_git_repo(const fs::path& p);
+std::string get_local_hash(const fs::path& repo);
+std::string get_current_branch(const fs::path& repo);
+std::string get_remote_hash(const fs::path& repo, const std::string& branch);
+std::string get_origin_url(const fs::path& repo);
+bool is_github_url(const std::string& url);
+bool remote_accessible(const fs::path& repo);
+int try_pull(const fs::path& repo, std::string& out_pull_log);
+
+} // namespace git
+
+#endif // GIT_UTILS_H

--- a/repo_info.h
+++ b/repo_info.h
@@ -1,0 +1,31 @@
+#ifndef REPO_INFO_H
+#define REPO_INFO_H
+
+#include <filesystem>
+#include <string>
+
+namespace git {
+namespace fs = std::filesystem;
+
+enum RepoStatus {
+    RS_CHECKING,
+    RS_UP_TO_DATE,
+    RS_PULLING,
+    RS_PULL_OK,
+    RS_PKGLOCK_FIXED,
+    RS_ERROR,
+    RS_SKIPPED,
+    RS_HEAD_PROBLEM
+};
+
+struct RepoInfo {
+    fs::path path;
+    RepoStatus status = RS_CHECKING;
+    std::string message;
+    std::string branch;
+    std::string last_pull_log;
+};
+
+} // namespace git
+
+#endif // REPO_INFO_H

--- a/tui.cpp
+++ b/tui.cpp
@@ -1,0 +1,92 @@
+#include "tui.h"
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <chrono>
+#include <ctime>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace tui {
+
+const char* COLOR_RESET = "\033[0m";
+const char* COLOR_GREEN = "\033[32m";
+const char* COLOR_YELLOW = "\033[33m";
+const char* COLOR_RED = "\033[31m";
+const char* COLOR_CYAN = "\033[36m";
+const char* COLOR_GRAY = "\033[90m";
+const char* COLOR_BOLD = "\033[1m";
+
+#ifdef _WIN32
+void enable_win_ansi() {
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hOut == INVALID_HANDLE_VALUE) return;
+    DWORD dwMode = 0;
+    if (!GetConsoleMode(hOut, &dwMode)) return;
+    dwMode |= 0x0004; // ENABLE_VIRTUAL_TERMINAL_PROCESSING
+    SetConsoleMode(hOut, dwMode);
+}
+#else
+void enable_win_ansi() {}
+#endif
+
+static std::string timestamp() {
+    std::time_t now = std::time(nullptr);
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
+    return std::string(buf);
+}
+
+void draw_tui(const std::vector<std::filesystem::path>& all_repos,
+              const std::map<std::filesystem::path, git::RepoInfo>& repo_infos,
+              int interval, int seconds_left, bool scanning,
+              bool show_skipped) {
+    std::ostringstream out;
+    out << "\033[2J\033[H";
+    out << COLOR_BOLD << "AutoGitPull TUI   " << COLOR_RESET
+        << COLOR_CYAN << timestamp() << COLOR_RESET
+        << "   Monitoring: "
+        << COLOR_YELLOW
+        << (all_repos.empty() ? "" : all_repos[0].parent_path().string())
+        << COLOR_RESET << "\n";
+    out << "Interval: " << interval << "s    (Ctrl+C to exit)\n";
+    if (scanning) out << COLOR_YELLOW << "Scan in progress...\n" << COLOR_RESET;
+    out << "---------------------------------------------------------------------\n";
+    out << COLOR_BOLD << "  Status     Repo" << COLOR_RESET << "\n";
+    out << "---------------------------------------------------------------------\n";
+    for (const auto& p : all_repos) {
+        git::RepoInfo ri;
+        auto it = repo_infos.find(p);
+        if (it != repo_infos.end())
+            ri = it->second;
+        else {
+            ri.path = p;
+            ri.status = git::RS_CHECKING;
+            ri.message = "Pending...";
+        }
+        if (!show_skipped && ri.status == git::RS_SKIPPED) continue;
+        std::string color = COLOR_GRAY, status_s = "CHECK    ";
+        switch (ri.status) {
+            case git::RS_CHECKING:      color = COLOR_CYAN;   status_s = "Checking "; break;
+            case git::RS_UP_TO_DATE:    color = COLOR_GREEN;  status_s = "UpToDate "; break;
+            case git::RS_PULLING:       color = COLOR_YELLOW; status_s = "Pulling  "; break;
+            case git::RS_PULL_OK:       color = COLOR_GREEN;  status_s = "Pulled   "; break;
+            case git::RS_PKGLOCK_FIXED: color = COLOR_YELLOW; status_s = "PkgLockOk"; break;
+            case git::RS_ERROR:         color = COLOR_RED;    status_s = "Error    "; break;
+            case git::RS_SKIPPED:       color = COLOR_GRAY;   status_s = "Skipped  "; break;
+            case git::RS_HEAD_PROBLEM:  color = COLOR_RED;    status_s = "HEAD/BR  "; break;
+        }
+        out << color << " [" << std::left << std::setw(9) << status_s << "]  "
+            << p.filename().string() << COLOR_RESET;
+        if (!ri.branch.empty()) out << "  (" << ri.branch << ")";
+        if (!ri.message.empty()) out << " - " << ri.message;
+        out << "\n";
+    }
+    out << "---------------------------------------------------------------------\n";
+    out << COLOR_CYAN << "Next scan in " << seconds_left << " seconds..." << COLOR_RESET;
+    std::cout << out.str() << std::flush;
+}
+
+} // namespace tui

--- a/tui.h
+++ b/tui.h
@@ -1,0 +1,21 @@
+#ifndef TUI_H
+#define TUI_H
+
+#include <vector>
+#include <map>
+#include <filesystem>
+
+#include "repo_info.h"
+
+namespace tui {
+
+void draw_tui(const std::vector<std::filesystem::path>& all_repos,
+              const std::map<std::filesystem::path, git::RepoInfo>& repo_infos,
+              int interval, int seconds_left, bool scanning,
+              bool show_skipped);
+
+void enable_win_ansi();
+
+} // namespace tui
+
+#endif // TUI_H


### PR DESCRIPTION
## Summary
- restructure code into separate `git_utils`, `tui`, and `repo_info` modules
- add simple `ArgParser` for `--include-private` and new `--show-skipped` flag
- keep `main` lightweight and update compile scripts

## Testing
- `g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp arg_parser.cpp -o /tmp/agptest && echo done`

------
https://chatgpt.com/codex/tasks/task_e_6875217266c88325860a80faf292eb9d