### PR TITLE
Fix linting and update contribution guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 To maintain code quality, all commits must pass the following checks **before** they are committed:
 
-1. `make lint` – runs clang-format and cpplint to ensure the C++ sources follow the project's style rules.
-2. `npm run format` – formats any JavaScript/TypeScript sources.
+1. `make lint` – runs clang-format, cpplint **and Prettier checks** to ensure all sources follow the project's style rules.
+2. `npm run format` – formats all Markdown and JSON files using Prettier.
 3. The full test suite via `make test`.
 
 Run these commands locally from the repository root:

--- a/arg_parser.hpp
+++ b/arg_parser.hpp
@@ -29,7 +29,7 @@ class ArgParser {
      * @param known_flags Optional set of flags that are considered valid. If
      *        empty, all flags are treated as known.
      */
-    ArgParser(int argc, char *argv[], const std::set<std::string> &known_flags = {})
+    ArgParser(int argc, char* argv[], const std::set<std::string>& known_flags = {})
         : known_flags_(known_flags) {
         for (int i = 1; i < argc; ++i) {
             std::string arg = argv[i];
@@ -72,7 +72,7 @@ class ArgParser {
      * @param flag Flag name including the leading `--`.
      * @return `true` if the flag was present, otherwise `false`.
      */
-    bool has_flag(const std::string &flag) const { return flags_.count(flag) > 0; }
+    bool has_flag(const std::string& flag) const { return flags_.count(flag) > 0; }
 
     /**
      * @brief Retrieve the value associated with an option.
@@ -82,7 +82,7 @@ class ArgParser {
      * @param opt Option name including the leading `--`.
      * @return Stored option value or empty string if missing.
      */
-    std::string get_option(const std::string &opt) const {
+    std::string get_option(const std::string& opt) const {
         auto it = options_.find(opt);
         if (it != options_.end())
             return it->second;
@@ -90,16 +90,16 @@ class ArgParser {
     }
 
     /** @return Set of all flags found during parsing. */
-    const std::set<std::string> &flags() const { return flags_; }
+    const std::set<std::string>& flags() const { return flags_; }
 
     /** @return Map of option names to their parsed values. */
-    const std::map<std::string, std::string> &options() const { return options_; }
+    const std::map<std::string, std::string>& options() const { return options_; }
 
     /** @return Ordered list of positional arguments. */
-    const std::vector<std::string> &positional() const { return positional_; }
+    const std::vector<std::string>& positional() const { return positional_; }
 
     /** @return Flags that were not part of @a known_flags. */
-    const std::vector<std::string> &unknown_flags() const { return unknown_flags_; }
+    const std::vector<std::string>& unknown_flags() const { return unknown_flags_; }
 };
 
 #endif // ARG_PARSER_HPP

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -284,7 +284,7 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
 }
 
 #ifndef AUTOGITPULL_NO_MAIN
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     git::GitInitGuard git_guard;
     try {
         const std::set<std::string> known{

--- a/git_utils.cpp
+++ b/git_utils.cpp
@@ -7,10 +7,10 @@ using namespace std;
 
 namespace git {
 
-static int credential_cb(git_credential **out, const char *url, const char *username_from_url,
-                         unsigned int allowed_types, void *payload) {
-    const char *user = getenv("GIT_USERNAME");
-    const char *pass = getenv("GIT_PASSWORD");
+static int credential_cb(git_credential** out, const char* url, const char* username_from_url,
+                         unsigned int allowed_types, void* payload) {
+    const char* user = getenv("GIT_USERNAME");
+    const char* pass = getenv("GIT_PASSWORD");
 
     if ((allowed_types & GIT_CREDENTIAL_USERPASS_PLAINTEXT) && user && pass) {
         return git_credential_userpass_plaintext_new(out, user, pass);
@@ -22,18 +22,18 @@ GitInitGuard::GitInitGuard() { git_libgit2_init(); }
 
 GitInitGuard::~GitInitGuard() { git_libgit2_shutdown(); }
 
-bool is_git_repo(const fs::path &p) {
+bool is_git_repo(const fs::path& p) {
     return fs::exists(p / ".git") && fs::is_directory(p / ".git");
 }
 
-static string oid_to_hex(const git_oid &oid) {
+static string oid_to_hex(const git_oid& oid) {
     char buf[GIT_OID_HEXSZ + 1];
     git_oid_tostr(buf, sizeof(buf), &oid);
     return string(buf);
 }
 
-string get_local_hash(const fs::path &repo) {
-    git_repository *r = nullptr;
+string get_local_hash(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
     git_oid oid;
@@ -46,29 +46,29 @@ string get_local_hash(const fs::path &repo) {
     return hash;
 }
 
-string get_current_branch(const fs::path &repo) {
-    git_repository *r = nullptr;
+string get_current_branch(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
-    git_reference *head = nullptr;
+    git_reference* head = nullptr;
     if (git_repository_head(&head, r) != 0) {
         git_repository_free(r);
         return "";
     }
-    const char *name = git_reference_shorthand(head);
+    const char* name = git_reference_shorthand(head);
     string branch = name ? name : "";
     git_reference_free(head);
     git_repository_free(r);
     return branch;
 }
 
-string get_remote_hash(const fs::path &repo, const string &branch, bool use_credentials,
-                       bool *auth_failed) {
-    git_repository *r = nullptr;
+string get_remote_hash(const fs::path& repo, const string& branch, bool use_credentials,
+                       bool* auth_failed) {
+    git_repository* r = nullptr;
 
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         return "";
@@ -78,7 +78,7 @@ string get_remote_hash(const fs::path &repo, const string &branch, bool use_cred
         fetch_opts.callbacks.credentials = credential_cb;
     int err = git_remote_fetch(remote, nullptr, &fetch_opts, nullptr);
     if (err != 0) {
-        const git_error *e = git_error_last();
+        const git_error* e = git_error_last();
         if (auth_failed && e && e->message &&
             std::string(e->message).find("auth") != std::string::npos)
             *auth_failed = true;
@@ -95,30 +95,29 @@ string get_remote_hash(const fs::path &repo, const string &branch, bool use_cred
     return hash;
 }
 
-string get_origin_url(const fs::path &repo) {
-    git_repository *r = nullptr;
+string get_origin_url(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         return "";
     }
-    const char *url = git_remote_url(remote);
+    const char* url = git_remote_url(remote);
     string result = url ? url : "";
     git_remote_free(remote);
     git_repository_free(r);
     return result;
 }
 
-bool is_github_url(const string &url) { return url.find("github.com") != string::npos; }
+bool is_github_url(const string& url) { return url.find("github.com") != string::npos; }
 
-
-bool remote_accessible(const fs::path &repo) {
-    git_repository *r = nullptr;
+bool remote_accessible(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return false;
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         return false;
@@ -132,9 +131,8 @@ bool remote_accessible(const fs::path &repo) {
     return ok;
 }
 
-int try_pull(const fs::path &repo, string &out_pull_log,
-             const std::function<void(int)> *progress_cb, bool use_credentials, bool *auth_failed) {
-
+int try_pull(const fs::path& repo, string& out_pull_log,
+             const std::function<void(int)>* progress_cb, bool use_credentials, bool* auth_failed) {
 
     if (progress_cb)
         (*progress_cb)(0);
@@ -142,8 +140,8 @@ int try_pull(const fs::path &repo, string &out_pull_log,
         if (progress_cb)
             (*progress_cb)(100);
     };
-  
-    git_repository *r = nullptr;
+
+    git_repository* r = nullptr;
 
     if (git_repository_open(&r, repo.string().c_str()) != 0) {
         out_pull_log = "Failed to open repository";
@@ -151,7 +149,7 @@ int try_pull(const fs::path &repo, string &out_pull_log,
         return 2;
     }
     string branch = get_current_branch(repo);
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         out_pull_log = "No origin remote";
@@ -161,11 +159,11 @@ int try_pull(const fs::path &repo, string &out_pull_log,
     git_fetch_options fetch_opts = GIT_FETCH_OPTIONS_INIT;
     git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
     if (progress_cb) {
-        callbacks.payload = const_cast<std::function<void(int)> *>(progress_cb);
-        callbacks.transfer_progress = [](const git_transfer_progress *stats, void *payload) -> int {
+        callbacks.payload = const_cast<std::function<void(int)>*>(progress_cb);
+        callbacks.transfer_progress = [](const git_transfer_progress* stats, void* payload) -> int {
             if (!payload)
                 return 0;
-            auto cb = static_cast<std::function<void(int)> *>(payload);
+            auto cb = static_cast<std::function<void(int)>*>(payload);
 
             int pct = 0;
             if (stats->total_objects > 0) {
@@ -180,7 +178,7 @@ int try_pull(const fs::path &repo, string &out_pull_log,
     fetch_opts.callbacks = callbacks;
     int err = git_remote_fetch(remote, nullptr, &fetch_opts, nullptr);
     if (err != 0) {
-        const git_error *e = git_error_last();
+        const git_error* e = git_error_last();
         if (auth_failed && e && e->message &&
             std::string(e->message).find("auth") != std::string::npos)
             *auth_failed = true;
@@ -214,7 +212,7 @@ int try_pull(const fs::path &repo, string &out_pull_log,
         finalize();
         return 0;
     }
-    git_object *target = nullptr;
+    git_object* target = nullptr;
     if (git_object_lookup(&target, r, &remote_oid, GIT_OBJECT_COMMIT) != 0) {
         git_remote_free(remote);
         git_repository_free(r);

--- a/git_utils.hpp
+++ b/git_utils.hpp
@@ -27,7 +27,7 @@ struct GitInitGuard {
  * @param p Filesystem path to check.
  * @return `true` if a `.git` directory exists inside @a p.
  */
-bool is_git_repo(const fs::path &p);
+bool is_git_repo(const fs::path& p);
 
 /**
  * @brief Get the commit hash pointed to by `HEAD`.
@@ -35,7 +35,7 @@ bool is_git_repo(const fs::path &p);
  * @param repo Path to a Git repository.
  * @return 40 character hexadecimal commit hash, or empty string on error.
  */
-std::string get_local_hash(const fs::path &repo);
+std::string get_local_hash(const fs::path& repo);
 
 /**
  * @brief Retrieve the currently checked out branch name.
@@ -43,7 +43,7 @@ std::string get_local_hash(const fs::path &repo);
  * @param repo Path to a Git repository.
  * @return Branch name or empty string if it cannot be determined.
  */
-std::string get_current_branch(const fs::path &repo);
+std::string get_current_branch(const fs::path& repo);
 
 /**
  * @brief Fetch `origin` and return the hash of the specified remote branch.
@@ -56,8 +56,8 @@ std::string get_current_branch(const fs::path &repo);
  *                        fails.
  * @return Commit hash of the remote branch, or empty string on failure.
  */
-std::string get_remote_hash(const fs::path &repo, const std::string &branch,
-                            bool use_credentials = false, bool *auth_failed = nullptr);
+std::string get_remote_hash(const fs::path& repo, const std::string& branch,
+                            bool use_credentials = false, bool* auth_failed = nullptr);
 
 /**
  * @brief Obtain the URL of the `origin` remote.
@@ -65,7 +65,7 @@ std::string get_remote_hash(const fs::path &repo, const std::string &branch,
  * @param repo Path to a Git repository.
  * @return Remote URL as a string, or empty string on failure.
  */
-std::string get_origin_url(const fs::path &repo);
+std::string get_origin_url(const fs::path& repo);
 
 /**
  * @brief Check if a URL points to GitHub.
@@ -73,7 +73,7 @@ std::string get_origin_url(const fs::path &repo);
  * @param url Remote URL string.
  * @return `true` if the URL contains `github.com`.
  */
-bool is_github_url(const std::string &url);
+bool is_github_url(const std::string& url);
 
 /**
  * @brief Attempt to connect to the `origin` remote.
@@ -81,7 +81,7 @@ bool is_github_url(const std::string &url);
  * @param repo Path to a Git repository.
  * @return `true` if the remote can be contacted.
  */
-bool remote_accessible(const fs::path &repo);
+bool remote_accessible(const fs::path& repo);
 
 /**
  * @brief Perform a fast-forward pull from the `origin` remote.
@@ -98,9 +98,9 @@ bool remote_accessible(const fs::path &repo);
  * @param auth_failed    Optional output flag set when authentication fails.
  * @return `0` on success or when already up to date, `2` on failure.
  */
-int try_pull(const fs::path &repo, std::string &out_pull_log,
-             const std::function<void(int)> *progress_cb = nullptr, bool use_credentials = false,
-             bool *auth_failed = nullptr);
+int try_pull(const fs::path& repo, std::string& out_pull_log,
+             const std::function<void(int)>* progress_cb = nullptr, bool use_credentials = false,
+             bool* auth_failed = nullptr);
 
 } // namespace git
 


### PR DESCRIPTION
## Summary
- run clang-format on C++ sources so `make lint` passes
- clarify AGENTS.md instructions to mention Prettier

## Testing
- `npm run format`
- `make lint`
- `make test` *(fails: libgit2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d22835ec8325aa4f5beb583e52c9