### PR TITLE
Add network throttling options

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -43,7 +43,8 @@ void handle_signal(int) {
 void process_repo(const fs::path& p, std::map<fs::path, RepoInfo>& repo_infos,
                   std::set<fs::path>& skip_repos, std::mutex& mtx, std::atomic<bool>& running,
                   std::string& action, std::mutex& action_mtx, bool include_private,
-                  const fs::path& log_dir, bool check_only, bool hash_check) {
+                  const fs::path& log_dir, bool check_only, bool hash_check, size_t down_limit,
+                  size_t up_limit) {
     if (!running)
         return;
     if (logger_initialized())
@@ -166,7 +167,7 @@ void process_repo(const fs::path& p, std::map<fs::path, RepoInfo>& repo_infos,
                         };
                         bool pull_auth_fail = false;
                         int code = git::try_pull(p, pull_log, &progress_cb, include_private,
-                                                 &pull_auth_fail);
+                                                 &pull_auth_fail, down_limit, up_limit);
                         ri.auth_failed = pull_auth_fail;
                         ri.last_pull_log = pull_log;
                         fs::path log_file_path;
@@ -236,7 +237,8 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
                 std::set<fs::path>& skip_repos, std::mutex& mtx, std::atomic<bool>& scanning_flag,
                 std::atomic<bool>& running, std::string& action, std::mutex& action_mtx,
                 bool include_private, const fs::path& log_dir, bool check_only, bool hash_check,
-                size_t concurrency, int cpu_percent_limit, size_t mem_limit) {
+                size_t concurrency, int cpu_percent_limit, size_t mem_limit, size_t down_limit,
+                size_t up_limit) {
     if (concurrency == 0)
         concurrency = 1;
     concurrency = std::min(concurrency, all_repos.size());
@@ -251,7 +253,7 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
                 break;
             const auto& p = all_repos[idx];
             process_repo(p, repo_infos, skip_repos, mtx, running, action, action_mtx,
-                         include_private, log_dir, check_only, hash_check);
+                         include_private, log_dir, check_only, hash_check, down_limit, up_limit);
             if (mem_limit > 0 && procutil::get_memory_usage_mb() > mem_limit) {
                 log_error("Memory limit exceeded");
                 running = false;
@@ -284,7 +286,7 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
 }
 
 #ifndef AUTOGITPULL_NO_MAIN
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     git::GitInitGuard git_guard;
     try {
         const std::set<std::string> known{
@@ -293,7 +295,8 @@ int main(int argc, char *argv[]) {
             "--check-only",      "--no-hash-check",  "--log-level",         "--verbose",
             "--max-threads",     "--cpu-percent",    "--cpu-cores",         "--mem-limit",
             "--no-cpu-tracker",  "--no-mem-tracker", "--no-thread-tracker", "--help",
-            "--threads",         "--single-thread",  "--net-tracker"};
+            "--threads",         "--single-thread",  "--net-tracker",       "--download-limit",
+            "--upload-limit"};
         ArgParser parser(argc, argv, known);
 
         if (parser.has_flag("--help")) {
@@ -307,7 +310,8 @@ int main(int argc, char *argv[]) {
                 << " [--cpu-percent <n>] [--cpu-cores <n>]"
                 << " [--mem-limit <MB>] [--check-only] [--no-hash-check]"
                 << " [--no-cpu-tracker] [--no-mem-tracker]"
-                << " [--no-thread-tracker] [--net-tracker] [--help]\n";
+                << " [--no-thread-tracker] [--net-tracker]"
+                << " [--download-limit <KB/s>] [--upload-limit <KB/s>] [--help]\n";
             return 0;
         }
 
@@ -322,7 +326,8 @@ int main(int argc, char *argv[]) {
                 << " [--cpu-percent <n>] [--cpu-cores <n>]"
                 << " [--mem-limit <MB>] [--check-only] [--no-hash-check]"
                 << " [--no-cpu-tracker] [--no-mem-tracker]"
-                << " [--no-thread-tracker] [--net-tracker] [--help]\n";
+                << " [--no-thread-tracker] [--net-tracker]"
+                << " [--download-limit <KB/s>] [--upload-limit <KB/s>] [--help]\n";
             return 1;
         }
 
@@ -369,6 +374,8 @@ int main(int argc, char *argv[]) {
         int cpu_percent_limit = 0;
         int cpu_cores = 0;
         size_t mem_limit = 0;
+        size_t down_limit = 0;
+        size_t up_limit = 0;
         bool cpu_tracker = true;
         bool mem_tracker = true;
         bool thread_tracker = true;
@@ -492,6 +499,32 @@ int main(int argc, char *argv[]) {
                 return 1;
             }
         }
+        if (parser.has_flag("--download-limit")) {
+            std::string val = parser.get_option("--download-limit");
+            if (val.empty()) {
+                std::cerr << "--download-limit requires a numeric value\n";
+                return 1;
+            }
+            try {
+                down_limit = static_cast<size_t>(std::stoul(val));
+            } catch (...) {
+                std::cerr << "Invalid value for --download-limit: " << val << "\n";
+                return 1;
+            }
+        }
+        if (parser.has_flag("--upload-limit")) {
+            std::string val = parser.get_option("--upload-limit");
+            if (val.empty()) {
+                std::cerr << "--upload-limit requires a numeric value\n";
+                return 1;
+            }
+            try {
+                up_limit = static_cast<size_t>(std::stoul(val));
+            } catch (...) {
+                std::cerr << "Invalid value for --upload-limit: " << val << "\n";
+                return 1;
+            }
+        }
         cpu_tracker = !parser.has_flag("--no-cpu-tracker");
         mem_tracker = !parser.has_flag("--no-mem-tracker");
         thread_tracker = !parser.has_flag("--no-thread-tracker");
@@ -600,7 +633,7 @@ int main(int argc, char *argv[]) {
                     scan_repos, std::cref(all_repos), std::ref(repo_infos), std::ref(skip_repos),
                     std::ref(mtx), std::ref(scanning), std::ref(running), std::ref(current_action),
                     std::ref(action_mtx), include_private, std::cref(log_dir), check_only,
-                    hash_check, concurrency, cpu_percent_limit, mem_limit);
+                    hash_check, concurrency, cpu_percent_limit, mem_limit, down_limit, up_limit);
                 countdown_ms = std::chrono::seconds(interval);
             }
             {

--- a/git_utils.cpp
+++ b/git_utils.cpp
@@ -2,15 +2,24 @@
 #include <git2.h>
 #include <functional>
 #include <cstdlib>
+#include <chrono>
+#include <thread>
 
 using namespace std;
 
 namespace git {
 
-static int credential_cb(git_credential **out, const char *url, const char *username_from_url,
-                         unsigned int allowed_types, void *payload) {
-    const char *user = getenv("GIT_USERNAME");
-    const char *pass = getenv("GIT_PASSWORD");
+struct ProgressData {
+    const std::function<void(int)>* cb;
+    std::chrono::steady_clock::time_point start;
+    size_t down_limit;
+    size_t up_limit;
+};
+
+static int credential_cb(git_credential** out, const char* url, const char* username_from_url,
+                         unsigned int allowed_types, void* payload) {
+    const char* user = getenv("GIT_USERNAME");
+    const char* pass = getenv("GIT_PASSWORD");
 
     if ((allowed_types & GIT_CREDENTIAL_USERPASS_PLAINTEXT) && user && pass) {
         return git_credential_userpass_plaintext_new(out, user, pass);
@@ -22,18 +31,18 @@ GitInitGuard::GitInitGuard() { git_libgit2_init(); }
 
 GitInitGuard::~GitInitGuard() { git_libgit2_shutdown(); }
 
-bool is_git_repo(const fs::path &p) {
+bool is_git_repo(const fs::path& p) {
     return fs::exists(p / ".git") && fs::is_directory(p / ".git");
 }
 
-static string oid_to_hex(const git_oid &oid) {
+static string oid_to_hex(const git_oid& oid) {
     char buf[GIT_OID_HEXSZ + 1];
     git_oid_tostr(buf, sizeof(buf), &oid);
     return string(buf);
 }
 
-string get_local_hash(const fs::path &repo) {
-    git_repository *r = nullptr;
+string get_local_hash(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
     git_oid oid;
@@ -46,29 +55,29 @@ string get_local_hash(const fs::path &repo) {
     return hash;
 }
 
-string get_current_branch(const fs::path &repo) {
-    git_repository *r = nullptr;
+string get_current_branch(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
-    git_reference *head = nullptr;
+    git_reference* head = nullptr;
     if (git_repository_head(&head, r) != 0) {
         git_repository_free(r);
         return "";
     }
-    const char *name = git_reference_shorthand(head);
+    const char* name = git_reference_shorthand(head);
     string branch = name ? name : "";
     git_reference_free(head);
     git_repository_free(r);
     return branch;
 }
 
-string get_remote_hash(const fs::path &repo, const string &branch, bool use_credentials,
-                       bool *auth_failed) {
-    git_repository *r = nullptr;
+string get_remote_hash(const fs::path& repo, const string& branch, bool use_credentials,
+                       bool* auth_failed) {
+    git_repository* r = nullptr;
 
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         return "";
@@ -78,7 +87,7 @@ string get_remote_hash(const fs::path &repo, const string &branch, bool use_cred
         fetch_opts.callbacks.credentials = credential_cb;
     int err = git_remote_fetch(remote, nullptr, &fetch_opts, nullptr);
     if (err != 0) {
-        const git_error *e = git_error_last();
+        const git_error* e = git_error_last();
         if (auth_failed && e && e->message &&
             std::string(e->message).find("auth") != std::string::npos)
             *auth_failed = true;
@@ -95,30 +104,29 @@ string get_remote_hash(const fs::path &repo, const string &branch, bool use_cred
     return hash;
 }
 
-string get_origin_url(const fs::path &repo) {
-    git_repository *r = nullptr;
+string get_origin_url(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return "";
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         return "";
     }
-    const char *url = git_remote_url(remote);
+    const char* url = git_remote_url(remote);
     string result = url ? url : "";
     git_remote_free(remote);
     git_repository_free(r);
     return result;
 }
 
-bool is_github_url(const string &url) { return url.find("github.com") != string::npos; }
+bool is_github_url(const string& url) { return url.find("github.com") != string::npos; }
 
-
-bool remote_accessible(const fs::path &repo) {
-    git_repository *r = nullptr;
+bool remote_accessible(const fs::path& repo) {
+    git_repository* r = nullptr;
     if (git_repository_open(&r, repo.string().c_str()) != 0)
         return false;
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         return false;
@@ -132,9 +140,9 @@ bool remote_accessible(const fs::path &repo) {
     return ok;
 }
 
-int try_pull(const fs::path &repo, string &out_pull_log,
-             const std::function<void(int)> *progress_cb, bool use_credentials, bool *auth_failed) {
-
+int try_pull(const fs::path& repo, string& out_pull_log,
+             const std::function<void(int)>* progress_cb, bool use_credentials, bool* auth_failed,
+             size_t down_limit_kbps, size_t up_limit_kbps) {
 
     if (progress_cb)
         (*progress_cb)(0);
@@ -142,8 +150,8 @@ int try_pull(const fs::path &repo, string &out_pull_log,
         if (progress_cb)
             (*progress_cb)(100);
     };
-  
-    git_repository *r = nullptr;
+
+    git_repository* r = nullptr;
 
     if (git_repository_open(&r, repo.string().c_str()) != 0) {
         out_pull_log = "Failed to open repository";
@@ -151,7 +159,7 @@ int try_pull(const fs::path &repo, string &out_pull_log,
         return 2;
     }
     string branch = get_current_branch(repo);
-    git_remote *remote = nullptr;
+    git_remote* remote = nullptr;
     if (git_remote_lookup(&remote, r, "origin") != 0) {
         git_repository_free(r);
         out_pull_log = "No origin remote";
@@ -160,18 +168,38 @@ int try_pull(const fs::path &repo, string &out_pull_log,
     }
     git_fetch_options fetch_opts = GIT_FETCH_OPTIONS_INIT;
     git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
-    if (progress_cb) {
-        callbacks.payload = const_cast<std::function<void(int)> *>(progress_cb);
-        callbacks.transfer_progress = [](const git_transfer_progress *stats, void *payload) -> int {
+    ProgressData progress{progress_cb, std::chrono::steady_clock::now(), down_limit_kbps,
+                          up_limit_kbps};
+    if (progress_cb || down_limit_kbps > 0 || up_limit_kbps > 0) {
+        callbacks.payload = &progress;
+        callbacks.transfer_progress = [](const git_transfer_progress* stats, void* payload) -> int {
             if (!payload)
                 return 0;
-            auto cb = static_cast<std::function<void(int)> *>(payload);
-
-            int pct = 0;
-            if (stats->total_objects > 0) {
-                pct = static_cast<int>(100 * stats->received_objects / stats->total_objects);
+            auto* pd = static_cast<ProgressData*>(payload);
+            if (pd->cb) {
+                int pct = 0;
+                if (stats->total_objects > 0)
+                    pct = static_cast<int>(100 * stats->received_objects / stats->total_objects);
+                (*pd->cb)(pct);
             }
-            (*cb)(pct);
+            double expected_ms = 0.0;
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::steady_clock::now() - pd->start)
+                               .count();
+            if (pd->down_limit > 0) {
+                double ms = (double)stats->received_bytes / (pd->down_limit * 1024.0) * 1000.0;
+                if (ms > expected_ms)
+                    expected_ms = ms;
+            }
+            if (pd->up_limit > 0) {
+                double ms = (double)stats->received_bytes / (pd->up_limit * 1024.0) * 1000.0;
+                if (ms > expected_ms)
+                    expected_ms = ms;
+            }
+            if (expected_ms > elapsed) {
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(static_cast<int>(expected_ms - elapsed)));
+            }
             return 0;
         };
     }
@@ -180,7 +208,7 @@ int try_pull(const fs::path &repo, string &out_pull_log,
     fetch_opts.callbacks = callbacks;
     int err = git_remote_fetch(remote, nullptr, &fetch_opts, nullptr);
     if (err != 0) {
-        const git_error *e = git_error_last();
+        const git_error* e = git_error_last();
         if (auth_failed && e && e->message &&
             std::string(e->message).find("auth") != std::string::npos)
             *auth_failed = true;
@@ -214,7 +242,7 @@ int try_pull(const fs::path &repo, string &out_pull_log,
         finalize();
         return 0;
     }
-    git_object *target = nullptr;
+    git_object* target = nullptr;
     if (git_object_lookup(&target, r, &remote_oid, GIT_OBJECT_COMMIT) != 0) {
         git_remote_free(remote);
         git_repository_free(r);

--- a/git_utils.hpp
+++ b/git_utils.hpp
@@ -27,7 +27,7 @@ struct GitInitGuard {
  * @param p Filesystem path to check.
  * @return `true` if a `.git` directory exists inside @a p.
  */
-bool is_git_repo(const fs::path &p);
+bool is_git_repo(const fs::path& p);
 
 /**
  * @brief Get the commit hash pointed to by `HEAD`.
@@ -35,7 +35,7 @@ bool is_git_repo(const fs::path &p);
  * @param repo Path to a Git repository.
  * @return 40 character hexadecimal commit hash, or empty string on error.
  */
-std::string get_local_hash(const fs::path &repo);
+std::string get_local_hash(const fs::path& repo);
 
 /**
  * @brief Retrieve the currently checked out branch name.
@@ -43,7 +43,7 @@ std::string get_local_hash(const fs::path &repo);
  * @param repo Path to a Git repository.
  * @return Branch name or empty string if it cannot be determined.
  */
-std::string get_current_branch(const fs::path &repo);
+std::string get_current_branch(const fs::path& repo);
 
 /**
  * @brief Fetch `origin` and return the hash of the specified remote branch.
@@ -56,8 +56,8 @@ std::string get_current_branch(const fs::path &repo);
  *                        fails.
  * @return Commit hash of the remote branch, or empty string on failure.
  */
-std::string get_remote_hash(const fs::path &repo, const std::string &branch,
-                            bool use_credentials = false, bool *auth_failed = nullptr);
+std::string get_remote_hash(const fs::path& repo, const std::string& branch,
+                            bool use_credentials = false, bool* auth_failed = nullptr);
 
 /**
  * @brief Obtain the URL of the `origin` remote.
@@ -65,7 +65,7 @@ std::string get_remote_hash(const fs::path &repo, const std::string &branch,
  * @param repo Path to a Git repository.
  * @return Remote URL as a string, or empty string on failure.
  */
-std::string get_origin_url(const fs::path &repo);
+std::string get_origin_url(const fs::path& repo);
 
 /**
  * @brief Check if a URL points to GitHub.
@@ -73,7 +73,7 @@ std::string get_origin_url(const fs::path &repo);
  * @param url Remote URL string.
  * @return `true` if the URL contains `github.com`.
  */
-bool is_github_url(const std::string &url);
+bool is_github_url(const std::string& url);
 
 /**
  * @brief Attempt to connect to the `origin` remote.
@@ -81,7 +81,7 @@ bool is_github_url(const std::string &url);
  * @param repo Path to a Git repository.
  * @return `true` if the remote can be contacted.
  */
-bool remote_accessible(const fs::path &repo);
+bool remote_accessible(const fs::path& repo);
 
 /**
  * @brief Perform a fast-forward pull from the `origin` remote.
@@ -98,9 +98,9 @@ bool remote_accessible(const fs::path &repo);
  * @param auth_failed    Optional output flag set when authentication fails.
  * @return `0` on success or when already up to date, `2` on failure.
  */
-int try_pull(const fs::path &repo, std::string &out_pull_log,
-             const std::function<void(int)> *progress_cb = nullptr, bool use_credentials = false,
-             bool *auth_failed = nullptr);
+int try_pull(const fs::path& repo, std::string& out_pull_log,
+             const std::function<void(int)>* progress_cb = nullptr, bool use_credentials = false,
+             bool* auth_failed = nullptr, size_t down_limit_kbps = 0, size_t up_limit_kbps = 0);
 
 } // namespace git
 

--- a/tests/memory_leak.cpp
+++ b/tests/memory_leak.cpp
@@ -12,11 +12,12 @@
 
 namespace fs = std::filesystem;
 
-void scan_repos(const std::vector<fs::path> &all_repos, std::map<fs::path, RepoInfo> &repo_infos,
-                std::set<fs::path> &skip_repos, std::mutex &mtx, std::atomic<bool> &scanning_flag,
-                std::atomic<bool> &running, std::string &action, std::mutex &action_mtx,
-                bool include_private, const fs::path &log_dir, bool check_only, bool hash_check,
-                size_t concurrency, int cpu_percent_limit, size_t mem_limit);
+void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoInfo>& repo_infos,
+                std::set<fs::path>& skip_repos, std::mutex& mtx, std::atomic<bool>& scanning_flag,
+                std::atomic<bool>& running, std::string& action, std::mutex& action_mtx,
+                bool include_private, const fs::path& log_dir, bool check_only, bool hash_check,
+                size_t concurrency, int cpu_percent_limit, size_t mem_limit, size_t down_limit,
+                size_t up_limit);
 
 TEST_CASE("scan_repos memory stability") {
     git::GitInitGuard guard;
@@ -45,7 +46,7 @@ TEST_CASE("scan_repos memory stability") {
         scanning = true;
         running = true;
         scan_repos(repos, infos, skip, mtx, scanning, running, action, action_mtx, false,
-                   fs::path(), true, true, 1, 0, 0);
+                   fs::path(), true, true, 1, 0, 0, 0, 0);
         size_t mem = procutil::get_memory_usage_mb();
         if (i == 0)
             baseline = mem;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -12,8 +12,8 @@
 namespace fs = std::filesystem;
 
 TEST_CASE("ArgParser basic parsing") {
-    const char *argv[] = {"prog", "--foo", "--opt", "42", "pos", "--unknown"};
-    ArgParser parser(6, const_cast<char **>(argv), {"--foo", "--bar", "--opt"});
+    const char* argv[] = {"prog", "--foo", "--opt", "42", "pos", "--unknown"};
+    ArgParser parser(6, const_cast<char**>(argv), {"--foo", "--bar", "--opt"});
     REQUIRE(parser.has_flag("--foo"));
     REQUIRE(parser.get_option("--opt") == "42");
     REQUIRE(parser.positional().size() == 1);
@@ -23,15 +23,15 @@ TEST_CASE("ArgParser basic parsing") {
 }
 
 TEST_CASE("ArgParser option with equals") {
-    const char *argv[] = {"prog", "--opt=val"};
-    ArgParser parser(2, const_cast<char **>(argv), {"--opt"});
+    const char* argv[] = {"prog", "--opt=val"};
+    ArgParser parser(2, const_cast<char**>(argv), {"--opt"});
     REQUIRE(parser.has_flag("--opt"));
     REQUIRE(parser.get_option("--opt") == "val");
 }
 
 TEST_CASE("ArgParser unknown flag detection") {
-    const char *argv[] = {"prog", "--foo"};
-    ArgParser parser(2, const_cast<char **>(argv), {"--bar"});
+    const char* argv[] = {"prog", "--foo"};
+    ArgParser parser(2, const_cast<char**>(argv), {"--bar"});
     REQUIRE(parser.has_flag("--foo") == false);
     REQUIRE(parser.unknown_flags().size() == 1);
     REQUIRE(parser.unknown_flags()[0] == "--foo");
@@ -73,16 +73,16 @@ TEST_CASE("RepoInfo defaults") {
 }
 
 TEST_CASE("ArgParser log level flags") {
-    const char *argv[] = {"prog", "--log-level", "DEBUG", "--verbose"};
-    ArgParser parser(4, const_cast<char **>(argv), {"--log-level", "--verbose"});
+    const char* argv[] = {"prog", "--log-level", "DEBUG", "--verbose"};
+    ArgParser parser(4, const_cast<char**>(argv), {"--log-level", "--verbose"});
     REQUIRE(parser.has_flag("--log-level"));
     REQUIRE(parser.get_option("--log-level") == "DEBUG");
     REQUIRE(parser.has_flag("--verbose"));
 }
 
 TEST_CASE("ArgParser log file option") {
-    const char *argv[] = {"prog", "--log-file", "my.log", "path"};
-    ArgParser parser(4, const_cast<char **>(argv), {"--log-file"});
+    const char* argv[] = {"prog", "--log-file", "my.log", "path"};
+    ArgParser parser(4, const_cast<char**>(argv), {"--log-file"});
     REQUIRE(parser.has_flag("--log-file"));
     REQUIRE(parser.get_option("--log-file") == "my.log");
     REQUIRE(parser.positional().size() == 1);
@@ -90,9 +90,9 @@ TEST_CASE("ArgParser log file option") {
 }
 
 TEST_CASE("ArgParser resource flags") {
-    const char *argv[] = {"prog", "--max-threads", "4",   "--cpu-percent", "50", "--cpu-cores",
+    const char* argv[] = {"prog", "--max-threads", "4",   "--cpu-percent", "50", "--cpu-cores",
                           "2",    "--mem-limit",   "100", "path"};
-    ArgParser parser(10, const_cast<char **>(argv),
+    ArgParser parser(10, const_cast<char**>(argv),
                      {"--max-threads", "--cpu-percent", "--cpu-cores", "--mem-limit"});
     REQUIRE(parser.get_option("--max-threads") == std::string("4"));
     REQUIRE(parser.get_option("--cpu-percent") == std::string("50"));
@@ -145,13 +145,13 @@ TEST_CASE("Logger appends messages") {
 }
 
 TEST_CASE("--log-file without value creates file") {
-    const char *argv[] = {"prog", "--log-file"};
-    ArgParser parser(2, const_cast<char **>(argv), {"--log-file"});
+    const char* argv[] = {"prog", "--log-file"};
+    ArgParser parser(2, const_cast<char**>(argv), {"--log-file"});
     REQUIRE(parser.has_flag("--log-file"));
     REQUIRE(parser.get_option("--log-file").empty());
 
     std::string ts = timestamp();
-    for (char &ch : ts) {
+    for (char& ch : ts) {
         if (ch == ' ' || ch == ':')
             ch = '_';
         else if (ch == '/')
@@ -168,9 +168,16 @@ TEST_CASE("--log-file without value creates file") {
 }
 
 TEST_CASE("ArgParser threads flags") {
-    const char *argv[] = {"prog", "--threads", "8", "--single-thread"};
-    ArgParser parser(4, const_cast<char **>(argv), {"--threads", "--single-thread"});
+    const char* argv[] = {"prog", "--threads", "8", "--single-thread"};
+    ArgParser parser(4, const_cast<char**>(argv), {"--threads", "--single-thread"});
     REQUIRE(parser.has_flag("--threads"));
     REQUIRE(parser.get_option("--threads") == std::string("8"));
     REQUIRE(parser.has_flag("--single-thread"));
+}
+
+TEST_CASE("ArgParser network limits") {
+    const char* argv[] = {"prog", "--download-limit", "100", "--upload-limit", "50"};
+    ArgParser parser(5, const_cast<char**>(argv), {"--download-limit", "--upload-limit"});
+    REQUIRE(parser.get_option("--download-limit") == std::string("100"));
+    REQUIRE(parser.get_option("--upload-limit") == std::string("50"));
 }


### PR DESCRIPTION
## Summary
- implement optional download/upload limits for `try_pull`
- expose new `--download-limit` and `--upload-limit` CLI flags
- propagate rate limits through repo processing
- cover new options in tests

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877d1ccc2e08325958bd5648c5ba5b4