### PR TITLE
Refactor timestamp helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT LIBGIT2_FOUND)
     message(FATAL_ERROR "libgit2 not found. Install the libgit2 development package or run ./install_deps.sh")
 endif()
 
-add_library(autogitpull_lib STATIC git_utils.cpp logger.cpp resource_utils.cpp)
+add_library(autogitpull_lib STATIC git_utils.cpp logger.cpp resource_utils.cpp time_utils.cpp)
 target_link_libraries(autogitpull_lib PRIVATE PkgConfig::LIBGIT2 pthread)
 
 add_executable(autogitpull autogitpull.cpp tui.cpp)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ else
 LDFLAGS = $(shell pkg-config --static --libs libgit2 2>/dev/null || echo -lgit2) -static
 endif
 
-SRC = autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp
+SRC = autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp time_utils.cpp
 OBJ = $(SRC:.cpp=.o)
 FORMAT_FILES = $(SRC) *.hpp
 

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -19,6 +19,7 @@
 #include "tui.hpp"
 #include "repo.hpp"
 #include "logger.hpp"
+#include "time_utils.hpp"
 #include "resource_utils.hpp"
 
 namespace fs = std::filesystem;

--- a/logger.cpp
+++ b/logger.cpp
@@ -1,9 +1,7 @@
 #include "logger.hpp"
 #include <fstream>
 #include <mutex>
-#include <chrono>
-#include <ctime>
-#include <iomanip>
+#include "time_utils.hpp"
 
 static std::ofstream g_log_ofs;
 static std::mutex g_log_mtx;
@@ -23,20 +21,6 @@ void set_log_level(LogLevel level) {
 bool logger_initialized() {
     std::lock_guard<std::mutex> lk(g_log_mtx);
     return g_log_ofs.is_open();
-}
-
-static std::string timestamp() {
-    auto now = std::chrono::system_clock::now();
-    std::time_t t = std::chrono::system_clock::to_time_t(now);
-    std::tm tm;
-#ifdef _WIN32
-    localtime_s(&tm, &t);
-#else
-    localtime_r(&t, &tm);
-#endif
-    char buf[32];
-    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
-    return buf;
 }
 
 static void log(LogLevel level, const std::string &label, const std::string &msg) {

--- a/time_utils.cpp
+++ b/time_utils.cpp
@@ -1,0 +1,17 @@
+#include "time_utils.hpp"
+#include <chrono>
+#include <ctime>
+
+std::string timestamp() {
+    auto now = std::chrono::system_clock::now();
+    std::time_t t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &t);
+#else
+    localtime_r(&t, &tm);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
+    return std::string(buf);
+}

--- a/time_utils.hpp
+++ b/time_utils.hpp
@@ -1,0 +1,11 @@
+#ifndef TIME_UTILS_HPP
+#define TIME_UTILS_HPP
+
+#include <string>
+
+/**
+ * @brief Get the current local time formatted as YYYY-MM-DD HH:MM:SS.
+ */
+std::string timestamp();
+
+#endif // TIME_UTILS_HPP

--- a/tui.cpp
+++ b/tui.cpp
@@ -2,10 +2,9 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
-#include <ctime>
-#include <chrono>
 #include <filesystem>
 #include <string>
+#include "time_utils.hpp"
 #include "git_utils.hpp"
 #include "resource_utils.hpp"
 
@@ -39,18 +38,6 @@ void enable_win_ansi() {
 void enable_win_ansi() {}
 #endif
 
-std::string timestamp() {
-    std::time_t now = std::time(nullptr);
-    std::tm tm{};
-#ifdef _WIN32
-    localtime_s(&tm, &now);
-#else
-    localtime_r(&now, &tm);
-#endif
-    char buf[32];
-    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
-    return std::string(buf);
-}
 
 void draw_tui(const std::vector<fs::path> &all_repos,
               const std::map<fs::path, RepoInfo> &repo_infos, int interval, int seconds_left,

--- a/tui.hpp
+++ b/tui.hpp
@@ -14,10 +14,6 @@
  */
 void enable_win_ansi();
 
-/**
- * @brief Get the current local time formatted as `YYYY-MM-DD HH:MM:SS`.
- */
-std::string timestamp();
 
 /**
  * @brief Render the text user interface.


### PR DESCRIPTION
## Summary
- create shared `time_utils` for timestamp function
- remove duplicate implementations from `tui` and `logger`
- update sources and build files to use the new helper

## Testing
- `./install_deps.sh`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877af552f688325b95089adbbe771f5