### PR TITLE
Fix thread safety in timestamp()

### DIFF
--- a/tui.cpp
+++ b/tui.cpp
@@ -38,8 +38,14 @@ void enable_win_ansi() {}
 
 std::string timestamp() {
     std::time_t now = std::time(nullptr);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &now);
+#else
+    localtime_r(&now, &tm);
+#endif
     char buf[32];
-    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
     return std::string(buf);
 }
 


### PR DESCRIPTION
## Summary
- replace `std::localtime` usage
- construct a `tm` locally with `localtime_r` or `localtime_s`
- keep `strftime` working with the local structure

## Testing
- `g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp $(pkg-config --cflags --libs libgit2) -pthread -o autogitpull`

------
https://chatgpt.com/codex/tasks/task_e_6876989423dc8325b8583702e1336a05