### PR TITLE
Add configurable scan interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # autogitpull
 Automatic Git Puller & Monitor
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>]`
 
 By default, repositories whose `origin` remote does not point to GitHub or require authentication are skipped during scanning. Pass `--include-private` after the root folder to include these repositories. Skipped repositories are hidden from the TUI unless you also pass `--show-skipped`.
+
+Use `--interval` to specify the delay in seconds between automatic scans (default is 60 seconds).

--- a/arg_parser.hpp
+++ b/arg_parser.hpp
@@ -3,23 +3,45 @@
 #include <string>
 #include <set>
 #include <vector>
+#include <map>
 
 class ArgParser {
     std::set<std::string> flags_;
+    std::map<std::string, std::string> options_;
     std::vector<std::string> positional_;
 public:
     ArgParser(int argc, char* argv[]) {
-        for(int i=1;i<argc;++i) {
+        for (int i = 1; i < argc; ++i) {
             std::string arg = argv[i];
-            if(arg.rfind("--",0)==0) {
-                flags_.insert(arg);
+            if (arg.rfind("--", 0) == 0) {
+                size_t eq = arg.find('=');
+                if (eq != std::string::npos) {
+                    std::string key = arg.substr(0, eq);
+                    std::string val = arg.substr(eq + 1);
+                    flags_.insert(key);
+                    options_[key] = val;
+                } else if (i + 1 < argc && std::string(argv[i + 1]).rfind("--", 0) != 0) {
+                    std::string key = arg;
+                    std::string val = argv[++i];
+                    flags_.insert(key);
+                    options_[key] = val;
+                } else {
+                    flags_.insert(arg);
+                }
             } else {
                 positional_.push_back(arg);
             }
         }
     }
-    bool has_flag(const std::string& flag) const { return flags_.count(flag)>0; }
+
+    bool has_flag(const std::string& flag) const { return flags_.count(flag) > 0; }
+    std::string get_option(const std::string& opt) const {
+        auto it = options_.find(opt);
+        if (it != options_.end()) return it->second;
+        return "";
+    }
     const std::set<std::string>& flags() const { return flags_; }
+    const std::map<std::string, std::string>& options() const { return options_; }
     const std::vector<std::string>& positional() const { return positional_; }
 };
 


### PR DESCRIPTION
## Summary
- add option parsing with values to `ArgParser`
- support `--interval` option in `autogitpull`
- document interval option in README

## Testing
- `g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp -pthread -o autogitpull_test`

------
https://chatgpt.com/codex/tasks/task_e_68753179bdf48325981a27d2e6cd1c26