### PR TITLE
Add pending repo status

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ is written to a timestamped file inside this directory and its location is shown
 Use `--log-file <path>` to append high level messages to the given file. The program records startup, repository actions and shutdown there. For example:
 `./autogitpull myprojects --log-dir logs --log-file autogitpull.log`
 
+### Status labels
+When the program starts, each repository is listed with the **Pending** status
+until it is checked for the first time. Once a scan begins the status switches
+to **Checking** and later reflects the pull result.
+
 ## Runtime requirements
 * **Git** must be available in your `PATH` for libgit2 to interact with repositories.
 * Network access is required to contact remote Git servers when pulling updates.

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -394,7 +394,7 @@ int main(int argc, char* argv[]) {
         }
         std::map<fs::path, RepoInfo> repo_infos;
         for (const auto& p : all_repos) {
-            repo_infos[p] = RepoInfo{p, RS_CHECKING, "Pending...", "", "", "", 0, false};
+            repo_infos[p] = RepoInfo{p, RS_PENDING, "Pending...", "", "", "", 0, false};
         }
 
         std::set<fs::path> skip_repos;

--- a/repo.hpp
+++ b/repo.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 enum RepoStatus {
+    RS_PENDING,
     RS_CHECKING,
     RS_UP_TO_DATE,
     RS_PULLING,
@@ -17,7 +18,7 @@ enum RepoStatus {
 
 struct RepoInfo {
     std::filesystem::path path;
-    RepoStatus status = RS_CHECKING;
+    RepoStatus status = RS_PENDING;
     std::string message;
     std::string branch;
     std::string commit; // short hash of HEAD

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -65,7 +65,7 @@ TEST_CASE("Git utils GitHub url detection") {
 
 TEST_CASE("RepoInfo defaults") {
     RepoInfo ri;
-    REQUIRE(ri.status == RS_CHECKING);
+    REQUIRE(ri.status == RS_PENDING);
     REQUIRE(ri.progress == 0);
     REQUIRE_FALSE(ri.auth_failed);
 }

--- a/tui.cpp
+++ b/tui.cpp
@@ -79,15 +79,16 @@ void draw_tui(const std::vector<fs::path>& all_repos,
         if (it != repo_infos.end())
             ri = it->second;
         else {
-            ri.status = RS_CHECKING;
+            ri.status = RS_PENDING;
             ri.message = "Pending...";
             ri.path = p;
             ri.auth_failed = false;
         }
         if (ri.status == RS_SKIPPED && !show_skipped)
             continue;
-        std::string color = COLOR_GRAY, status_s = "CHECK    ";
+        std::string color = COLOR_GRAY, status_s = "Pending ";
         switch (ri.status) {
+            case RS_PENDING:       color = COLOR_GRAY;   status_s = "Pending "; break;
             case RS_CHECKING:      color = COLOR_CYAN;   status_s = "Checking "; break;
             case RS_UP_TO_DATE:    color = COLOR_GREEN;  status_s = "UpToDate "; break;
             case RS_PULLING:       color = COLOR_YELLOW; status_s = "Pulling  "; break;


### PR DESCRIPTION
## Summary
- introduce `RS_PENDING` enum value and set as default repo status
- initialise repos with `RS_PENDING`
- support `RS_PENDING` in the TUI
- update tests for new default
- document pending status in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6876d3d8c6648325ab68314f3d8bed81