### PR TITLE
Add shutdown_logger and improve init

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -660,7 +660,7 @@ int main(int argc, char* argv[]) {
             scan_thread.join();
         if (logger_initialized())
             log_info("Program exiting");
-        close_logger();
+        shutdown_logger();
     } catch (...) {
         throw;
     }

--- a/git_utils.cpp
+++ b/git_utils.cpp
@@ -10,7 +10,6 @@ using namespace std;
 
 namespace git {
 
-
 struct ProgressData {
     const std::function<void(int)>* cb;
     std::chrono::steady_clock::time_point start;
@@ -152,8 +151,6 @@ int try_pull(const fs::path& repo, string& out_pull_log,
         if (progress_cb)
             (*progress_cb)(100);
     };
-
-    git_repository* r = nullptr;
 
     git_repository* raw_repo = nullptr;
 

--- a/logger.cpp
+++ b/logger.cpp
@@ -9,6 +9,10 @@ static LogLevel g_min_level = LogLevel::INFO;
 
 void init_logger(const std::string& path, LogLevel level) {
     std::lock_guard<std::mutex> lk(g_log_mtx);
+    if (g_log_ofs.is_open()) {
+        g_log_ofs.flush();
+        g_log_ofs.close();
+    }
     g_log_ofs.open(path, std::ios::app);
     g_min_level = level;
 }
@@ -38,6 +42,14 @@ void log_warning(const std::string& msg) { log(LogLevel::WARNING, "WARNING", msg
 void log_error(const std::string& msg) { log(LogLevel::ERROR, "ERROR", msg); }
 
 void close_logger() {
+    std::lock_guard<std::mutex> lk(g_log_mtx);
+    if (g_log_ofs.is_open()) {
+        g_log_ofs.flush();
+        g_log_ofs.close();
+    }
+}
+
+void shutdown_logger() {
     std::lock_guard<std::mutex> lk(g_log_mtx);
     if (g_log_ofs.is_open()) {
         g_log_ofs.flush();

--- a/logger.hpp
+++ b/logger.hpp
@@ -12,5 +12,6 @@ void log_info(const std::string& msg);
 void log_warning(const std::string& msg);
 void log_error(const std::string& msg);
 void close_logger();
+void shutdown_logger();
 
 #endif // LOGGER_HPP

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -141,7 +141,7 @@ TEST_CASE("Logger appends messages") {
         REQUIRE(lines.size() == count_before + 1);
         REQUIRE(lines.back().find("third entry") != std::string::npos);
     }
-    close_logger();
+    shutdown_logger();
 }
 
 TEST_CASE("--log-file without value creates file") {
@@ -162,7 +162,7 @@ TEST_CASE("--log-file without value creates file") {
     init_logger(log.string());
     REQUIRE(logger_initialized());
     log_info("test entry");
-    close_logger();
+    shutdown_logger();
     REQUIRE(fs::exists(log));
     fs::remove(log);
 }


### PR DESCRIPTION
## Summary
- close any open log file before opening a new one
- add `shutdown_logger()` and use it on exit
- update unit tests for new logger cleanup
- fix git_utils compile issue

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6877d78c1ea883258af1a8df2c3c709f