### PR TITLE
Improve macOS dependency check

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
 set -e
 
-if ! (command -v pkg-config >/dev/null && pkg-config --exists libgit2); then
-    echo "libgit2 not found, attempting to install..."
-    ./install_deps.sh
+os="$(uname -s)"
+
+if command -v pkg-config >/dev/null && pkg-config --exists libgit2; then
+    :
+else
+    if [[ "$os" == "Darwin" ]]; then
+        if command -v brew >/dev/null && brew ls --versions libgit2 >/dev/null; then
+            echo "libgit2 found via brew"
+        else
+            echo "libgit2 not found, attempting to install..."
+            ./install_deps.sh
+        fi
+    else
+        echo "libgit2 not found, attempting to install..."
+        ./install_deps.sh
+    fi
 fi
 
 g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp -lgit2 -o git_auto_pull_all


### PR DESCRIPTION
## Summary
- enhance `compile.sh` to check for libgit2 via brew when `pkg-config` isn't present on macOS

## Testing
- `./compile.sh`

------
https://chatgpt.com/codex/tasks/task_e_687549c06f40832591dd41fa83e6c0f9