### PR TITLE
Fix unique_ptr repository variable

### DIFF
--- a/git_utils.cpp
+++ b/git_utils.cpp
@@ -10,7 +10,6 @@ using namespace std;
 
 namespace git {
 
-
 struct ProgressData {
     const std::function<void(int)>* cb;
     std::chrono::steady_clock::time_point start;
@@ -152,8 +151,6 @@ int try_pull(const fs::path& repo, string& out_pull_log,
         if (progress_cb)
             (*progress_cb)(100);
     };
-
-    git_repository* r = nullptr;
 
     git_repository* raw_repo = nullptr;
 


### PR DESCRIPTION
## Summary
- resolve compile conflict in git_utils.cpp by removing unused raw pointer before creating unique_ptr

## Testing
- `make lint`
- `npm run format`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877d84db3588325bdd99563ef264366