### PR TITLE
Fix status always idle

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -196,10 +196,6 @@ void process_repo(const fs::path& p,
         ri.message = e.what();
         skip_repos.insert(p);
     }
-    {
-        std::lock_guard<std::mutex> lk(action_mtx);
-        action = "Idle";
-    }
     std::lock_guard<std::mutex> lk(mtx);
     repo_infos[p] = ri;
 }
@@ -241,6 +237,10 @@ void scan_repos(
         threads.emplace_back(worker);
     for (auto& t : threads) t.join();
     scanning_flag = false;
+    {
+        std::lock_guard<std::mutex> lk(action_mtx);
+        action = "Idle";
+    }
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
## Summary
- prevent action from being cleared while other repos are still processing
- reset action to *Idle* only once scanning finishes

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6876c5336aa48325bf2dfebf650a342a