### PR TITLE
Fix libgit2 detection on macOS in build script

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if ! pkg-config --exists libgit2; then
+if ! (command -v pkg-config >/dev/null && pkg-config --exists libgit2); then
     echo "libgit2 not found, attempting to install..."
     ./install_deps.sh
 fi


### PR DESCRIPTION
## Summary
- avoid `pkg-config` errors when compiling on macOS by checking if it exists

## Testing
- `./install_deps.sh`
- `./compile.sh`

------
https://chatgpt.com/codex/tasks/task_e_68754491d8048325845cd249d5d8f8ac