### PR TITLE
Add log-file documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ make test
 This command generates a `build` directory (if missing), compiles the tests and
 executes them through CMake's `ctest` driver.
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--concurrency <n>] [--check-only] [--no-hash-check] [--help]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--log-file <path>] [--concurrency <n>] [--check-only] [--no-hash-check] [--help]`
 
 Available options:
 
@@ -110,6 +110,7 @@ Available options:
 * `--interval <seconds>` – delay between automatic scans (default 30).
 * `--refresh-rate <ms>` – how often the TUI refreshes in milliseconds (default 250).
 * `--log-dir <path>` – directory where pull logs will be written.
+* `--log-file <path>` – file for general messages.
 * `--concurrency <n>` – number of repositories processed in parallel (default 3).
 * `--check-only` – only check for updates without pulling.
 * `--no-hash-check` – always pull without comparing commit hashes first.
@@ -119,6 +120,8 @@ By default, repositories whose `origin` remote does not point to GitHub or requi
 
 Provide `--log-dir <path>` to store pull logs for each repository. After every pull operation the log
 is written to a timestamped file inside this directory and its location is shown in the TUI.
+Use `--log-file <path>` to append high level messages to the given file. The program records startup, repository actions and shutdown there. For example:
+`./autogitpull myprojects --log-dir logs --log-file autogitpull.log`
 
 ## Runtime requirements
 * **Git** must be available in your `PATH` for libgit2 to interact with repositories.


### PR DESCRIPTION
## Summary
- document `--log-file` option in README
- explain how the file receives general messages and show an example

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6876cd8c7d048325adda44fc71a1a47d