### PR TITLE
Fix CI tag push permissions

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build-test-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- enable write permissions for CI

## Testing
- `./install_deps.sh`
- `cmake ..`
- `make -j$(nproc)`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_687795aa08388325bd4d90f93d6148a5