### PR TITLE
Add cross-platform debug build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ will attempt to install a C++ compiler if one isn't present. Windows users get
 
 Clean up intermediate files with `make clean`.
 
+### Debug builds for leak analysis
+
+The scripts `compile-debug.sh`, `compile-debug.bat` and `compile-debug-cl.bat`
+compile the program with AddressSanitizer and debug information enabled. They
+produce `autogitpull_debug` (or `autogitpull_debug.exe` on Windows). Use these
+builds when running leak detection tools:
+
+```bash
+./compile-debug.sh      # Linux/macOS
+compile-debug.bat       # MinGW
+compile-debug-cl.bat    # MSVC
+```
+
 ### Manual compilation
 
 If you prefer to build without the helper scripts, the following commands show

--- a/compile-debug-cl.bat
+++ b/compile-debug-cl.bat
@@ -1,0 +1,21 @@
+@echo off
+setlocal
+
+where cl >nul 2>nul
+if errorlevel 1 (
+    echo MSVC cl compiler not found in PATH.
+    exit /b 1
+)
+
+if not exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
+    call install_deps.bat
+    if errorlevel 1 exit /b 1
+)
+
+set "INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
+set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
+
+cl /nologo /std:c++20 /EHsc /Zi /I"%INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ^
+    "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib /fsanitize=address /Feautogitpull_debug.exe
+
+endlocal

--- a/compile-debug.bat
+++ b/compile-debug.bat
@@ -1,0 +1,25 @@
+@echo off
+setlocal
+
+where g++ >nul 2>nul
+if errorlevel 1 (
+    echo MinGW g++ not found. Attempting to install...
+    if defined ChocolateyInstall (
+        choco install -y mingw
+    ) else (
+        echo Please install MinGW and ensure g++ is in PATH.
+        exit /b 1
+    )
+)
+
+set "LIBGIT2_INC=libgit2\_install\include"
+set "LIBGIT2_LIB=libgit2\_install\lib"
+
+if not exist "%LIBGIT2_LIB%\libgit2.a" (
+    call install_libgit2_mingw.bat
+    if errorlevel 1 exit /b 1
+)
+
+g++ -std=c++20 -O0 -g -fsanitize=address -I"%LIBGIT2_INC%" autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -fsanitize=address -o autogitpull_debug.exe
+
+endlocal

--- a/compile-debug.sh
+++ b/compile-debug.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -e
+
+os="$(uname -s)"
+
+# Ensure a compiler is available
+if command -v g++ >/dev/null; then
+    CXX=g++
+elif command -v clang++ >/dev/null; then
+    CXX=clang++
+else
+    echo "No C++ compiler found, attempting to install..."
+    if [[ "$os" == "Darwin" ]]; then
+        if command -v brew >/dev/null; then
+            brew install llvm
+            CXX=clang++
+        else
+            echo "Homebrew not found. Please install Xcode or a compiler manually." >&2
+            exit 1
+        fi
+    else
+        if command -v apt-get >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y g++
+            CXX=g++
+        elif command -v yum >/dev/null; then
+            sudo yum install -y gcc-c++
+            CXX=g++
+        else
+            echo "Unsupported Linux distribution. Please install g++ manually." >&2
+            exit 1
+        fi
+    fi
+fi
+
+if command -v pkg-config >/dev/null && pkg-config --exists libgit2; then
+    :
+else
+    if [[ "$os" == "Darwin" ]]; then
+        if command -v brew >/dev/null && brew ls --versions libgit2 >/dev/null; then
+            echo "libgit2 found via brew"
+        else
+            echo "libgit2 not found, attempting to install..."
+            ./install_deps.sh
+        fi
+    else
+        echo "libgit2 not found, attempting to install..."
+        ./install_deps.sh
+    fi
+fi
+
+PKG_CFLAGS="$(pkg-config --cflags libgit2 2>/dev/null || echo '')"
+PKG_LIBS="$(pkg-config --libs libgit2 2>/dev/null || echo '-lgit2')"
+
+${CXX} -std=c++20 -O0 -g -fsanitize=address ${PKG_CFLAGS} autogitpull.cpp git_utils.cpp tui.cpp logger.cpp resource_utils.cpp system_utils.cpp time_utils.cpp ${PKG_LIBS} -fsanitize=address -o autogitpull_debug


### PR DESCRIPTION
## Summary
- add `compile-debug` scripts for leak analysis
- document new debug scripts in README

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6877ed77c0488325a0e7ff3b639bf71d