### PR TITLE
Add logger tests and log-file parsing coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,10 @@ else()
 endif()
 pkg_check_modules(LIBGIT2 REQUIRED IMPORTED_TARGET libgit2)
 
-add_library(autogitpull_lib STATIC git_utils.cpp)
+add_library(autogitpull_lib STATIC git_utils.cpp logger.cpp)
 target_link_libraries(autogitpull_lib PRIVATE PkgConfig::LIBGIT2 pthread)
 
-add_executable(autogitpull autogitpull.cpp tui.cpp logger.cpp)
+add_executable(autogitpull autogitpull.cpp tui.cpp)
 target_link_libraries(autogitpull PRIVATE autogitpull_lib)
 if(MSVC)
     target_link_options(autogitpull PRIVATE /MT)


### PR DESCRIPTION
## Summary
- link logger.cpp into autogitpull_lib so tests can use logging
- verify `--log-file` handling in ArgParser
- test logger functionality by writing to a temporary file

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6876e0f1aa5c8325aec55af743dfe128