### PR TITLE
Fix Windows static linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Ensure that the resulting `vcpkg` `installed` folder is on your `LIB` and
 The Windows build scripts (`compile.bat` and `compile-cl.bat`) look for a
 `vcpkg` directory in the project root or use the `VCPKG_ROOT` environment
 variable. Make sure one of these is set so the headers (`git2.h`) and the
-library can be found.
+library can be found. vcpkg names its static libraries using the `.lib`
+extension, and `compile.bat` links against `libgit2.lib` directly.
 
 ## Building
 ### Using the provided scripts

--- a/compile.bat
+++ b/compile.bat
@@ -11,11 +11,12 @@ if "%VCPKG_ROOT%"=="" (
 set "LIBGIT2_INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
 set "LIBGIT2_LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
-if not exist "%LIBGIT2_LIB%\libgit2.a" (
+rem Check for the static libgit2 archive (vcpkg uses .lib on Windows)
+if not exist "%LIBGIT2_LIB%\libgit2.lib" (
     call install_deps.bat
 )
 
-g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp "%LIBGIT2_LIB%\libgit2.a" -o autogitpull.exe
+g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp "%LIBGIT2_LIB%\libgit2.lib" -o autogitpull.exe
 
 endlocal
 

--- a/install_deps.bat
+++ b/install_deps.bat
@@ -1,5 +1,6 @@
 @echo off
-if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\libgit2.a" (
+rem vcpkg places static libraries under .lib
+if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\libgit2.lib" (
     echo libgit2 already installed.
     goto :eof
 )


### PR DESCRIPTION
## Summary
- fix Windows compile scripts to use libgit2.lib
- adjust dependency checks for libgit2 on Windows
- clarify README on `.lib` usage

## Testing
- `make clean`
- `make` *(fails: undefined reference to `gss_display_status` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6875834719448325ae48a062591d620f