### PR TITLE
Add configurable TUI refresh rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,14 @@ cmake --build build
 
 The resulting executable will be in the `build` directory.
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--log-dir <path>] [--help]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--help]`
 
 Available options:
 
 * `--include-private` – include private or non-GitHub repositories in the scan.
 * `--show-skipped` – display repositories that were skipped because they are non-GitHub or require authentication.
 * `--interval <seconds>` – delay between automatic scans (default 60).
+* `--refresh-rate <ms>` – how often the TUI refreshes in milliseconds (default 500).
 * `--log-dir <path>` – directory where pull logs will be written.
 * `--help` – show the usage information and exit.
 


### PR DESCRIPTION
## Summary
- add `--refresh-rate` option and document it
- parse refresh-rate in `main`
- refresh screen using `std::chrono::milliseconds`

## Testing
- `make clean && make` *(fails: undefined reference to gss*)*

------
https://chatgpt.com/codex/tasks/task_e_687668a05d0883259b7f666962255066