### PR TITLE
Add log directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # autogitpull
 Automatic Git Puller & Monitor
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--log-dir <path>]`
 
 By default, repositories whose `origin` remote does not point to GitHub or require authentication are skipped during scanning. Pass `--include-private` after the root folder to include these repositories. Skipped repositories are hidden from the TUI unless you also pass `--show-skipped`.
 
 Use `--interval` to specify the delay in seconds between automatic scans (default is 60 seconds).
+
+Provide `--log-dir <path>` to store pull logs for each repository. After every pull operation the log
+is written to a timestamped file inside this directory and its location is shown in the TUI.


### PR DESCRIPTION
## Summary
- add `--log-dir` flag
- dump pull output to timestamped files
- show log file path in TUI messages
- document the new flag in README

## Testing
- `g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp -lboost_system -lboost_filesystem -o /tmp/agp_test`

------
https://chatgpt.com/codex/tasks/task_e_68753612de588325b311a37f2bd07e9a