### PR TITLE
Update refresh rate defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Available options:
 * `--include-private` – include private or non-GitHub repositories in the scan.
 * `--show-skipped` – display repositories that were skipped because they are non-GitHub or require authentication.
 * `--interval <seconds>` – delay between automatic scans (default 30).
-* `--refresh-rate <ms>` – how often the TUI refreshes in milliseconds (default 500).
+* `--refresh-rate <ms>` – how often the TUI refreshes in milliseconds (default 250).
 * `--log-dir <path>` – directory where pull logs will be written.
 * `--concurrency <n>` – number of repositories processed in parallel (default 3).
 * `--check-only` – only check for updates without pulling.

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -237,7 +237,7 @@ int main(int argc, char* argv[]) {
         bool hash_check = !parser.has_flag("--no-hash-check");
         size_t concurrency = 3;
         int interval = 30;
-        std::chrono::milliseconds refresh_ms(500);
+        std::chrono::milliseconds refresh_ms(250);
         if (parser.has_flag("--interval")) {
             std::string val = parser.get_option("--interval");
             if (val.empty()) {


### PR DESCRIPTION
## Summary
- adjust default TUI refresh interval to 250ms
- document new `--refresh-rate` default in README

## Testing
- `make` *(fails: undefined reference to gss_display_status)*

------
https://chatgpt.com/codex/tasks/task_e_687698757e308325b009e78f93d929b7