### PR TITLE
Fix help screen not to clear terminal

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -155,7 +155,6 @@ void scan_repos(
 }
 
 int main(int argc, char* argv[]) {
-    AltScreenGuard guard;
     git::GitInitGuard git_guard;
     try {
         const std::set<std::string> known{ "--include-private", "--show-skipped", "--interval", "--log-dir", "--help" };
@@ -243,6 +242,8 @@ int main(int argc, char* argv[]) {
 
         std::thread scan_thread;
         int countdown = 0; // Run immediately on start
+
+        AltScreenGuard guard;
 
         while (running) {
             if (!scanning && scan_thread.joinable())


### PR DESCRIPTION
## Summary
- avoid using the alternate screen when printing usage or help
- move AltScreenGuard creation so `--help` and invalid usage show plain text

## Testing
- `make LDFLAGS="$(pkg-config --libs libgit2)"`
- `./autogitpull --help | head -n 20`
- `./autogitpull | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68763872bc508325a97ada1af97a8904