### PR TITLE
Fix missing build file and update instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,5 @@ clang-format -i <file.cpp> <file.hpp>
 ```
 
 If any command fails, fix the issues before committing. Pull requests failing any of these checks will be rejected.
+
+When adding new C++ source files, update all build scripts (`compile.sh`, `compile.bat`, and `compile-cl.bat`) so they compile the new files. Build script changes are mandatory.

--- a/compile-cl.bat
+++ b/compile-cl.bat
@@ -15,6 +15,6 @@ if not exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
 set "INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
 set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
-cl /nologo /std:c++17 /EHsc /I"%INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp time_utils.cpp ^
+cl /nologo /std:c++17 /EHsc /I"%INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ^
     "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib /Feautogitpull.exe
 endlocal

--- a/compile.bat
+++ b/compile.bat
@@ -22,7 +22,7 @@ if not exist "%LIBGIT2_LIB%\libgit2.a" (
     if errorlevel 1 exit /b 1
 )
 
-g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp time_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -o autogitpull.exe
+g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -o autogitpull.exe
 
 endlocal
 

--- a/compile.sh
+++ b/compile.sh
@@ -52,10 +52,10 @@ fi
 PKG_CFLAGS="$(pkg-config --cflags libgit2 2>/dev/null || echo '')"
 if [[ "$os" == "Darwin" ]]; then
     PKG_LIBS="$(pkg-config --libs libgit2 2>/dev/null || echo '-lgit2')"
-    ${CXX} -std=c++17 ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp time_utils.cpp ${PKG_LIBS} -o autogitpull
+    ${CXX} -std=c++17 ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ${PKG_LIBS} -o autogitpull
 else
     PKG_LIBS="$(pkg-config --static --libs libgit2 2>/dev/null || echo '-lgit2')"
-    ${CXX} -std=c++17 -static ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp time_utils.cpp ${PKG_LIBS} -o autogitpull
+    ${CXX} -std=c++17 -static ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ${PKG_LIBS} -o autogitpull
 fi
 
 


### PR DESCRIPTION
## Summary
- ensure `system_utils.cpp` is compiled in all build scripts
- clarify that build scripts must be kept up to date in `AGENTS.md`

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6877db36b6a88325a9a657be163ee477