### PR TITLE
Update default scan interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Available options:
 
 * `--include-private` – include private or non-GitHub repositories in the scan.
 * `--show-skipped` – display repositories that were skipped because they are non-GitHub or require authentication.
-* `--interval <seconds>` – delay between automatic scans (default 60).
+* `--interval <seconds>` – delay between automatic scans (default 30).
 * `--refresh-rate <ms>` – how often the TUI refreshes in milliseconds (default 500).
 * `--log-dir <path>` – directory where pull logs will be written.
 * `--concurrency <n>` – number of repositories processed in parallel (default 3).

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -236,7 +236,7 @@ int main(int argc, char* argv[]) {
         bool check_only = parser.has_flag("--check-only");
         bool hash_check = !parser.has_flag("--no-hash-check");
         size_t concurrency = 3;
-        int interval = 60;
+        int interval = 30;
         std::chrono::milliseconds refresh_ms(500);
         if (parser.has_flag("--interval")) {
             std::string val = parser.get_option("--interval");


### PR DESCRIPTION
## Summary
- reduce the default automatic scan interval from 60 to 30 seconds
- update README to document the new default

## Testing
- `make` *(fails: undefined reference to gssapi symbols)*

------
https://chatgpt.com/codex/tasks/task_e_6876974cd0848325b40bd65a21372eda