### PR TITLE
Refactor autogitpull into modules with simple arg parser

### DIFF
--- a/arg_parser.hpp
+++ b/arg_parser.hpp
@@ -1,0 +1,26 @@
+#ifndef ARG_PARSER_HPP
+#define ARG_PARSER_HPP
+#include <string>
+#include <set>
+#include <vector>
+
+class ArgParser {
+    std::set<std::string> flags_;
+    std::vector<std::string> positional_;
+public:
+    ArgParser(int argc, char* argv[]) {
+        for(int i=1;i<argc;++i) {
+            std::string arg = argv[i];
+            if(arg.rfind("--",0)==0) {
+                flags_.insert(arg);
+            } else {
+                positional_.push_back(arg);
+            }
+        }
+    }
+    bool has_flag(const std::string& flag) const { return flags_.count(flag)>0; }
+    const std::set<std::string>& flags() const { return flags_; }
+    const std::vector<std::string>& positional() const { return positional_; }
+};
+
+#endif // ARG_PARSER_HPP

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -5,220 +5,18 @@
 #include <string>
 #include <thread>
 #include <chrono>
-#include <ctime>
 #include <set>
 #include <map>
 #include <mutex>
 #include <atomic>
 #include <sstream>
-#include <cstdlib>
-
-#ifdef _WIN32
-#include <windows.h>
-#define popen _popen
-#define pclose _pclose
-const char* QUOTE = "\"";
-#else
-const char* QUOTE = "'";
-#endif
+#include "arg_parser.hpp"
+#include "git_utils.hpp"
+#include "tui.hpp"
+#include "repo.hpp"
 
 namespace fs = std::filesystem;
 
-// ANSI color codes
-const char* COLOR_RESET = "\033[0m";
-const char* COLOR_GREEN = "\033[32m";
-const char* COLOR_YELLOW = "\033[33m";
-const char* COLOR_RED = "\033[31m";
-const char* COLOR_CYAN = "\033[36m";
-const char* COLOR_GRAY = "\033[90m";
-const char* COLOR_BOLD = "\033[1m";
-
-#ifdef _WIN32
-void enable_win_ansi() {
-    // Enable ANSI color on Windows 10+ console
-    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-    if (hOut == INVALID_HANDLE_VALUE) return;
-    DWORD dwMode = 0;
-    if (!GetConsoleMode(hOut, &dwMode)) return;
-    dwMode |= 0x0004; // ENABLE_VIRTUAL_TERMINAL_PROCESSING
-    SetConsoleMode(hOut, dwMode);
-}
-#else
-void enable_win_ansi() {} // No-op on non-Windows
-#endif
-
-
-std::string timestamp() {
-    std::time_t now = std::time(nullptr);
-    char buf[32];
-    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
-    return std::string(buf);
-}
-
-struct PopenHandle {
-    FILE* fp;
-    ~PopenHandle() {
-        if (fp)
-            pclose(fp);
-    }
-};
-
-std::string run_cmd(const std::string& cmd, int timeout_sec = 0) {
-#ifndef _WIN32
-    std::string final_cmd = cmd;
-    if (timeout_sec > 0) {
-        final_cmd = "timeout " + std::to_string(timeout_sec) + " " + cmd;
-    }
-#else
-    std::string final_cmd = cmd; // Timeout not supported on Windows fallback
-    (void)timeout_sec;
-#endif
-
-    std::string data;
-    char buffer[256];
-    FILE* raw = popen(final_cmd.c_str(), "r");
-    PopenHandle stream{raw};
-    if (stream.fp) {
-        while (fgets(buffer, sizeof(buffer), stream.fp)) {
-            data.append(buffer);
-        }
-    }
-    if (!data.empty() && data.back() == '\n')
-        data.pop_back();
-    return data;
-}
-
-// Quote a filesystem path for safe command usage
-std::string quote_path(const fs::path& p) {
-    return std::string(QUOTE) + p.string() + std::string(QUOTE);
-}
-
-bool is_git_repo(const fs::path& p) {
-    return fs::exists(p / ".git") && fs::is_directory(p / ".git");
-}
-
-std::string get_local_hash(const fs::path& repo) {
-    std::string cmd = "cd " + quote_path(repo)
-        + " && git rev-parse HEAD 2>&1";
-    return run_cmd(cmd, 30);
-}
-
-std::string get_current_branch(const fs::path& repo) {
-    std::string cmd = "cd " + quote_path(repo)
-        + " && git rev-parse --abbrev-ref HEAD 2>&1";
-    return run_cmd(cmd, 30);
-}
-
-std::string get_remote_hash(const fs::path& repo, const std::string& branch) {
-    std::string fetch_cmd = "cd " + quote_path(repo)
-        + " && git fetch --quiet 2>&1";
-    run_cmd(fetch_cmd, 30);
-    std::string cmd = "cd " + quote_path(repo)
-        + " && git rev-parse origin/" + branch + " 2>&1";
-    return run_cmd(cmd, 30);
-}
-
-std::string get_origin_url(const fs::path& repo) {
-    std::string cmd = "cd " + quote_path(repo)
-        + " && git config --get remote.origin.url 2>&1";
-    return run_cmd(cmd, 15);
-}
-
-bool is_github_url(const std::string& url) {
-    return url.find("github.com") != std::string::npos;
-}
-
-bool remote_accessible(const fs::path& repo) {
-    std::string cmd = "cd " + quote_path(repo)
-        + " && git ls-remote -h origin HEAD 2>&1";
-    std::string out = run_cmd(cmd, 30);
-    if (out.find("fatal") != std::string::npos || out.find("Permission denied") != std::string::npos
-        || out.find("ERROR") != std::string::npos)
-        return false;
-    return true;
-}
-
-// Return codes: 0 = ok, 1 = package-lock reset+pull, 2 = error
-int try_pull(const fs::path& repo, std::string& out_pull_log) {
-    std::string pull = run_cmd("cd " + quote_path(repo) + " && git pull 2>&1", 30);
-    out_pull_log = pull;
-    if (pull.find("package-lock.json") != std::string::npos && pull.find("Please commit your changes or stash them before you merge") != std::string::npos) {
-        run_cmd("cd " + quote_path(repo) + " && git checkout -- package-lock.json", 30);
-        pull = run_cmd("cd " + quote_path(repo) + " && git pull 2>&1", 30);
-        out_pull_log += "\n[Auto-discarded package-lock.json]\n" + pull;
-        if (pull.find("Already up to date") != std::string::npos || pull.find("Updating") != std::string::npos)
-            return 1;
-        else
-            return 2;
-    }
-    if (pull.find("Already up to date") != std::string::npos || pull.find("Updating") != std::string::npos)
-        return 0;
-    return 2;
-}
-
-enum RepoStatus {
-    RS_CHECKING,
-    RS_UP_TO_DATE,
-    RS_PULLING,
-    RS_PULL_OK,
-    RS_PKGLOCK_FIXED,
-    RS_ERROR,
-    RS_SKIPPED,
-    RS_HEAD_PROBLEM
-};
-
-struct RepoInfo {
-    fs::path path;
-    RepoStatus status = RS_CHECKING;
-    std::string message;
-    std::string branch;
-    std::string last_pull_log;
-};
-
-void draw_tui(const std::vector<fs::path>& all_repos, const std::map<fs::path, RepoInfo>& repo_infos,
-              int interval, int seconds_left, bool scanning, bool show_skipped) {
-    std::ostringstream out;
-    out << "\033[2J\033[H";
-    out << COLOR_BOLD << "AutoGitPull TUI   " << COLOR_RESET
-        << COLOR_CYAN << timestamp() << COLOR_RESET
-        << "   Monitoring: " << COLOR_YELLOW << (all_repos.empty() ? "" : all_repos[0].parent_path().string()) << COLOR_RESET << "\n";
-    out << "Interval: " << interval << "s    (Ctrl+C to exit)\n";
-    if (scanning) out << COLOR_YELLOW << "Scan in progress...\n" << COLOR_RESET;
-    out << "---------------------------------------------------------------------\n";
-    out << COLOR_BOLD << "  Status     Repo" << COLOR_RESET << "\n";
-    out << "---------------------------------------------------------------------\n";
-    for (const auto& p : all_repos) {
-        RepoInfo ri;
-        auto it = repo_infos.find(p);
-        if (it != repo_infos.end())
-            ri = it->second;
-        else {
-            ri.path = p;
-            ri.status = RS_CHECKING;
-            ri.message = "Pending...";
-        }
-        if (ri.status == RS_SKIPPED && !show_skipped)
-            continue;
-        std::string color = COLOR_GRAY, status_s = "CHECK    ";
-        switch (ri.status) {
-            case RS_CHECKING:      color = COLOR_CYAN;   status_s = "Checking "; break;
-            case RS_UP_TO_DATE:    color = COLOR_GREEN;  status_s = "UpToDate "; break;
-            case RS_PULLING:       color = COLOR_YELLOW; status_s = "Pulling  "; break;
-            case RS_PULL_OK:       color = COLOR_GREEN;  status_s = "Pulled   "; break;
-            case RS_PKGLOCK_FIXED: color = COLOR_YELLOW; status_s = "PkgLockOk"; break;
-            case RS_ERROR:         color = COLOR_RED;    status_s = "Error    "; break;
-            case RS_SKIPPED:       color = COLOR_GRAY;   status_s = "Skipped  "; break;
-            case RS_HEAD_PROBLEM:  color = COLOR_RED;    status_s = "HEAD/BR  "; break;
-        }
-        out << color << " [" << std::left << std::setw(9) << status_s << "]  " << p.filename().string() << COLOR_RESET;
-        if (!ri.branch.empty()) out << "  (" << ri.branch << ")";
-        if (!ri.message.empty()) out << " - " << ri.message;
-        out << "\n";
-    }
-    out << "---------------------------------------------------------------------\n";
-    out << COLOR_CYAN << "Next scan in " << seconds_left << " seconds..." << COLOR_RESET;
-    std::cout << out.str() << std::flush;
-}
 
 // Background thread: scan and update info
 void scan_repos(
@@ -249,17 +47,17 @@ void scan_repos(
         try {
             ri.status = RS_CHECKING;
             ri.message = "";
-            if (fs::is_directory(p) && is_git_repo(p)) {
-                std::string origin = get_origin_url(p);
+            if (fs::is_directory(p) && git::is_git_repo(p)) {
+                std::string origin = git::get_origin_url(p);
                 if (!include_private) {
-                    if (!is_github_url(origin)) {
+                    if (!git::is_github_url(origin)) {
                         ri.status = RS_SKIPPED;
                         ri.message = "Non-GitHub repo (skipped)";
                         std::lock_guard<std::mutex> lk(mtx);
                         repo_infos[p] = ri;
                         continue;
                     }
-                    if (!remote_accessible(p)) {
+                    if (!git::remote_accessible(p)) {
                         ri.status = RS_SKIPPED;
                         ri.message = "Private or inaccessible repo";
                         std::lock_guard<std::mutex> lk(mtx);
@@ -267,14 +65,14 @@ void scan_repos(
                         continue;
                     }
                 }
-                ri.branch = get_current_branch(p);
+                ri.branch = git::get_current_branch(p);
                 if (ri.branch.empty() || ri.branch == "HEAD") {
                     ri.status = RS_HEAD_PROBLEM;
                     ri.message = "Detached HEAD or branch error";
                     skip_repos.insert(p);
                 } else {
-                    std::string local = get_local_hash(p);
-                    std::string remote = get_remote_hash(p, ri.branch);
+                    std::string local = git::get_local_hash(p);
+                    std::string remote = git::get_remote_hash(p, ri.branch);
                     if (local.empty() || remote.empty()) {
                         ri.status = RS_ERROR;
                         ri.message = "Error getting hashes or remote";
@@ -287,7 +85,7 @@ void scan_repos(
                             repo_infos[p] = ri;
                         }
                         std::string pull_log;
-                        int code = try_pull(p, pull_log);
+                        int code = git::try_pull(p, pull_log);
                         ri.last_pull_log = pull_log;
                         if (code == 0) {
                             ri.status = RS_PULL_OK;
@@ -325,26 +123,22 @@ int main(int argc, char* argv[]) {
     enable_win_ansi();
     std::cout << "\033[?1049h"; // enter alternate buffer
     try {
-        if (argc < 2 || argc > 4) {
+        ArgParser parser(argc, argv);
+        if (parser.positional().size() != 1) {
             std::cerr << "Usage: " << argv[0] << " <root-folder> [--include-private] [--show-skipped]\n";
-            std::cout << "\033[?1049l" << std::flush; // leave alt buffer
+            std::cout << "\033[?1049l" << std::flush;
             return 1;
         }
-        bool include_private = false;
-        bool show_skipped = false;
-        for (int i = 2; i < argc; ++i) {
-            std::string arg = argv[i];
-            if (arg == "--include-private")
-                include_private = true;
-            else if (arg == "--show-skipped")
-                show_skipped = true;
-            else {
-                std::cerr << "Unknown option: " << arg << "\n";
+        for(const auto& f : parser.flags()) {
+            if (f != "--include-private" && f != "--show-skipped") {
+                std::cerr << "Unknown option: " << f << "\n";
                 std::cout << "\033[?1049l" << std::flush;
                 return 1;
             }
         }
-        fs::path root = argv[1];
+        bool include_private = parser.has_flag("--include-private");
+        bool show_skipped = parser.has_flag("--show-skipped");
+        fs::path root = parser.positional().front();
         if (!fs::exists(root) || !fs::is_directory(root)) {
             std::cerr << "Root path does not exist or is not a directory.\n";
             std::cout << "\033[?1049l" << std::flush; // leave alt buffer

--- a/compile-cl.bat
+++ b/compile-cl.bat
@@ -1,1 +1,1 @@
-cl /std:c++17 /EHsc autogitpull.cpp
+cl /std:c++17 /EHsc autogitpull.cpp git_utils.cpp tui.cpp

--- a/compile.bat
+++ b/compile.bat
@@ -1,1 +1,1 @@
- g++ -std=c++17 -o git_auto_pull_all.exe autogitpull.cpp
+ g++ -std=c++17 -o git_auto_pull_all.exe autogitpull.cpp git_utils.cpp tui.cpp

--- a/git_utils.cpp
+++ b/git_utils.cpp
@@ -1,0 +1,104 @@
+#include "git_utils.hpp"
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include <sstream>
+
+#ifdef _WIN32
+#include <windows.h>
+#define popen _popen
+#define pclose _pclose
+const char* QUOTE = "\"";
+#else
+const char* QUOTE = "'";
+#endif
+
+using namespace std;
+
+namespace git {
+
+string run_cmd(const string& cmd, int timeout_sec) {
+#ifndef _WIN32
+    string final_cmd = cmd;
+    if (timeout_sec > 0) {
+        final_cmd = "timeout " + to_string(timeout_sec) + " " + cmd;
+    }
+#else
+    string final_cmd = cmd;
+    (void)timeout_sec;
+#endif
+    string data;
+    char buffer[256];
+    FILE* raw = popen(final_cmd.c_str(), "r");
+    if (!raw) return data;
+    struct PopenHandle { FILE* fp; ~PopenHandle(){ if(fp) pclose(fp); } } handle{raw};
+    while (fgets(buffer, sizeof(buffer), handle.fp)) {
+        data.append(buffer);
+    }
+    if (!data.empty() && data.back() == '\n')
+        data.pop_back();
+    return data;
+}
+
+string quote_path(const fs::path& p) {
+    return string(QUOTE) + p.string() + string(QUOTE);
+}
+
+bool is_git_repo(const fs::path& p) {
+    return fs::exists(p / ".git") && fs::is_directory(p / ".git");
+}
+
+string get_local_hash(const fs::path& repo) {
+    string cmd = "cd " + quote_path(repo) + " && git rev-parse HEAD 2>&1";
+    return run_cmd(cmd, 30);
+}
+
+string get_current_branch(const fs::path& repo) {
+    string cmd = "cd " + quote_path(repo) + " && git rev-parse --abbrev-ref HEAD 2>&1";
+    return run_cmd(cmd, 30);
+}
+
+string get_remote_hash(const fs::path& repo, const string& branch) {
+    string fetch_cmd = "cd " + quote_path(repo) + " && git fetch --quiet 2>&1";
+    run_cmd(fetch_cmd, 30);
+    string cmd = "cd " + quote_path(repo) + " && git rev-parse origin/" + branch + " 2>&1";
+    return run_cmd(cmd, 30);
+}
+
+string get_origin_url(const fs::path& repo) {
+    string cmd = "cd " + quote_path(repo) + " && git config --get remote.origin.url 2>&1";
+    return run_cmd(cmd, 15);
+}
+
+bool is_github_url(const string& url) {
+    return url.find("github.com") != string::npos;
+}
+
+bool remote_accessible(const fs::path& repo) {
+    string cmd = "cd " + quote_path(repo) + " && git ls-remote -h origin HEAD 2>&1";
+    string out = run_cmd(cmd, 30);
+    if (out.find("fatal") != string::npos || out.find("Permission denied") != string::npos ||
+        out.find("ERROR") != string::npos)
+        return false;
+    return true;
+}
+
+int try_pull(const fs::path& repo, string& out_pull_log) {
+    string pull = run_cmd("cd " + quote_path(repo) + " && git pull 2>&1", 30);
+    out_pull_log = pull;
+    if (pull.find("package-lock.json") != string::npos &&
+        pull.find("Please commit your changes or stash them before you merge") != string::npos) {
+        run_cmd("cd " + quote_path(repo) + " && git checkout -- package-lock.json", 30);
+        pull = run_cmd("cd " + quote_path(repo) + " && git pull 2>&1", 30);
+        out_pull_log += "\n[Auto-discarded package-lock.json]\n" + pull;
+        if (pull.find("Already up to date") != string::npos || pull.find("Updating") != string::npos)
+            return 1;
+        else
+            return 2;
+    }
+    if (pull.find("Already up to date") != string::npos || pull.find("Updating") != string::npos)
+        return 0;
+    return 2;
+}
+
+} // namespace git

--- a/git_utils.hpp
+++ b/git_utils.hpp
@@ -1,0 +1,23 @@
+#ifndef GIT_UTILS_HPP
+#define GIT_UTILS_HPP
+
+#include <string>
+#include <filesystem>
+
+namespace git {
+namespace fs = std::filesystem;
+
+std::string run_cmd(const std::string& cmd, int timeout_sec = 0);
+std::string quote_path(const fs::path& p);
+bool is_git_repo(const fs::path& p);
+std::string get_local_hash(const fs::path& repo);
+std::string get_current_branch(const fs::path& repo);
+std::string get_remote_hash(const fs::path& repo, const std::string& branch);
+std::string get_origin_url(const fs::path& repo);
+bool is_github_url(const std::string& url);
+bool remote_accessible(const fs::path& repo);
+int try_pull(const fs::path& repo, std::string& out_pull_log);
+
+} // namespace git
+
+#endif // GIT_UTILS_HPP

--- a/repo.hpp
+++ b/repo.hpp
@@ -1,0 +1,25 @@
+#ifndef REPO_HPP
+#define REPO_HPP
+#include <filesystem>
+#include <string>
+
+enum RepoStatus {
+    RS_CHECKING,
+    RS_UP_TO_DATE,
+    RS_PULLING,
+    RS_PULL_OK,
+    RS_PKGLOCK_FIXED,
+    RS_ERROR,
+    RS_SKIPPED,
+    RS_HEAD_PROBLEM
+};
+
+struct RepoInfo {
+    std::filesystem::path path;
+    RepoStatus status = RS_CHECKING;
+    std::string message;
+    std::string branch;
+    std::string last_pull_log;
+};
+
+#endif // REPO_HPP

--- a/tui.cpp
+++ b/tui.cpp
@@ -1,0 +1,96 @@
+#include "tui.hpp"
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <ctime>
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include "git_utils.hpp"
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace fs = std::filesystem;
+
+const char* COLOR_RESET = "\033[0m";
+const char* COLOR_GREEN = "\033[32m";
+const char* COLOR_YELLOW = "\033[33m";
+const char* COLOR_RED = "\033[31m";
+const char* COLOR_CYAN = "\033[36m";
+const char* COLOR_GRAY = "\033[90m";
+const char* COLOR_BOLD = "\033[1m";
+
+#ifdef _WIN32
+void enable_win_ansi() {
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hOut == INVALID_HANDLE_VALUE) return;
+    DWORD dwMode = 0;
+    if (!GetConsoleMode(hOut, &dwMode)) return;
+    dwMode |= 0x0004; // ENABLE_VIRTUAL_TERMINAL_PROCESSING
+    SetConsoleMode(hOut, dwMode);
+}
+#else
+void enable_win_ansi() {}
+#endif
+
+std::string timestamp() {
+    std::time_t now = std::time(nullptr);
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
+    return std::string(buf);
+}
+
+void draw_tui(const std::vector<fs::path>& all_repos,
+              const std::map<fs::path, RepoInfo>& repo_infos,
+              int interval, int seconds_left, bool scanning, bool show_skipped) {
+    std::ostringstream out;
+    out << "\033[2J\033[H";
+    out << COLOR_BOLD << "AutoGitPull TUI   " << COLOR_RESET
+        << COLOR_CYAN << timestamp() << COLOR_RESET
+        << "   Monitoring: "
+        << COLOR_YELLOW
+        << (all_repos.empty() ? "" : all_repos[0].parent_path().string())
+        << COLOR_RESET << "\n";
+    out << "Interval: " << interval << "s    (Ctrl+C to exit)\n";
+    if (scanning) out << COLOR_YELLOW << "Scan in progress...\n" << COLOR_RESET;
+    out << "--------------------------------------------------------------";
+    out << "-------------------\n";
+    out << COLOR_BOLD << "  Status     Repo" << COLOR_RESET << "\n";
+    out << "--------------------------------------------------------------";
+    out << "-------------------\n";
+    for (const auto& p : all_repos) {
+        RepoInfo ri;
+        auto it = repo_infos.find(p);
+        if (it != repo_infos.end())
+            ri = it->second;
+        else {
+            ri.status = RS_CHECKING;
+            ri.message = "Pending...";
+            ri.path = p;
+        }
+        if (ri.status == RS_SKIPPED && !show_skipped)
+            continue;
+        std::string color = COLOR_GRAY, status_s = "CHECK    ";
+        switch (ri.status) {
+            case RS_CHECKING:      color = COLOR_CYAN;   status_s = "Checking "; break;
+            case RS_UP_TO_DATE:    color = COLOR_GREEN;  status_s = "UpToDate "; break;
+            case RS_PULLING:       color = COLOR_YELLOW; status_s = "Pulling  "; break;
+            case RS_PULL_OK:       color = COLOR_GREEN;  status_s = "Pulled   "; break;
+            case RS_PKGLOCK_FIXED: color = COLOR_YELLOW; status_s = "PkgLockOk"; break;
+            case RS_ERROR:         color = COLOR_RED;    status_s = "Error    "; break;
+            case RS_SKIPPED:       color = COLOR_GRAY;   status_s = "Skipped  "; break;
+            case RS_HEAD_PROBLEM:  color = COLOR_RED;    status_s = "HEAD/BR  "; break;
+        }
+        out << color << " [" << std::left << std::setw(9) << status_s << "]  "
+            << p.filename().string() << COLOR_RESET;
+        if (!ri.branch.empty()) out << "  (" << ri.branch << ")";
+        if (!ri.message.empty()) out << " - " << ri.message;
+        out << "\n";
+    }
+    out << "--------------------------------------------------------------";
+    out << "-------------------\n";
+    out << COLOR_CYAN << "Next scan in " << seconds_left << " seconds..." << COLOR_RESET;
+    std::cout << out.str() << std::flush;
+}

--- a/tui.hpp
+++ b/tui.hpp
@@ -1,0 +1,16 @@
+#ifndef TUI_HPP
+#define TUI_HPP
+
+#include <filesystem>
+#include <vector>
+#include <map>
+#include <string>
+#include "repo.hpp"
+
+void enable_win_ansi();
+std::string timestamp();
+void draw_tui(const std::vector<std::filesystem::path>& all_repos,
+              const std::map<std::filesystem::path, RepoInfo>& repo_infos,
+              int interval, int seconds_left, bool scanning, bool show_skipped);
+
+#endif // TUI_HPP


### PR DESCRIPTION
## Summary
- introduce `ArgParser` helper for flag parsing
- split git operations into `git_utils` module
- move TUI code into `tui` module
- keep `autogitpull.cpp` focused on orchestration
- update build scripts

## Testing
- `g++ -std=c++17 -pthread -o autogitpull autogitpull.cpp git_utils.cpp tui.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68752345365883259131be87386cc5a1