### PR TITLE
Fix logger linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,19 +62,19 @@ the bare minimum required to compile the program.
 On Linux with `g++`:
 
 ```bash
-g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp $(pkg-config --cflags --libs libgit2) -pthread -static -o autogitpull
+g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp logger.cpp $(pkg-config --cflags --libs libgit2) -pthread -static -o autogitpull
 ```
 
 On macOS with `clang++`:
 
 ```bash
-clang++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp $(pkg-config --cflags --libs libgit2) -pthread -o autogitpull
+clang++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp logger.cpp $(pkg-config --cflags --libs libgit2) -pthread -o autogitpull
 ```
 
 On Windows with MSVC's `cl`:
 
 ```batch
-cl /std:c++17 /EHsc /MT /Ipath\to\libgit2\include autogitpull.cpp git_utils.cpp tui.cpp /link /LIBPATH:path\to\libgit2\lib git2.lib
+cl /std:c++17 /EHsc /MT /Ipath\to\libgit2\include autogitpull.cpp git_utils.cpp tui.cpp logger.cpp /link /LIBPATH:path\to\libgit2\lib git2.lib
 ```
 
 These commands mirror what the scripts do internally.

--- a/compile-cl.bat
+++ b/compile-cl.bat
@@ -15,6 +15,6 @@ if not exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
 set "INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
 set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
-cl /nologo /std:c++17 /EHsc /I"%INC%" autogitpull.cpp git_utils.cpp tui.cpp ^
+cl /nologo /std:c++17 /EHsc /I"%INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp ^
     "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib /Feautogitpull.exe
 endlocal

--- a/compile.bat
+++ b/compile.bat
@@ -22,7 +22,7 @@ if not exist "%LIBGIT2_LIB%\libgit2.a" (
     if errorlevel 1 exit /b 1
 )
 
-g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -o autogitpull.exe
+g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -o autogitpull.exe
 
 endlocal
 

--- a/compile.sh
+++ b/compile.sh
@@ -52,10 +52,10 @@ fi
 PKG_CFLAGS="$(pkg-config --cflags libgit2 2>/dev/null || echo '')"
 if [[ "$os" == "Darwin" ]]; then
     PKG_LIBS="$(pkg-config --libs libgit2 2>/dev/null || echo '-lgit2')"
-    ${CXX} -std=c++17 ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp ${PKG_LIBS} -o autogitpull
+    ${CXX} -std=c++17 ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp ${PKG_LIBS} -o autogitpull
 else
     PKG_LIBS="$(pkg-config --static --libs libgit2 2>/dev/null || echo '-lgit2')"
-    ${CXX} -std=c++17 -static ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp ${PKG_LIBS} -o autogitpull
+    ${CXX} -std=c++17 -static ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp ${PKG_LIBS} -o autogitpull
 fi
 
 


### PR DESCRIPTION
## Summary
- include `logger.cpp` in compile scripts
- document manual compilation with `logger.cpp`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6876d043980883259115507fa9709a4f