### PR TITLE
Add lint instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 To maintain code quality, all commits must pass the following checks **before** they are committed:
 
-1. `make lint` – runs clang-format, cpplint **and Prettier checks** to ensure all sources follow the project's style rules.
-2. `npm run format` – formats all Markdown and JSON files using Prettier.
+1. `make lint` – runs `clang-format` and `cpplint` using the project's `.clang-format` configuration.
+2. `npm run format` – formats all Markdown and JSON files with Prettier.
 3. The full test suite via `make test`.
 
 Run these commands locally from the repository root:
@@ -12,6 +12,12 @@ Run these commands locally from the repository root:
 make lint
 npm run format
 make test
+```
+
+`clang-format` (configured by `.clang-format`) and `cpplint` are mandatory tools. You can auto-format sources with:
+
+```bash
+clang-format -i <file.cpp> <file.hpp>
 ```
 
 If any command fails, fix the issues before committing. Pull requests failing any of these checks will be rejected.

--- a/git_utils.cpp
+++ b/git_utils.cpp
@@ -144,7 +144,6 @@ int try_pull(const fs::path& repo, string& out_pull_log,
              const std::function<void(int)>* progress_cb, bool use_credentials, bool* auth_failed,
              size_t down_limit_kbps, size_t up_limit_kbps) {
 
-
     if (progress_cb)
         (*progress_cb)(0);
     auto finalize = [&]() {

--- a/tests/memory_leak.cpp
+++ b/tests/memory_leak.cpp
@@ -19,7 +19,6 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
                 size_t concurrency, int cpu_percent_limit, size_t mem_limit, size_t down_limit,
                 size_t up_limit);
 
-
 TEST_CASE("scan_repos memory stability") {
     git::GitInitGuard guard;
     fs::path repo = fs::temp_directory_path() / "memory_leak_repo";


### PR DESCRIPTION
## Summary
- document required lint workflow in AGENTS guidelines
- minor clang-format cleanup for `git_utils.cpp` and test file

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6877d482f59483259f82f3475af937ec