### PR TITLE
Add cross-platform dependency installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 Automatic Git Puller & Monitor
 
 ## Dependencies
-This tool relies on [libgit2](https://libgit2.org/). On Linux install the
-`libgit2-dev` package before compiling. Windows builds require `libgit2.lib`
-to be available on the library path.
+This tool relies on [libgit2](https://libgit2.org/). Run `install_deps.sh` on Linux or macOS, or `install_deps.bat` on Windows to download and install `libgit2` automatically. These scripts are also invoked from the compile scripts when the library is missing.
 
 Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--log-dir <path>]`
 
@@ -14,3 +12,4 @@ Use `--interval` to specify the delay in seconds between automatic scans (defaul
 
 Provide `--log-dir <path>` to store pull logs for each repository. After every pull operation the log
 is written to a timestamped file inside this directory and its location is shown in the TUI.
+

--- a/compile-cl.bat
+++ b/compile-cl.bat
@@ -1,1 +1,8 @@
+@echo off
+where libgit2.lib >nul 2>nul
+if NOT %ERRORLEVEL%==0 (
+    call install_deps.bat
+)
+
 cl /std:c++17 /EHsc autogitpull.cpp git_utils.cpp tui.cpp libgit2.lib
+

--- a/compile.bat
+++ b/compile.bat
@@ -1,1 +1,8 @@
- g++ -std=c++17 -lgit2 -o git_auto_pull_all.exe autogitpull.cpp git_utils.cpp tui.cpp
+@echo off
+where libgit2.lib >nul 2>nul
+if NOT %ERRORLEVEL%==0 (
+    call install_deps.bat
+)
+
+g++ -std=c++17 -lgit2 -o git_auto_pull_all.exe autogitpull.cpp git_utils.cpp tui.cpp
+

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+if ! pkg-config --exists libgit2; then
+    echo "libgit2 not found, attempting to install..."
+    ./install_deps.sh
+fi
+
+g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp -lgit2 -o git_auto_pull_all
+
+

--- a/install_deps.bat
+++ b/install_deps.bat
@@ -1,0 +1,25 @@
+@echo off
+where libgit2.lib >nul 2>nul
+if %ERRORLEVEL%==0 (
+    echo libgit2 already installed.
+    goto :eof
+)
+
+if exist vcpkg (
+    echo Installing libgit2 via vcpkg...
+    vcpkg\vcpkg install libgit2
+    goto :eof
+)
+
+echo libgit2 not found. Downloading vcpkg to install...
+if not exist git.exe (
+    echo Git is required to download vcpkg. Please install Git and retry.
+    exit /b 1
+)
+
+git clone https://github.com/microsoft/vcpkg
+cd vcpkg
+call bootstrap-vcpkg.bat
+cd ..
+vcpkg\vcpkg install libgit2
+

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+# Install libgit2 if missing
+if command -v pkg-config >/dev/null && pkg-config --exists libgit2; then
+    echo "libgit2 already installed"
+    exit 0
+fi
+
+os="$(uname -s)"
+case "$os" in
+    Linux*)
+        if command -v apt-get >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y libgit2-dev
+        elif command -v yum >/dev/null; then
+            sudo yum install -y libgit2-devel
+        else
+            echo "Unsupported Linux distribution. Please install libgit2 manually."
+            exit 1
+        fi
+        ;;
+    Darwin*)
+        if command -v brew >/dev/null; then
+            brew install libgit2
+        else
+            echo "Homebrew not found. Please install libgit2 manually."
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Unsupported OS."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- add `install_deps.sh` for Linux/macOS and `install_deps.bat` for Windows
- add `compile.sh` for Unix builds
- update compile scripts to auto-install missing deps
- document new scripts in README

## Testing
- `./compile.sh`

------
https://chatgpt.com/codex/tasks/task_e_68753a61621883259ba2bacf6cf817fd