### PR TITLE
Add configurable concurrency for repo scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ cmake --build build
 
 The resulting executable will be in the `build` directory.
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--thread-per-repo] [--help]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--concurrency <n>] [--help]`
 
 Available options:
 
@@ -96,7 +96,7 @@ Available options:
 * `--interval <seconds>` – delay between automatic scans (default 60).
 * `--refresh-rate <ms>` – how often the TUI refreshes in milliseconds (default 500).
 * `--log-dir <path>` – directory where pull logs will be written.
-* `--thread-per-repo` – spawn a separate thread for each repository (honors `AUTOGITPULL_MAX_THREADS` if set).
+* `--concurrency <n>` – number of repositories processed in parallel (default 3).
 * `--help` – show the usage information and exit.
 
 By default, repositories whose `origin` remote does not point to GitHub or require authentication are skipped during scanning. Use `--include-private` to include them. Skipped repositories are hidden from the TUI unless `--show-skipped` is also provided.


### PR DESCRIPTION
## Summary
- add `--concurrency <n>` option with default 3
- implement thread pool in `scan_repos`
- document new option in README

## Testing
- `./install_deps.sh`
- `make` *(fails: undefined reference to gssapi symbols)*

------
https://chatgpt.com/codex/tasks/task_e_687683556a388325b89964d1326ef2b0