### PR TITLE
Add clang-format config and lint target

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+SortIncludes: false
+UseTab: Never

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -18,6 +18,12 @@ jobs:
       - name: Install dependencies
         run: ./install_deps.sh
 
+      - name: Install lint tools
+        run: pip install cpplint
+
+      - name: Lint
+        run: make lint
+
       - name: Build
         run: |
           mkdir build && cd build

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ endif
 
 SRC = autogitpull.cpp git_utils.cpp tui.cpp logger.cpp
 OBJ = $(SRC:.cpp=.o)
+FORMAT_FILES = $(SRC) *.hpp
 
 all: autogitpull
 
@@ -21,9 +22,13 @@ autogitpull: $(OBJ)
 clean:
 	rm -f $(OBJ) autogitpull
 
+lint:
+	clang-format --dry-run --Werror $(FORMAT_FILES)
+	cpplint $(FORMAT_FILES)
+
 test:
 	cmake -S . -B build
 	cmake --build build
 	cd build && ctest --output-on-failure
 
-.PHONY: all clean test
+.PHONY: all clean lint test

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ is written to a timestamped file inside this directory and its location is shown
 Use `--log-file <path>` to append high level messages to the given file. The program records startup, repository actions and shutdown there. For example:
 `./autogitpull myprojects --log-dir logs --log-file autogitpull.log`
 
+## Linting
+The project uses `clang-format` and `cpplint` to enforce a consistent code style.
+Run `make lint` before committing to ensure formatting and style rules pass:
+
+```bash
+make lint
+```
+
+The CI workflow also executes this command and will fail on formatting or lint errors.
+
 ### Status labels
 When the program starts, each repository is listed with the **Pending** status
 until it is checked for the first time. Once a scan begins the status switches


### PR DESCRIPTION
## Summary
- define project clang-format style
- add `make lint` that checks formatting and runs cpplint
- run lint step in CI
- document linting in README

## Testing
- `make lint` *(fails: code should be clang-formatted)*
- `make test` *(fails: libgit2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876e18bb3f88325b4334c0059ad2f03