### PR TITLE
Fix Windows lib naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Windows build scripts (`compile.bat` and `compile-cl.bat`) look for a
 `vcpkg` directory in the project root or use the `VCPKG_ROOT` environment
 variable. Make sure one of these is set so the headers (`git2.h`) and the
 library can be found. vcpkg names its static libraries using the `.lib`
-extension, and `compile.bat` links against `libgit2.lib` directly.
+extension, and `compile.bat` links against `git2.lib` directly.
 
 ## Building
 ### Using the provided scripts

--- a/compile-cl.bat
+++ b/compile-cl.bat
@@ -11,11 +11,12 @@ if "%VCPKG_ROOT%"=="" (
 set "LIBGIT2_INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
 set "LIBGIT2_LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
-if not exist "%LIBGIT2_LIB%\libgit2.lib" (
+rem Newer versions may name the library git2.lib
+if not exist "%LIBGIT2_LIB%\git2.lib" (
     call install_deps.bat
 )
 
-cl /std:c++17 /EHsc /MT /I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp /link /LIBPATH:"%LIBGIT2_LIB%" libgit2.lib
+cl /std:c++17 /EHsc /MT /I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp /link /LIBPATH:"%LIBGIT2_LIB%" git2.lib
 
 endlocal
 

--- a/compile.bat
+++ b/compile.bat
@@ -12,11 +12,12 @@ set "LIBGIT2_INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
 set "LIBGIT2_LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
 rem Check for the static libgit2 archive (vcpkg uses .lib on Windows)
-if not exist "%LIBGIT2_LIB%\libgit2.lib" (
+rem Newer versions may name the library git2.lib
+if not exist "%LIBGIT2_LIB%\git2.lib" (
     call install_deps.bat
 )
 
-g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp "%LIBGIT2_LIB%\libgit2.lib" -o autogitpull.exe
+g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp "%LIBGIT2_LIB%\git2.lib" -o autogitpull.exe
 
 endlocal
 

--- a/install_deps.bat
+++ b/install_deps.bat
@@ -1,6 +1,6 @@
 @echo off
 rem vcpkg places static libraries under .lib
-if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\libgit2.lib" (
+if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
     echo libgit2 already installed.
     goto :eof
 )


### PR DESCRIPTION
## Summary
- update Windows build scripts to search for `git2.lib`
- document new `git2.lib` name in README

## Testing
- `make clean`
- `make` *(fails: undefined reference to gssapi symbols)*

------
https://chatgpt.com/codex/tasks/task_e_6875850b0cb083259e43306b075295ab