### PR TITLE
Fix missing sources in build scripts

### DIFF
--- a/compile-cl.bat
+++ b/compile-cl.bat
@@ -15,6 +15,6 @@ if not exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
 set "INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
 set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
-cl /nologo /std:c++17 /EHsc /I"%INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp ^
+cl /nologo /std:c++17 /EHsc /I"%INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp time_utils.cpp ^
     "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib /Feautogitpull.exe
 endlocal

--- a/compile.bat
+++ b/compile.bat
@@ -22,7 +22,7 @@ if not exist "%LIBGIT2_LIB%\libgit2.a" (
     if errorlevel 1 exit /b 1
 )
 
-g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -o autogitpull.exe
+g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp time_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -o autogitpull.exe
 
 endlocal
 

--- a/compile.sh
+++ b/compile.sh
@@ -52,10 +52,10 @@ fi
 PKG_CFLAGS="$(pkg-config --cflags libgit2 2>/dev/null || echo '')"
 if [[ "$os" == "Darwin" ]]; then
     PKG_LIBS="$(pkg-config --libs libgit2 2>/dev/null || echo '-lgit2')"
-    ${CXX} -std=c++17 ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp ${PKG_LIBS} -o autogitpull
+    ${CXX} -std=c++17 ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp time_utils.cpp ${PKG_LIBS} -o autogitpull
 else
     PKG_LIBS="$(pkg-config --static --libs libgit2 2>/dev/null || echo '-lgit2')"
-    ${CXX} -std=c++17 -static ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp ${PKG_LIBS} -o autogitpull
+    ${CXX} -std=c++17 -static ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp time_utils.cpp ${PKG_LIBS} -o autogitpull
 fi
 
 


### PR DESCRIPTION
## Summary
- include `resource_utils.cpp` and `time_utils.cpp` in Windows build scripts
- add the same sources to `compile.sh`

## Testing
- `make test`
- `./compile.sh` *(fails: undefined reference to gssapi symbols)*

------
https://chatgpt.com/codex/tasks/task_e_6877b4832c908325880b913ce28c7b8a