### PR TITLE
Add network usage tracker option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ make test
 This command generates a `build` directory (if missing), compiles the tests and
 executes them through CMake's `ctest` driver.
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--log-file <path>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <n>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--help]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--log-file <path>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <n>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--help]`
 
 Available options:
 
@@ -129,6 +129,7 @@ Available options:
 * `--no-cpu-tracker` – disable CPU usage display in the TUI.
 * `--no-mem-tracker` – disable memory usage display in the TUI.
 * `--no-thread-tracker` – disable thread count display in the TUI.
+* `--net-tracker` – show total network usage since startup.
 * `--help` – show the usage information and exit.
 
 By default, repositories whose `origin` remote does not point to GitHub or require authentication are skipped during scanning. Use `--include-private` to include them. Skipped repositories are hidden from the TUI unless `--show-skipped` is also provided.
@@ -137,7 +138,7 @@ Provide `--log-dir <path>` to store pull logs for each repository. After every p
 is written to a timestamped file inside this directory and its location is shown in the TUI.
 Use `--log-file <path>` to append high level messages to the given file. The program records startup, repository actions and shutdown there. For example:
 `./autogitpull myprojects --log-dir logs --log-file autogitpull.log --log-level DEBUG`
-CPU, memory and thread usage are tracked and shown by default. Disable them individually with `--no-cpu-tracker`, `--no-mem-tracker` or `--no-thread-tracker`.
+CPU, memory and thread usage are tracked and shown by default. Disable them individually with `--no-cpu-tracker`, `--no-mem-tracker` or `--no-thread-tracker`. Enable network usage tracking with `--net-tracker`.
 
 ## Linting
 The project uses `clang-format` and `cpplint` to enforce a consistent code style.

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -292,34 +292,36 @@ int main(int argc, char *argv[]) {
             "--check-only",      "--no-hash-check",  "--log-level",         "--verbose",
             "--max-threads",     "--cpu-percent",    "--cpu-cores",         "--mem-limit",
             "--no-cpu-tracker",  "--no-mem-tracker", "--no-thread-tracker", "--help",
-            "--threads",         "--single-thread"};
+            "--threads",         "--single-thread",  "--net-tracker"};
         ArgParser parser(argc, argv, known);
 
         if (parser.has_flag("--help")) {
-            std::cout << "Usage: " << argv[0]
-                      << " <root-folder> [--include-private] [--show-skipped] [--show-version]"
-                      << " [--interval <seconds>] [--refresh-rate <ms>]"
-                      << " [--log-dir <path>] [--log-file <path>]"
-                      << " [--log-level <level>] [--verbose]"
-                      << " [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>]"
-                      << " [--cpu-percent <n>] [--cpu-cores <n>]"
-                      << " [--mem-limit <MB>] [--check-only] [--no-hash-check]"
-                      << " [--no-cpu-tracker] [--no-mem-tracker]"
-                      << " [--no-thread-tracker] [--help]\n";
+            std::cout
+                << "Usage: " << argv[0]
+                << " <root-folder> [--include-private] [--show-skipped] [--show-version]"
+                << " [--interval <seconds>] [--refresh-rate <ms>]"
+                << " [--log-dir <path>] [--log-file <path>]"
+                << " [--log-level <level>] [--verbose]"
+                << " [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>]"
+                << " [--cpu-percent <n>] [--cpu-cores <n>]"
+                << " [--mem-limit <MB>] [--check-only] [--no-hash-check]"
+                << " [--no-cpu-tracker] [--no-mem-tracker]"
+                << " [--no-thread-tracker] [--net-tracker] [--help]\n";
             return 0;
         }
 
         if (parser.positional().size() != 1) {
-            std::cerr << "Usage: " << argv[0]
-                      << " <root-folder> [--include-private] [--show-skipped] [--show-version]"
-                      << " [--interval <seconds>] [--refresh-rate <ms>]"
-                      << " [--log-dir <path>] [--log-file <path>]"
-                      << " [--log-level <level>] [--verbose]"
-                      << " [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>]"
-                      << " [--cpu-percent <n>] [--cpu-cores <n>]"
-                      << " [--mem-limit <MB>] [--check-only] [--no-hash-check]"
-                      << " [--no-cpu-tracker] [--no-mem-tracker]"
-                      << " [--no-thread-tracker] [--help]\n";
+            std::cerr
+                << "Usage: " << argv[0]
+                << " <root-folder> [--include-private] [--show-skipped] [--show-version]"
+                << " [--interval <seconds>] [--refresh-rate <ms>]"
+                << " [--log-dir <path>] [--log-file <path>]"
+                << " [--log-level <level>] [--verbose]"
+                << " [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>]"
+                << " [--cpu-percent <n>] [--cpu-cores <n>]"
+                << " [--mem-limit <MB>] [--check-only] [--no-hash-check]"
+                << " [--no-cpu-tracker] [--no-mem-tracker]"
+                << " [--no-thread-tracker] [--net-tracker] [--help]\n";
             return 1;
         }
 
@@ -369,6 +371,7 @@ int main(int argc, char *argv[]) {
         bool cpu_tracker = true;
         bool mem_tracker = true;
         bool thread_tracker = true;
+        bool net_tracker = false;
         int interval = 30;
         std::chrono::milliseconds refresh_ms(250);
         if (parser.has_flag("--interval")) {
@@ -491,6 +494,7 @@ int main(int argc, char *argv[]) {
         cpu_tracker = !parser.has_flag("--no-cpu-tracker");
         mem_tracker = !parser.has_flag("--no-mem-tracker");
         thread_tracker = !parser.has_flag("--no-thread-tracker");
+        net_tracker = parser.has_flag("--net-tracker");
         if (max_threads > 0 && concurrency > max_threads)
             concurrency = max_threads;
         fs::path log_dir;
@@ -535,6 +539,9 @@ int main(int argc, char *argv[]) {
         }
         if (cpu_cores > 0)
             procutil::set_cpu_affinity(cpu_cores);
+
+        if (net_tracker)
+            procutil::init_network_usage();
 
         if (!log_file.empty()) {
             init_logger(log_file, log_level);
@@ -607,7 +614,7 @@ int main(int argc, char *argv[]) {
                     act = current_action;
                 }
                 draw_tui(all_repos, repo_infos, interval, sec_left, scanning, act, show_skipped,
-                         show_version, cpu_tracker, mem_tracker, thread_tracker);
+                         show_version, cpu_tracker, mem_tracker, thread_tracker, net_tracker);
             }
             std::this_thread::sleep_for(refresh_ms);
             countdown_ms -= refresh_ms;

--- a/resource_utils.cpp
+++ b/resource_utils.cpp
@@ -3,6 +3,8 @@
 #include <fstream>
 #include <string>
 #include <thread>
+#include <sstream>
+#include <utility>
 #ifdef __linux__
 #include <sched.h>
 #include <unistd.h>
@@ -46,6 +48,36 @@ static std::size_t read_status_value(const std::string &) { return 0; }
 
 static long prev_jiffies = 0;
 static auto prev_time = std::chrono::steady_clock::now();
+#ifdef __linux__
+static std::pair<std::size_t, std::size_t> read_net_bytes() {
+    std::ifstream net("/proc/self/net/dev");
+    std::string line;
+    std::getline(net, line);
+    std::getline(net, line);
+    std::size_t rx_total = 0, tx_total = 0;
+    while (std::getline(net, line)) {
+        std::istringstream iss(line);
+        std::string iface;
+        if (!std::getline(iss, iface, ':'))
+            continue;
+        std::size_t rx_bytes = 0, rx_packets = 0, rx_errs = 0, rx_drop = 0, rx_fifo = 0,
+                    rx_frame = 0, rx_compressed = 0, rx_multicast = 0;
+        std::size_t tx_bytes = 0, tx_packets = 0, tx_errs = 0, tx_drop = 0, tx_fifo = 0,
+                    tx_colls = 0, tx_carrier = 0, tx_compressed = 0;
+        iss >> rx_bytes >> rx_packets >> rx_errs >> rx_drop >> rx_fifo >> rx_frame >>
+            rx_compressed >> rx_multicast >> tx_bytes >> tx_packets >> tx_errs >> tx_drop >>
+            tx_fifo >> tx_colls >> tx_carrier >> tx_compressed;
+        rx_total += rx_bytes;
+        tx_total += tx_bytes;
+    }
+    return {rx_total, tx_total};
+}
+#else
+static std::pair<std::size_t, std::size_t> read_net_bytes() { return {0, 0}; }
+#endif
+
+static std::size_t base_down = 0;
+static std::size_t base_up = 0;
 
 double get_cpu_percent() {
 #ifdef __linux__
@@ -96,6 +128,20 @@ bool set_cpu_affinity(int cores) {
     (void)cores;
     return false;
 #endif
+}
+
+void init_network_usage() {
+    auto bytes = read_net_bytes();
+    base_down = bytes.first;
+    base_up = bytes.second;
+}
+
+NetUsage get_network_usage() {
+    auto bytes = read_net_bytes();
+    NetUsage u;
+    u.download_bytes = bytes.first - base_down;
+    u.upload_bytes = bytes.second - base_up;
+    return u;
 }
 
 } // namespace procutil

--- a/resource_utils.hpp
+++ b/resource_utils.hpp
@@ -9,6 +9,14 @@ std::size_t get_memory_usage_mb();
 std::size_t get_thread_count();
 bool set_cpu_affinity(int cores);
 
+struct NetUsage {
+    std::size_t download_bytes;
+    std::size_t upload_bytes;
+};
+
+void init_network_usage();
+NetUsage get_network_usage();
+
 } // namespace procutil
 
 #endif // RESOURCE_UTILS_HPP

--- a/tui.cpp
+++ b/tui.cpp
@@ -40,11 +40,10 @@ void enable_win_ansi() {
 void enable_win_ansi() {}
 #endif
 
-
 void draw_tui(const std::vector<fs::path> &all_repos,
               const std::map<fs::path, RepoInfo> &repo_infos, int interval, int seconds_left,
               bool scanning, const std::string &action, bool show_skipped, bool show_version,
-              bool track_cpu, bool track_mem, bool track_threads) {
+              bool track_cpu, bool track_mem, bool track_threads, bool track_net) {
     std::ostringstream out;
     out << "\033[2J\033[H";
     out << COLOR_BOLD << "AutoGitPull TUI";
@@ -77,6 +76,18 @@ void draw_tui(const std::vector<fs::path> &all_repos,
         else
             out << "N/A";
         out << "\n";
+    }
+    if (track_net) {
+        auto usage = procutil::get_network_usage();
+        auto fmt = [](std::size_t b) {
+            std::ostringstream ss;
+            if (b >= 1024 * 1024)
+                ss << b / (1024 * 1024) << " MB";
+            else
+                ss << b / 1024 << " KB";
+            return ss.str();
+        };
+        out << "Net: D " << fmt(usage.download_bytes) << "  U " << fmt(usage.upload_bytes) << "\n";
     }
     out << "--------------------------------------------------------------";
     out << "-------------------\n";

--- a/tui.hpp
+++ b/tui.hpp
@@ -14,7 +14,6 @@
  */
 void enable_win_ansi();
 
-
 /**
  * @brief Render the text user interface.
  *
@@ -29,6 +28,7 @@ void enable_win_ansi();
 void draw_tui(const std::vector<std::filesystem::path> &all_repos,
               const std::map<std::filesystem::path, RepoInfo> &repo_infos, int interval,
               int seconds_left, bool scanning, const std::string &action, bool show_skipped,
-              bool show_version, bool track_cpu, bool track_mem, bool track_threads);
+              bool show_version, bool track_cpu, bool track_mem, bool track_threads,
+              bool track_net);
 
 #endif // TUI_HPP


### PR DESCRIPTION
## Summary
- extend resource_utils with network usage helpers
- display cumulative network transfer in TUI when enabled
- add `--net-tracker` CLI flag and documentation

## Testing
- `make lint` *(fails: cpplint errors)*
- `make test` *(fails: libgit2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877c72f51448325ba04b4abc55a5942