### PR TITLE
Fix windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ vcpkg\vcpkg install libgit2
 Ensure that the resulting `vcpkg` `installed` folder is on your `LIB` and
 `INCLUDE` paths when compiling.
 
+The Windows build scripts (`compile.bat` and `compile-cl.bat`) look for a
+`vcpkg` directory in the project root or use the `VCPKG_ROOT` environment
+variable. Make sure one of these is set so the headers (`git2.h`) and the
+library can be found.
+
 ## Building
 ### Using the provided scripts
 Run `make` (Linux/macOS) or `compile.bat` (MinGW) to build the project. These

--- a/compile-cl.bat
+++ b/compile-cl.bat
@@ -1,8 +1,21 @@
 @echo off
-where libgit2.lib >nul 2>nul
-if NOT %ERRORLEVEL%==0 (
+setlocal
+
+rem Determine the vcpkg root (either via environment or local folder)
+if "%VCPKG_ROOT%"=="" (
+    if exist vcpkg (
+        set "VCPKG_ROOT=%CD%\vcpkg"
+    )
+)
+
+set "LIBGIT2_INC=%VCPKG_ROOT%\installed\x64-windows\include"
+set "LIBGIT2_LIB=%VCPKG_ROOT%\installed\x64-windows\lib"
+
+if not exist "%LIBGIT2_LIB%\libgit2.lib" (
     call install_deps.bat
 )
 
-cl /std:c++17 /EHsc autogitpull.cpp git_utils.cpp tui.cpp libgit2.lib
+cl /std:c++17 /EHsc /I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp /link /LIBPATH:"%LIBGIT2_LIB%" libgit2.lib
+
+endlocal
 

--- a/compile.bat
+++ b/compile.bat
@@ -1,8 +1,21 @@
 @echo off
-where libgit2.lib >nul 2>nul
-if NOT %ERRORLEVEL%==0 (
+setlocal
+
+rem Determine the vcpkg root (either via environment or local folder)
+if "%VCPKG_ROOT%"=="" (
+    if exist vcpkg (
+        set "VCPKG_ROOT=%CD%\vcpkg"
+    )
+)
+
+set "LIBGIT2_INC=%VCPKG_ROOT%\installed\x64-windows\include"
+set "LIBGIT2_LIB=%VCPKG_ROOT%\installed\x64-windows\lib"
+
+if not exist "%LIBGIT2_LIB%\libgit2.lib" (
     call install_deps.bat
 )
 
-g++ -std=c++17 -lgit2 -o git_auto_pull_all.exe autogitpull.cpp git_utils.cpp tui.cpp
+g++ -std=c++17 -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp -L"%LIBGIT2_LIB%" -lgit2 -o git_auto_pull_all.exe
+
+endlocal
 


### PR DESCRIPTION
## Summary
- fix Windows build by including libgit2 paths in batch scripts
- describe setup of VCPKG_ROOT in README

## Testing
- `make`
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_687568e6f010832593380107b2c2612c