### PR TITLE
Use jthread for scanning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(autogitpull)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 find_package(PkgConfig REQUIRED)
 if(APPLE)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -std=c++17 -pthread $(shell pkg-config --cflags libgit2 2>/dev/null)
+CXXFLAGS = -std=c++20 -pthread $(shell pkg-config --cflags libgit2 2>/dev/null)
 UNAME_S := $(shell uname -s)
 LIBGIT2_STATIC_AVAILABLE := $(shell pkg-config --static --libs libgit2 >/dev/null 2>&1 && echo yes)
 ifeq ($(UNAME_S),Darwin)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ the bare minimum required to compile the program.
 On Linux with `g++`:
 
 ```bash
-g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp logger.cpp \
+g++ -std=c++20 autogitpull.cpp git_utils.cpp tui.cpp logger.cpp \
     $(pkg-config --cflags libgit2) \
     $(pkg-config --static --libs libgit2 2>/dev/null || pkg-config --libs libgit2) \
     -pthread -o autogitpull
@@ -80,13 +80,13 @@ g++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp logger.cpp \
 On macOS with `clang++`:
 
 ```bash
-clang++ -std=c++17 autogitpull.cpp git_utils.cpp tui.cpp logger.cpp $(pkg-config --cflags --libs libgit2) -pthread -o autogitpull
+clang++ -std=c++20 autogitpull.cpp git_utils.cpp tui.cpp logger.cpp $(pkg-config --cflags --libs libgit2) -pthread -o autogitpull
 ```
 
 On Windows with MSVC's `cl`:
 
 ```batch
-cl /std:c++17 /EHsc /MT /Ipath\to\libgit2\include autogitpull.cpp git_utils.cpp tui.cpp logger.cpp /link /LIBPATH:path\to\libgit2\lib git2.lib
+cl /std:c++20 /EHsc /MT /Ipath\to\libgit2\include autogitpull.cpp git_utils.cpp tui.cpp logger.cpp /link /LIBPATH:path\to\libgit2\lib git2.lib
 ```
 
 These commands mirror what the scripts do internally.

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -272,7 +272,7 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
         }
     };
 
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     threads.reserve(concurrency);
     for (size_t i = 0; i < concurrency; ++i)
         threads.emplace_back(worker);

--- a/compile-cl.bat
+++ b/compile-cl.bat
@@ -15,6 +15,6 @@ if not exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
 set "INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
 set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
-cl /nologo /std:c++17 /EHsc /I"%INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ^
+cl /nologo /std:c++20 /EHsc /I"%INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ^
     "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib /Feautogitpull.exe
 endlocal

--- a/compile.bat
+++ b/compile.bat
@@ -22,7 +22,7 @@ if not exist "%LIBGIT2_LIB%\libgit2.a" (
     if errorlevel 1 exit /b 1
 )
 
-g++ -std=c++17 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -o autogitpull.exe
+g++ -std=c++20 -static -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -o autogitpull.exe
 
 endlocal
 

--- a/compile.sh
+++ b/compile.sh
@@ -52,10 +52,10 @@ fi
 PKG_CFLAGS="$(pkg-config --cflags libgit2 2>/dev/null || echo '')"
 if [[ "$os" == "Darwin" ]]; then
     PKG_LIBS="$(pkg-config --libs libgit2 2>/dev/null || echo '-lgit2')"
-    ${CXX} -std=c++17 ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ${PKG_LIBS} -o autogitpull
+    ${CXX} -std=c++20 ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ${PKG_LIBS} -o autogitpull
 else
     PKG_LIBS="$(pkg-config --static --libs libgit2 2>/dev/null || echo '-lgit2')"
-    ${CXX} -std=c++17 -static ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ${PKG_LIBS} -o autogitpull
+    ${CXX} -std=c++20 -static ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ${PKG_LIBS} -o autogitpull
 fi
 
 


### PR DESCRIPTION
## Summary
- swap out `std::thread` for `std::jthread` in `scan_repos`
- require C++20 in build scripts and README

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6877dea3e7608325af08ef0f51d12178