### PR TITLE
Switch to libgit2 for Git operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # autogitpull
 Automatic Git Puller & Monitor
 
+## Dependencies
+This tool relies on [libgit2](https://libgit2.org/). On Linux install the
+`libgit2-dev` package before compiling. Windows builds require `libgit2.lib`
+to be available on the library path.
+
 Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--log-dir <path>]`
 
 By default, repositories whose `origin` remote does not point to GitHub or require authentication are skipped during scanning. Pass `--include-private` after the root folder to include these repositories. Skipped repositories are hidden from the TUI unless you also pass `--show-skipped`.

--- a/compile-cl.bat
+++ b/compile-cl.bat
@@ -1,1 +1,1 @@
-cl /std:c++17 /EHsc autogitpull.cpp git_utils.cpp tui.cpp
+cl /std:c++17 /EHsc autogitpull.cpp git_utils.cpp tui.cpp libgit2.lib

--- a/compile.bat
+++ b/compile.bat
@@ -1,1 +1,1 @@
- g++ -std=c++17 -o git_auto_pull_all.exe autogitpull.cpp git_utils.cpp tui.cpp
+ g++ -std=c++17 -lgit2 -o git_auto_pull_all.exe autogitpull.cpp git_utils.cpp tui.cpp

--- a/git_utils.hpp
+++ b/git_utils.hpp
@@ -7,13 +7,6 @@
 namespace git {
 namespace fs = std::filesystem;
 
-struct CmdResult {
-    int exit_code = -1;
-    std::string output;
-};
-
-CmdResult run_cmd(const std::string& cmd, int timeout_sec = 0);
-std::string quote_path(const fs::path& p);
 bool is_git_repo(const fs::path& p);
 std::string get_local_hash(const fs::path& repo);
 std::string get_current_branch(const fs::path& repo);


### PR DESCRIPTION
## Summary
- depend on libgit2
- drop Boost.Process usage and shell invocations
- implement git helpers using libgit2
- update build scripts to link with libgit2

## Testing
- `g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp -lgit2 -o autogitpull_test`


------
https://chatgpt.com/codex/tasks/task_e_687537e1ddbc8325af4d714142899c30