### PR TITLE
Add GitInitGuard for libgit2 initialization

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -151,6 +151,7 @@ void scan_repos(
 
 int main(int argc, char* argv[]) {
     AltScreenGuard guard;
+    git::GitInitGuard git_guard;
     try {
         const std::set<std::string> known{ "--include-private", "--show-skipped", "--interval", "--log-dir", "--help" };
         ArgParser parser(argc, argv, known);

--- a/git_utils.cpp
+++ b/git_utils.cpp
@@ -5,6 +5,14 @@ using namespace std;
 
 namespace git {
 
+GitInitGuard::GitInitGuard() {
+    git_libgit2_init();
+}
+
+GitInitGuard::~GitInitGuard() {
+    git_libgit2_shutdown();
+}
+
 bool is_git_repo(const fs::path& p) {
     return fs::exists(p / ".git") && fs::is_directory(p / ".git");
 }

--- a/git_utils.hpp
+++ b/git_utils.hpp
@@ -7,6 +7,12 @@
 namespace git {
 namespace fs = std::filesystem;
 
+// RAII helper that manages global libgit2 initialization.
+struct GitInitGuard {
+    GitInitGuard();
+    ~GitInitGuard();
+};
+
 bool is_git_repo(const fs::path& p);
 std::string get_local_hash(const fs::path& repo);
 std::string get_current_branch(const fs::path& repo);


### PR DESCRIPTION
## Summary
- manage global libgit2 init/shutdown with `GitInitGuard`
- instantiate guard in `main` to ensure libgit2 is ready

## Testing
- `install_deps.sh`
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6875497228308325a1c8d587efebdacb