### PR TITLE
Fix Catch2 detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,19 @@ if(MINGW)
     target_link_libraries(autogitpull PRIVATE winhttp ole32 rpcrt4 crypt32)
 endif()
 
+include(FetchContent)
+
 enable_testing()
-find_package(Catch2 3 REQUIRED)
+find_package(Catch2 3 QUIET)
+if(NOT Catch2_FOUND)
+    message(STATUS "Catch2 not found, fetching via FetchContent...")
+    FetchContent_Declare(
+        Catch2
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG v3.5.2
+    )
+    FetchContent_MakeAvailable(Catch2)
+endif()
 add_executable(autogitpull_tests tests/tests.cpp)
 target_include_directories(autogitpull_tests PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(autogitpull_tests PRIVATE Catch2::Catch2WithMain autogitpull_lib)

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ cmake --build build
 The resulting executable will be in the `build` directory.
 
 ### Running tests
-Unit tests require [Catch2](https://github.com/catchorg/Catch2), which is
-available on most package managers. After installing the dependency, configure
-and build the project with CMake and run `ctest`:
+Unit tests use [Catch2](https://github.com/catchorg/Catch2). If the library is
+not installed, CMake will automatically download it using `FetchContent`. After
+configuring and building the project, run `ctest`:
 
 ```bash
 make test


### PR DESCRIPTION
## Summary
- automatically fetch Catch2 when it's missing
- update README to note automatic download

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6876dce80a2c8325a8e04db0e114b097