### PR TITLE
Add leak test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ make test
 This command generates a `build` directory (if missing), compiles the tests and
 executes them through CMake's `ctest` driver.
 
+### Leak test
+
+To run the memory leak regression test you need both the `valgrind` tool and the
+`libgit2-dev` package installed. After building the tests with `make test`, run:
+
+```bash
+valgrind ./build/memory_leak_test
+```
+
+Valgrind should finish with the message `All heap blocks were freed -- no leaks
+are possible`.
+
 Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--log-file <path>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <n>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--help]`
 
 Available options:

--- a/arg_parser.hpp
+++ b/arg_parser.hpp
@@ -29,7 +29,7 @@ class ArgParser {
      * @param known_flags Optional set of flags that are considered valid. If
      *        empty, all flags are treated as known.
      */
-    ArgParser(int argc, char *argv[], const std::set<std::string> &known_flags = {})
+    ArgParser(int argc, char* argv[], const std::set<std::string>& known_flags = {})
         : known_flags_(known_flags) {
         for (int i = 1; i < argc; ++i) {
             std::string arg = argv[i];
@@ -72,7 +72,7 @@ class ArgParser {
      * @param flag Flag name including the leading `--`.
      * @return `true` if the flag was present, otherwise `false`.
      */
-    bool has_flag(const std::string &flag) const { return flags_.count(flag) > 0; }
+    bool has_flag(const std::string& flag) const { return flags_.count(flag) > 0; }
 
     /**
      * @brief Retrieve the value associated with an option.
@@ -82,7 +82,7 @@ class ArgParser {
      * @param opt Option name including the leading `--`.
      * @return Stored option value or empty string if missing.
      */
-    std::string get_option(const std::string &opt) const {
+    std::string get_option(const std::string& opt) const {
         auto it = options_.find(opt);
         if (it != options_.end())
             return it->second;
@@ -90,16 +90,16 @@ class ArgParser {
     }
 
     /** @return Set of all flags found during parsing. */
-    const std::set<std::string> &flags() const { return flags_; }
+    const std::set<std::string>& flags() const { return flags_; }
 
     /** @return Map of option names to their parsed values. */
-    const std::map<std::string, std::string> &options() const { return options_; }
+    const std::map<std::string, std::string>& options() const { return options_; }
 
     /** @return Ordered list of positional arguments. */
-    const std::vector<std::string> &positional() const { return positional_; }
+    const std::vector<std::string>& positional() const { return positional_; }
 
     /** @return Flags that were not part of @a known_flags. */
-    const std::vector<std::string> &unknown_flags() const { return unknown_flags_; }
+    const std::vector<std::string>& unknown_flags() const { return unknown_flags_; }
 };
 
 #endif // ARG_PARSER_HPP

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -284,7 +284,7 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
 }
 
 #ifndef AUTOGITPULL_NO_MAIN
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     git::GitInitGuard git_guard;
     try {
         const std::set<std::string> known{

--- a/git_utils.cpp
+++ b/git_utils.cpp
@@ -7,10 +7,10 @@ using namespace std;
 
 namespace git {
 
-static int credential_cb(git_credential **out, const char *url, const char *username_from_url,
-                         unsigned int allowed_types, void *payload) {
-    const char *user = getenv("GIT_USERNAME");
-    const char *pass = getenv("GIT_PASSWORD");
+static int credential_cb(git_credential** out, const char* url, const char* username_from_url,
+                         unsigned int allowed_types, void* payload) {
+    const char* user = getenv("GIT_USERNAME");
+    const char* pass = getenv("GIT_PASSWORD");
 
     if ((allowed_types & GIT_CREDENTIAL_USERPASS_PLAINTEXT) && user && pass) {
         return git_credential_userpass_plaintext_new(out, user, pass);
@@ -22,18 +22,18 @@ GitInitGuard::GitInitGuard() { git_libgit2_init(); }
 
 GitInitGuard::~GitInitGuard() { git_libgit2_shutdown(); }
 
-bool is_git_repo(const fs::path &p) {
+bool is_git_repo(const fs::path& p) {
     return fs::exists(p / ".git") && fs::is_directory(p / ".git");
 }
 
-static string oid_to_hex(const git_oid &oid) {
+static string oid_to_hex(const git_oid& oid) {
     char buf[GIT_OID_HEXSZ + 1];
     git_oid_tostr(buf, sizeof(buf), &oid);
     return string(buf);
 }
 
-string get_local_hash(const fs::path &repo) {
-    git_repository *r = nullptr;
+string get_local_hash(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
     git_oid oid;
@@ -46,29 +46,29 @@ string get_local_hash(const fs::path &repo) {
     return hash;
 }
 
-string get_current_branch(const fs::path &repo) {
-    git_repository *r = nullptr;
+string get_current_branch(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
-    git_reference *head = nullptr;
+    git_reference* head = nullptr;
     if (git_repository_head(&head, r) != 0) {
         git_repository_free(r);
         return "";
     }
-    const char *name = git_reference_shorthand(head);
+    const char* name = git_reference_shorthand(head);
     string branch = name ? name : "";
     git_reference_free(head);
     git_repository_free(r);
     return branch;
 }
 
-string get_remote_hash(const fs::path &repo, const string &branch, bool use_credentials,
-                       bool *auth_failed) {
-    git_repository *r = nullptr;
+string get_remote_hash(const fs::path& repo, const string& branch, bool use_credentials,
+                       bool* auth_failed) {
+    git_repository* r = nullptr;
 
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         return "";
@@ -78,7 +78,7 @@ string get_remote_hash(const fs::path &repo, const string &branch, bool use_cred
         fetch_opts.callbacks.credentials = credential_cb;
     int err = git_remote_fetch(remote, nullptr, &fetch_opts, nullptr);
     if (err != 0) {
-        const git_error *e = git_error_last();
+        const git_error* e = git_error_last();
         if (auth_failed && e && e->message &&
             std::string(e->message).find("auth") != std::string::npos)
             *auth_failed = true;
@@ -95,30 +95,29 @@ string get_remote_hash(const fs::path &repo, const string &branch, bool use_cred
     return hash;
 }
 
-string get_origin_url(const fs::path &repo) {
-    git_repository *r = nullptr;
+string get_origin_url(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         return "";
     }
-    const char *url = git_remote_url(remote);
+    const char* url = git_remote_url(remote);
     string result = url ? url : "";
     git_remote_free(remote);
     git_repository_free(r);
     return result;
 }
 
-bool is_github_url(const string &url) { return url.find("github.com") != string::npos; }
+bool is_github_url(const string& url) { return url.find("github.com") != string::npos; }
 
-
-bool remote_accessible(const fs::path &repo) {
-    git_repository *r = nullptr;
+bool remote_accessible(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return false;
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         return false;
@@ -132,9 +131,8 @@ bool remote_accessible(const fs::path &repo) {
     return ok;
 }
 
-int try_pull(const fs::path &repo, string &out_pull_log,
-             const std::function<void(int)> *progress_cb, bool use_credentials, bool *auth_failed) {
-
+int try_pull(const fs::path& repo, string& out_pull_log,
+             const std::function<void(int)>* progress_cb, bool use_credentials, bool* auth_failed) {
 
     if (progress_cb)
         (*progress_cb)(0);
@@ -142,8 +140,8 @@ int try_pull(const fs::path &repo, string &out_pull_log,
         if (progress_cb)
             (*progress_cb)(100);
     };
-  
-    git_repository *r = nullptr;
+
+    git_repository* r = nullptr;
 
     if (git_repository_open(&r, repo.string().c_str()) != 0) {
         out_pull_log = "Failed to open repository";
@@ -151,7 +149,7 @@ int try_pull(const fs::path &repo, string &out_pull_log,
         return 2;
     }
     string branch = get_current_branch(repo);
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         out_pull_log = "No origin remote";
@@ -161,11 +159,11 @@ int try_pull(const fs::path &repo, string &out_pull_log,
     git_fetch_options fetch_opts = GIT_FETCH_OPTIONS_INIT;
     git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
     if (progress_cb) {
-        callbacks.payload = const_cast<std::function<void(int)> *>(progress_cb);
-        callbacks.transfer_progress = [](const git_transfer_progress *stats, void *payload) -> int {
+        callbacks.payload = const_cast<std::function<void(int)>*>(progress_cb);
+        callbacks.transfer_progress = [](const git_transfer_progress* stats, void* payload) -> int {
             if (!payload)
                 return 0;
-            auto cb = static_cast<std::function<void(int)> *>(payload);
+            auto cb = static_cast<std::function<void(int)>*>(payload);
 
             int pct = 0;
             if (stats->total_objects > 0) {
@@ -180,7 +178,7 @@ int try_pull(const fs::path &repo, string &out_pull_log,
     fetch_opts.callbacks = callbacks;
     int err = git_remote_fetch(remote, nullptr, &fetch_opts, nullptr);
     if (err != 0) {
-        const git_error *e = git_error_last();
+        const git_error* e = git_error_last();
         if (auth_failed && e && e->message &&
             std::string(e->message).find("auth") != std::string::npos)
             *auth_failed = true;
@@ -214,7 +212,7 @@ int try_pull(const fs::path &repo, string &out_pull_log,
         finalize();
         return 0;
     }
-    git_object *target = nullptr;
+    git_object* target = nullptr;
     if (git_object_lookup(&target, r, &remote_oid, GIT_OBJECT_COMMIT) != 0) {
         git_remote_free(remote);
         git_repository_free(r);

--- a/git_utils.hpp
+++ b/git_utils.hpp
@@ -27,7 +27,7 @@ struct GitInitGuard {
  * @param p Filesystem path to check.
  * @return `true` if a `.git` directory exists inside @a p.
  */
-bool is_git_repo(const fs::path &p);
+bool is_git_repo(const fs::path& p);
 
 /**
  * @brief Get the commit hash pointed to by `HEAD`.
@@ -35,7 +35,7 @@ bool is_git_repo(const fs::path &p);
  * @param repo Path to a Git repository.
  * @return 40 character hexadecimal commit hash, or empty string on error.
  */
-std::string get_local_hash(const fs::path &repo);
+std::string get_local_hash(const fs::path& repo);
 
 /**
  * @brief Retrieve the currently checked out branch name.
@@ -43,7 +43,7 @@ std::string get_local_hash(const fs::path &repo);
  * @param repo Path to a Git repository.
  * @return Branch name or empty string if it cannot be determined.
  */
-std::string get_current_branch(const fs::path &repo);
+std::string get_current_branch(const fs::path& repo);
 
 /**
  * @brief Fetch `origin` and return the hash of the specified remote branch.
@@ -56,8 +56,8 @@ std::string get_current_branch(const fs::path &repo);
  *                        fails.
  * @return Commit hash of the remote branch, or empty string on failure.
  */
-std::string get_remote_hash(const fs::path &repo, const std::string &branch,
-                            bool use_credentials = false, bool *auth_failed = nullptr);
+std::string get_remote_hash(const fs::path& repo, const std::string& branch,
+                            bool use_credentials = false, bool* auth_failed = nullptr);
 
 /**
  * @brief Obtain the URL of the `origin` remote.
@@ -65,7 +65,7 @@ std::string get_remote_hash(const fs::path &repo, const std::string &branch,
  * @param repo Path to a Git repository.
  * @return Remote URL as a string, or empty string on failure.
  */
-std::string get_origin_url(const fs::path &repo);
+std::string get_origin_url(const fs::path& repo);
 
 /**
  * @brief Check if a URL points to GitHub.
@@ -73,7 +73,7 @@ std::string get_origin_url(const fs::path &repo);
  * @param url Remote URL string.
  * @return `true` if the URL contains `github.com`.
  */
-bool is_github_url(const std::string &url);
+bool is_github_url(const std::string& url);
 
 /**
  * @brief Attempt to connect to the `origin` remote.
@@ -81,7 +81,7 @@ bool is_github_url(const std::string &url);
  * @param repo Path to a Git repository.
  * @return `true` if the remote can be contacted.
  */
-bool remote_accessible(const fs::path &repo);
+bool remote_accessible(const fs::path& repo);
 
 /**
  * @brief Perform a fast-forward pull from the `origin` remote.
@@ -98,9 +98,9 @@ bool remote_accessible(const fs::path &repo);
  * @param auth_failed    Optional output flag set when authentication fails.
  * @return `0` on success or when already up to date, `2` on failure.
  */
-int try_pull(const fs::path &repo, std::string &out_pull_log,
-             const std::function<void(int)> *progress_cb = nullptr, bool use_credentials = false,
-             bool *auth_failed = nullptr);
+int try_pull(const fs::path& repo, std::string& out_pull_log,
+             const std::function<void(int)>* progress_cb = nullptr, bool use_credentials = false,
+             bool* auth_failed = nullptr);
 
 } // namespace git
 

--- a/tests/memory_leak.cpp
+++ b/tests/memory_leak.cpp
@@ -12,10 +12,10 @@
 
 namespace fs = std::filesystem;
 
-void scan_repos(const std::vector<fs::path> &all_repos, std::map<fs::path, RepoInfo> &repo_infos,
-                std::set<fs::path> &skip_repos, std::mutex &mtx, std::atomic<bool> &scanning_flag,
-                std::atomic<bool> &running, std::string &action, std::mutex &action_mtx,
-                bool include_private, const fs::path &log_dir, bool check_only, bool hash_check,
+void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoInfo>& repo_infos,
+                std::set<fs::path>& skip_repos, std::mutex& mtx, std::atomic<bool>& scanning_flag,
+                std::atomic<bool>& running, std::string& action, std::mutex& action_mtx,
+                bool include_private, const fs::path& log_dir, bool check_only, bool hash_check,
                 size_t concurrency, int cpu_percent_limit, size_t mem_limit);
 
 TEST_CASE("scan_repos memory stability") {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -12,8 +12,8 @@
 namespace fs = std::filesystem;
 
 TEST_CASE("ArgParser basic parsing") {
-    const char *argv[] = {"prog", "--foo", "--opt", "42", "pos", "--unknown"};
-    ArgParser parser(6, const_cast<char **>(argv), {"--foo", "--bar", "--opt"});
+    const char* argv[] = {"prog", "--foo", "--opt", "42", "pos", "--unknown"};
+    ArgParser parser(6, const_cast<char**>(argv), {"--foo", "--bar", "--opt"});
     REQUIRE(parser.has_flag("--foo"));
     REQUIRE(parser.get_option("--opt") == "42");
     REQUIRE(parser.positional().size() == 1);
@@ -23,15 +23,15 @@ TEST_CASE("ArgParser basic parsing") {
 }
 
 TEST_CASE("ArgParser option with equals") {
-    const char *argv[] = {"prog", "--opt=val"};
-    ArgParser parser(2, const_cast<char **>(argv), {"--opt"});
+    const char* argv[] = {"prog", "--opt=val"};
+    ArgParser parser(2, const_cast<char**>(argv), {"--opt"});
     REQUIRE(parser.has_flag("--opt"));
     REQUIRE(parser.get_option("--opt") == "val");
 }
 
 TEST_CASE("ArgParser unknown flag detection") {
-    const char *argv[] = {"prog", "--foo"};
-    ArgParser parser(2, const_cast<char **>(argv), {"--bar"});
+    const char* argv[] = {"prog", "--foo"};
+    ArgParser parser(2, const_cast<char**>(argv), {"--bar"});
     REQUIRE(parser.has_flag("--foo") == false);
     REQUIRE(parser.unknown_flags().size() == 1);
     REQUIRE(parser.unknown_flags()[0] == "--foo");
@@ -73,16 +73,16 @@ TEST_CASE("RepoInfo defaults") {
 }
 
 TEST_CASE("ArgParser log level flags") {
-    const char *argv[] = {"prog", "--log-level", "DEBUG", "--verbose"};
-    ArgParser parser(4, const_cast<char **>(argv), {"--log-level", "--verbose"});
+    const char* argv[] = {"prog", "--log-level", "DEBUG", "--verbose"};
+    ArgParser parser(4, const_cast<char**>(argv), {"--log-level", "--verbose"});
     REQUIRE(parser.has_flag("--log-level"));
     REQUIRE(parser.get_option("--log-level") == "DEBUG");
     REQUIRE(parser.has_flag("--verbose"));
 }
 
 TEST_CASE("ArgParser log file option") {
-    const char *argv[] = {"prog", "--log-file", "my.log", "path"};
-    ArgParser parser(4, const_cast<char **>(argv), {"--log-file"});
+    const char* argv[] = {"prog", "--log-file", "my.log", "path"};
+    ArgParser parser(4, const_cast<char**>(argv), {"--log-file"});
     REQUIRE(parser.has_flag("--log-file"));
     REQUIRE(parser.get_option("--log-file") == "my.log");
     REQUIRE(parser.positional().size() == 1);
@@ -90,9 +90,9 @@ TEST_CASE("ArgParser log file option") {
 }
 
 TEST_CASE("ArgParser resource flags") {
-    const char *argv[] = {"prog", "--max-threads", "4",   "--cpu-percent", "50", "--cpu-cores",
+    const char* argv[] = {"prog", "--max-threads", "4",   "--cpu-percent", "50", "--cpu-cores",
                           "2",    "--mem-limit",   "100", "path"};
-    ArgParser parser(10, const_cast<char **>(argv),
+    ArgParser parser(10, const_cast<char**>(argv),
                      {"--max-threads", "--cpu-percent", "--cpu-cores", "--mem-limit"});
     REQUIRE(parser.get_option("--max-threads") == std::string("4"));
     REQUIRE(parser.get_option("--cpu-percent") == std::string("50"));
@@ -145,13 +145,13 @@ TEST_CASE("Logger appends messages") {
 }
 
 TEST_CASE("--log-file without value creates file") {
-    const char *argv[] = {"prog", "--log-file"};
-    ArgParser parser(2, const_cast<char **>(argv), {"--log-file"});
+    const char* argv[] = {"prog", "--log-file"};
+    ArgParser parser(2, const_cast<char**>(argv), {"--log-file"});
     REQUIRE(parser.has_flag("--log-file"));
     REQUIRE(parser.get_option("--log-file").empty());
 
     std::string ts = timestamp();
-    for (char &ch : ts) {
+    for (char& ch : ts) {
         if (ch == ' ' || ch == ':')
             ch = '_';
         else if (ch == '/')
@@ -168,8 +168,8 @@ TEST_CASE("--log-file without value creates file") {
 }
 
 TEST_CASE("ArgParser threads flags") {
-    const char *argv[] = {"prog", "--threads", "8", "--single-thread"};
-    ArgParser parser(4, const_cast<char **>(argv), {"--threads", "--single-thread"});
+    const char* argv[] = {"prog", "--threads", "8", "--single-thread"};
+    ArgParser parser(4, const_cast<char**>(argv), {"--threads", "--single-thread"});
     REQUIRE(parser.has_flag("--threads"));
     REQUIRE(parser.get_option("--threads") == std::string("8"));
     REQUIRE(parser.has_flag("--single-thread"));


### PR DESCRIPTION
## Summary
- add documentation for running the leak regression test
- apply clang-format to satisfy style checks

## Testing
- `make lint`
- `npm run format`
- `make test`
- `valgrind ./build/memory_leak_test`

------
https://chatgpt.com/codex/tasks/task_e_6877d1bcdbac8325ada4bee58f87a686