### PR TITLE
Add auto log-file name

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -495,10 +495,17 @@ int main(int argc, char *argv[]) {
         if (parser.has_flag("--log-file")) {
             std::string val = parser.get_option("--log-file");
             if (val.empty()) {
-                std::cerr << "--log-file requires a path\n";
-                return 1;
+                std::string ts = timestamp();
+                for (char &ch : ts) {
+                    if (ch == ' ' || ch == ':')
+                        ch = '_';
+                    else if (ch == '/')
+                        ch = '-';
+                }
+                log_file = "autogitpull-logs-" + ts + ".log";
+            } else {
+                log_file = val;
             }
-            log_file = val;
         }
         fs::path root = parser.positional().front();
         if (!fs::exists(root) || !fs::is_directory(root)) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -4,6 +4,7 @@
 #include "repo.hpp"
 #include "logger.hpp"
 #include "resource_utils.hpp"
+#include "time_utils.hpp"
 #include <filesystem>
 #include <fstream>
 #include <cstdlib>
@@ -140,4 +141,28 @@ TEST_CASE("Logger appends messages") {
         REQUIRE(lines.size() == count_before + 1);
         REQUIRE(lines.back().find("third entry") != std::string::npos);
     }
+    close_logger();
+}
+
+TEST_CASE("--log-file without value creates file") {
+    const char *argv[] = {"prog", "--log-file"};
+    ArgParser parser(2, const_cast<char **>(argv), {"--log-file"});
+    REQUIRE(parser.has_flag("--log-file"));
+    REQUIRE(parser.get_option("--log-file").empty());
+
+    std::string ts = timestamp();
+    for (char &ch : ts) {
+        if (ch == ' ' || ch == ':')
+            ch = '_';
+        else if (ch == '/')
+            ch = '-';
+    }
+    fs::path log = "autogitpull-logs-" + ts + ".log";
+    fs::remove(log);
+    init_logger(log.string());
+    REQUIRE(logger_initialized());
+    log_info("test entry");
+    close_logger();
+    REQUIRE(fs::exists(log));
+    fs::remove(log);
 }


### PR DESCRIPTION
## Summary
- support using `--log-file` without a value
- generate a timestamped log filename when the option value is empty
- close the logger in the logger test
- add a unit test for the empty `--log-file` case

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877b69e5aac8325ab4e03fba1f384b8