### PR TITLE
Add log levels and verbose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ make test
 This command generates a `build` directory (if missing), compiles the tests and
 executes them through CMake's `ctest` driver.
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--log-file <path>] [--concurrency <n>] [--check-only] [--no-hash-check] [--help]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--log-file <path>] [--log-level <level>] [--verbose] [--concurrency <n>] [--check-only] [--no-hash-check] [--help]`
 
 Available options:
 
@@ -111,6 +111,8 @@ Available options:
 * `--refresh-rate <ms>` – how often the TUI refreshes in milliseconds (default 250).
 * `--log-dir <path>` – directory where pull logs will be written.
 * `--log-file <path>` – file for general messages.
+* `--log-level <level>` – minimum message level written to the log (`DEBUG`, `INFO`, `WARNING`, `ERROR`).
+* `--verbose` – shorthand for `--log-level DEBUG`.
 * `--concurrency <n>` – number of repositories processed in parallel (default 3).
 * `--check-only` – only check for updates without pulling.
 * `--no-hash-check` – always pull without comparing commit hashes first.
@@ -121,7 +123,7 @@ By default, repositories whose `origin` remote does not point to GitHub or requi
 Provide `--log-dir <path>` to store pull logs for each repository. After every pull operation the log
 is written to a timestamped file inside this directory and its location is shown in the TUI.
 Use `--log-file <path>` to append high level messages to the given file. The program records startup, repository actions and shutdown there. For example:
-`./autogitpull myprojects --log-dir logs --log-file autogitpull.log`
+`./autogitpull myprojects --log-dir logs --log-file autogitpull.log --log-level DEBUG`
 
 ### Status labels
 When the program starts, each repository is listed with the **Pending** status

--- a/logger.cpp
+++ b/logger.cpp
@@ -7,10 +7,17 @@
 
 static std::ofstream g_log_ofs;
 static std::mutex g_log_mtx;
+static LogLevel g_min_level = LogLevel::INFO;
 
-void init_logger(const std::string& path) {
+void init_logger(const std::string& path, LogLevel level) {
     std::lock_guard<std::mutex> lk(g_log_mtx);
     g_log_ofs.open(path, std::ios::app);
+    g_min_level = level;
+}
+
+void set_log_level(LogLevel level) {
+    std::lock_guard<std::mutex> lk(g_log_mtx);
+    g_min_level = level;
 }
 
 bool logger_initialized() {
@@ -32,16 +39,23 @@ static std::string timestamp() {
     return buf;
 }
 
-static void log(const std::string& level, const std::string& msg) {
+static void log(LogLevel level, const std::string& label, const std::string& msg) {
     std::lock_guard<std::mutex> lk(g_log_mtx);
-    if (!g_log_ofs.is_open()) return;
-    g_log_ofs << "[" << timestamp() << "] [" << level << "] " << msg << std::endl;
+    if (!g_log_ofs.is_open() || level < g_min_level) return;
+    g_log_ofs << "[" << timestamp() << "] [" << label << "] " << msg << std::endl;
 }
 
+void log_debug(const std::string& msg) {
+    log(LogLevel::DEBUG, "DEBUG", msg);
+}
 void log_info(const std::string& msg) {
-    log("INFO", msg);
+    log(LogLevel::INFO, "INFO", msg);
+}
+
+void log_warning(const std::string& msg) {
+    log(LogLevel::WARNING, "WARNING", msg);
 }
 
 void log_error(const std::string& msg) {
-    log("ERROR", msg);
+    log(LogLevel::ERROR, "ERROR", msg);
 }

--- a/logger.hpp
+++ b/logger.hpp
@@ -2,9 +2,14 @@
 #define LOGGER_HPP
 #include <string>
 
-void init_logger(const std::string& path);
+enum class LogLevel { DEBUG = 0, INFO, WARNING, ERROR };
+
+void init_logger(const std::string& path, LogLevel level = LogLevel::INFO);
+void set_log_level(LogLevel level);
 bool logger_initialized();
+void log_debug(const std::string& msg);
 void log_info(const std::string& msg);
+void log_warning(const std::string& msg);
 void log_error(const std::string& msg);
 
 #endif // LOGGER_HPP

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -70,4 +70,12 @@ TEST_CASE("RepoInfo defaults") {
     REQUIRE_FALSE(ri.auth_failed);
 }
 
+TEST_CASE("ArgParser log level flags") {
+    const char* argv[] = { "prog", "--log-level", "DEBUG", "--verbose" };
+    ArgParser parser(4, const_cast<char**>(argv), {"--log-level", "--verbose"});
+    REQUIRE(parser.has_flag("--log-level"));
+    REQUIRE(parser.get_option("--log-level") == "DEBUG");
+    REQUIRE(parser.has_flag("--verbose"));
+}
+
 


### PR DESCRIPTION
## Summary
- implement `LogLevel` enum in logger and add debug/warning helpers
- allow setting log level via `--log-level` or `--verbose`
- use debug level for per-repo updates
- document new CLI flags in README
- test ArgParser handling of new flags

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6876e1083c54832591c00b5667853d84