### PR TITLE
Add thread-per-repo scanning option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ cmake --build build
 
 The resulting executable will be in the `build` directory.
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--help]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--thread-per-repo] [--help]`
 
 Available options:
 
@@ -96,6 +96,7 @@ Available options:
 * `--interval <seconds>` – delay between automatic scans (default 60).
 * `--refresh-rate <ms>` – how often the TUI refreshes in milliseconds (default 500).
 * `--log-dir <path>` – directory where pull logs will be written.
+* `--thread-per-repo` – spawn a separate thread for each repository (honors `AUTOGITPULL_MAX_THREADS` if set).
 * `--help` – show the usage information and exit.
 
 By default, repositories whose `origin` remote does not point to GitHub or require authentication are skipped during scanning. Use `--include-private` to include them. Skipped repositories are hidden from the TUI unless `--show-skipped` is also provided.


### PR DESCRIPTION
## Summary
- allow running repo scans concurrently via new `--thread-per-repo` flag
- update README with usage of the flag
- support optional concurrency limit using `AUTOGITPULL_MAX_THREADS`

## Testing
- `./install_deps.sh`
- `g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp -lgit2 -pthread -o autogitpull`
- `./autogitpull --thread-per-repo --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68767f9cc3f883258a475b4915c6a5d6