### PR TITLE
Simplify logger shutdown

### DIFF
--- a/logger.cpp
+++ b/logger.cpp
@@ -41,7 +41,7 @@ void log_warning(const std::string& msg) { log(LogLevel::WARNING, "WARNING", msg
 
 void log_error(const std::string& msg) { log(LogLevel::ERROR, "ERROR", msg); }
 
-void close_logger() {
+static void close_logger() {
     std::lock_guard<std::mutex> lk(g_log_mtx);
     if (g_log_ofs.is_open()) {
         g_log_ofs.flush();
@@ -49,10 +49,4 @@ void close_logger() {
     }
 }
 
-void shutdown_logger() {
-    std::lock_guard<std::mutex> lk(g_log_mtx);
-    if (g_log_ofs.is_open()) {
-        g_log_ofs.flush();
-        g_log_ofs.close();
-    }
-}
+void shutdown_logger() { close_logger(); }

--- a/logger.hpp
+++ b/logger.hpp
@@ -11,7 +11,6 @@ void log_debug(const std::string& msg);
 void log_info(const std::string& msg);
 void log_warning(const std::string& msg);
 void log_error(const std::string& msg);
-void close_logger();
 void shutdown_logger();
 
 #endif // LOGGER_HPP


### PR DESCRIPTION
## Summary
- consolidate logger shutdown
- expose only `shutdown_logger` in the public API

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687820a241208325ab92246f66eb25c4