### PR TITLE
Fix jiffies reading to reopen stat file each call

### DIFF
--- a/resource_utils.cpp
+++ b/resource_utils.cpp
@@ -22,11 +22,9 @@ namespace procutil {
 #ifdef __linux__
 
 static long read_proc_jiffies() {
-    static std::ifstream stat("/proc/self/stat");
+    std::ifstream stat("/proc/self/stat");
     if (!stat.is_open())
         return 0;
-    stat.clear();
-    stat.seekg(0);
     std::string tmp;
     for (int i = 0; i < 13; ++i)
         stat >> tmp; // skip fields


### PR DESCRIPTION
## Summary
- open `/proc/self/stat` in `read_proc_jiffies()` each call instead of using a static ifstream
- keep formatting & style

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68781fd8bbd88325af62f8e91e682d88