### PR TITLE
Improve header layout

### DIFF
--- a/tui.cpp
+++ b/tui.cpp
@@ -48,8 +48,8 @@ void draw_tui(const std::vector<fs::path>& all_repos,
     std::ostringstream out;
     out << "\033[2J\033[H";
     out << COLOR_BOLD << "AutoGitPull TUI   " << COLOR_RESET
-        << COLOR_CYAN << timestamp() << COLOR_RESET
-        << "   Monitoring: "
+        << COLOR_CYAN << timestamp() << COLOR_RESET << "\n";
+    out << "Monitoring: "
         << COLOR_YELLOW
         << (all_repos.empty() ? "" : all_repos[0].parent_path().string())
         << COLOR_RESET << "\n";


### PR DESCRIPTION
## Summary
- move monitoring path onto its own line so the header is easier to read

## Testing
- `make` *(fails: undefined reference to `gss_display_status`)*

------
https://chatgpt.com/codex/tasks/task_e_68767b65f8788325972401917919fb02