### PR TITLE
Add --show-version TUI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# autogitpull
+#autogitpull
 Automatic Git Puller & Monitor
 
 ## Dependencies
@@ -104,12 +104,13 @@ make test
 This command generates a `build` directory (if missing), compiles the tests and
 executes them through CMake's `ctest` driver.
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--log-file <path>] [--log-level <level>] [--verbose] [--concurrency <n>] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <n>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--help]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--log-file <path>] [--log-level <level>] [--verbose] [--concurrency <n>] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <n>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--help]`
 
 Available options:
 
 * `--include-private` – include private or non-GitHub repositories in the scan.
 * `--show-skipped` – display repositories that were skipped because they are non-GitHub or require authentication.
+* `--show-version` – display the program version in the TUI header.
 * `--interval <seconds>` – delay between automatic scans (default 30).
 * `--refresh-rate <ms>` – how often the TUI refreshes in milliseconds (default 250).
 * `--log-dir <path>` – directory where pull logs will be written.

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -286,16 +286,16 @@ int main(int argc, char *argv[]) {
     git::GitInitGuard git_guard;
     try {
         const std::set<std::string> known{
-            "--include-private", "--show-skipped",      "--interval",    "--refresh-rate",
-            "--log-dir",         "--log-file",          "--concurrency", "--check-only",
-            "--no-hash-check",   "--log-level",         "--verbose",     "--max-threads",
-            "--cpu-percent",     "--cpu-cores",         "--mem-limit",   "--no-cpu-tracker",
-            "--no-mem-tracker",  "--no-thread-tracker", "--help"};
+            "--include-private", "--show-skipped",   "--show-version",      "--interval",
+            "--refresh-rate",    "--log-dir",        "--log-file",          "--concurrency",
+            "--check-only",      "--no-hash-check",  "--log-level",         "--verbose",
+            "--max-threads",     "--cpu-percent",    "--cpu-cores",         "--mem-limit",
+            "--no-cpu-tracker",  "--no-mem-tracker", "--no-thread-tracker", "--help"};
         ArgParser parser(argc, argv, known);
 
         if (parser.has_flag("--help")) {
             std::cout << "Usage: " << argv[0]
-                      << " <root-folder> [--include-private] [--show-skipped]"
+                      << " <root-folder> [--include-private] [--show-skipped] [--show-version]"
                       << " [--interval <seconds>] [--refresh-rate <ms>]"
                       << " [--log-dir <path>] [--log-file <path>]"
                       << " [--log-level <level>] [--verbose]"
@@ -309,7 +309,7 @@ int main(int argc, char *argv[]) {
 
         if (parser.positional().size() != 1) {
             std::cerr << "Usage: " << argv[0]
-                      << " <root-folder> [--include-private] [--show-skipped]"
+                      << " <root-folder> [--include-private] [--show-skipped] [--show-version]"
                       << " [--interval <seconds>] [--refresh-rate <ms>]"
                       << " [--log-dir <path>] [--log-file <path>]"
                       << " [--log-level <level>] [--verbose]"
@@ -329,6 +329,7 @@ int main(int argc, char *argv[]) {
         }
         bool include_private = parser.has_flag("--include-private");
         bool show_skipped = parser.has_flag("--show-skipped");
+        bool show_version = parser.has_flag("--show-version");
         bool check_only = parser.has_flag("--check-only");
         bool hash_check = !parser.has_flag("--no-hash-check");
         LogLevel log_level = LogLevel::INFO;
@@ -577,7 +578,7 @@ int main(int argc, char *argv[]) {
                     act = current_action;
                 }
                 draw_tui(all_repos, repo_infos, interval, sec_left, scanning, act, show_skipped,
-                         cpu_tracker, mem_tracker, thread_tracker);
+                         show_version, cpu_tracker, mem_tracker, thread_tracker);
             }
             std::this_thread::sleep_for(refresh_ms);
             countdown_ms -= refresh_ms;

--- a/tui.cpp
+++ b/tui.cpp
@@ -24,6 +24,8 @@ const char *COLOR_GRAY = "\033[90m";
 const char *COLOR_BOLD = "\033[1m";
 const char *COLOR_MAGENTA = "\033[35m";
 
+const char *APP_VERSION = "0.1.0";
+
 #ifdef _WIN32
 void enable_win_ansi() {
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -54,12 +56,14 @@ std::string timestamp() {
 
 void draw_tui(const std::vector<fs::path> &all_repos,
               const std::map<fs::path, RepoInfo> &repo_infos, int interval, int seconds_left,
-              bool scanning, const std::string &action, bool show_skipped, bool track_cpu,
-              bool track_mem, bool track_threads) {
+              bool scanning, const std::string &action, bool show_skipped, bool show_version,
+              bool track_cpu, bool track_mem, bool track_threads) {
     std::ostringstream out;
     out << "\033[2J\033[H";
-    out << COLOR_BOLD << "AutoGitPull TUI   " << COLOR_RESET << COLOR_CYAN << timestamp()
-        << COLOR_RESET << "\n";
+    out << COLOR_BOLD << "AutoGitPull TUI";
+    if (show_version)
+        out << " v" << APP_VERSION;
+    out << "   " << COLOR_RESET << COLOR_CYAN << timestamp() << COLOR_RESET << "\n";
     out << "Monitoring: " << COLOR_YELLOW
         << (all_repos.empty() ? "" : all_repos[0].parent_path().string()) << COLOR_RESET << "\n";
     out << "Interval: " << interval << "s    (Ctrl+C to exit)\n";

--- a/tui.hpp
+++ b/tui.hpp
@@ -33,6 +33,6 @@ std::string timestamp();
 void draw_tui(const std::vector<std::filesystem::path> &all_repos,
               const std::map<std::filesystem::path, RepoInfo> &repo_infos, int interval,
               int seconds_left, bool scanning, const std::string &action, bool show_skipped,
-              bool track_cpu, bool track_mem, bool track_threads);
+              bool show_version, bool track_cpu, bool track_mem, bool track_threads);
 
 #endif // TUI_HPP


### PR DESCRIPTION
## Summary
- extend known flags and option usage with `--show-version`
- pass `show_version` through to `draw_tui`
- print version string in the TUI header when requested
- document the new flag

## Testing
- `./install_deps.sh`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6877b1f346008325a62b951c55b89b4b