### PR TITLE
Replace popen with Boost.Process

### DIFF
--- a/git_utils.cpp
+++ b/git_utils.cpp
@@ -1,47 +1,72 @@
 #include "git_utils.hpp"
-#include <cstdio>
-#include <cstdlib>
-#include <vector>
+#include <boost/process.hpp>
+#include <chrono>
+#include <future>
 #include <sstream>
 
 #ifdef _WIN32
 #include <windows.h>
-#define popen _popen
-#define pclose _pclose
-const char* QUOTE = "\"";
-#else
-const char* QUOTE = "'";
 #endif
 
 using namespace std;
+namespace bp = boost::process;
 
 namespace git {
 
-string run_cmd(const string& cmd, int timeout_sec) {
-#ifndef _WIN32
-    string final_cmd = cmd;
+CmdResult run_cmd(const string& cmd, int timeout_sec) {
+    CmdResult result;
+    bp::ipstream pipe;
+    bp::child c(cmd, bp::shell, (bp::std_out & bp::std_err) > pipe);
+
+    auto reader = async(std::launch::async, [&]() {
+        string data, line;
+        while (getline(pipe, line)) {
+            data += line + '\n';
+        }
+        return data;
+    });
+
     if (timeout_sec > 0) {
-        final_cmd = "timeout " + to_string(timeout_sec) + " " + cmd;
+        if (!c.wait_for(chrono::seconds(timeout_sec))) {
+            c.terminate();
+            c.wait();
+            result.exit_code = -1;
+            result.output = reader.get();
+            if (!result.output.empty() && result.output.back() == '\n')
+                result.output.pop_back();
+            return result;
+        }
+    } else {
+        c.wait();
     }
-#else
-    string final_cmd = cmd;
-    (void)timeout_sec;
-#endif
-    string data;
-    char buffer[256];
-    FILE* raw = popen(final_cmd.c_str(), "r");
-    if (!raw) return data;
-    struct PopenHandle { FILE* fp; ~PopenHandle(){ if(fp) pclose(fp); } } handle{raw};
-    while (fgets(buffer, sizeof(buffer), handle.fp)) {
-        data.append(buffer);
-    }
-    if (!data.empty() && data.back() == '\n')
-        data.pop_back();
-    return data;
+
+    result.output = reader.get();
+    if (!result.output.empty() && result.output.back() == '\n')
+        result.output.pop_back();
+    result.exit_code = c.exit_code();
+    return result;
 }
 
 string quote_path(const fs::path& p) {
-    return string(QUOTE) + p.string() + string(QUOTE);
+#ifdef _WIN32
+    string s = p.string();
+    string escaped;
+    for (char ch : s) {
+        if (ch == '"') escaped += "\\\"";
+        else escaped += ch;
+    }
+    return string("\"") + escaped + string("\"");
+#else
+    string s = p.string();
+    string escaped;
+    for (char ch : s) {
+        if (ch == '\'' )
+            escaped += "'\\''";
+        else
+            escaped += ch;
+    }
+    return string("'") + escaped + string("'");
+#endif
 }
 
 bool is_git_repo(const fs::path& p) {
@@ -50,24 +75,24 @@ bool is_git_repo(const fs::path& p) {
 
 string get_local_hash(const fs::path& repo) {
     string cmd = "cd " + quote_path(repo) + " && git rev-parse HEAD 2>&1";
-    return run_cmd(cmd, 30);
+    return run_cmd(cmd, 30).output;
 }
 
 string get_current_branch(const fs::path& repo) {
     string cmd = "cd " + quote_path(repo) + " && git rev-parse --abbrev-ref HEAD 2>&1";
-    return run_cmd(cmd, 30);
+    return run_cmd(cmd, 30).output;
 }
 
 string get_remote_hash(const fs::path& repo, const string& branch) {
     string fetch_cmd = "cd " + quote_path(repo) + " && git fetch --quiet 2>&1";
     run_cmd(fetch_cmd, 30);
     string cmd = "cd " + quote_path(repo) + " && git rev-parse origin/" + branch + " 2>&1";
-    return run_cmd(cmd, 30);
+    return run_cmd(cmd, 30).output;
 }
 
 string get_origin_url(const fs::path& repo) {
     string cmd = "cd " + quote_path(repo) + " && git config --get remote.origin.url 2>&1";
-    return run_cmd(cmd, 15);
+    return run_cmd(cmd, 15).output;
 }
 
 bool is_github_url(const string& url) {
@@ -76,7 +101,7 @@ bool is_github_url(const string& url) {
 
 bool remote_accessible(const fs::path& repo) {
     string cmd = "cd " + quote_path(repo) + " && git ls-remote -h origin HEAD 2>&1";
-    string out = run_cmd(cmd, 30);
+    string out = run_cmd(cmd, 30).output;
     if (out.find("fatal") != string::npos || out.find("Permission denied") != string::npos ||
         out.find("ERROR") != string::npos)
         return false;
@@ -84,12 +109,13 @@ bool remote_accessible(const fs::path& repo) {
 }
 
 int try_pull(const fs::path& repo, string& out_pull_log) {
-    string pull = run_cmd("cd " + quote_path(repo) + " && git pull 2>&1", 30);
+    auto res = run_cmd("cd " + quote_path(repo) + " && git pull 2>&1", 30);
+    string pull = res.output;
     out_pull_log = pull;
     if (pull.find("package-lock.json") != string::npos &&
         pull.find("Please commit your changes or stash them before you merge") != string::npos) {
         run_cmd("cd " + quote_path(repo) + " && git checkout -- package-lock.json", 30);
-        pull = run_cmd("cd " + quote_path(repo) + " && git pull 2>&1", 30);
+        pull = run_cmd("cd " + quote_path(repo) + " && git pull 2>&1", 30).output;
         out_pull_log += "\n[Auto-discarded package-lock.json]\n" + pull;
         if (pull.find("Already up to date") != string::npos || pull.find("Updating") != string::npos)
             return 1;

--- a/git_utils.hpp
+++ b/git_utils.hpp
@@ -7,7 +7,12 @@
 namespace git {
 namespace fs = std::filesystem;
 
-std::string run_cmd(const std::string& cmd, int timeout_sec = 0);
+struct CmdResult {
+    int exit_code = -1;
+    std::string output;
+};
+
+CmdResult run_cmd(const std::string& cmd, int timeout_sec = 0);
 std::string quote_path(const fs::path& p);
 bool is_git_repo(const fs::path& p);
 std::string get_local_hash(const fs::path& repo);


### PR DESCRIPTION
## Summary
- create a `CmdResult` struct with exit code and output
- implement `run_cmd` using Boost.Process and timeout support
- escape paths safely on Windows and POSIX

## Testing
- `g++ -std=c++17 -lboost_system -lboost_filesystem -lpthread autogitpull.cpp git_utils.cpp tui.cpp -o /tmp/build`

------
https://chatgpt.com/codex/tasks/task_e_687533d537f88325bfed664b52a8429a