### PR TITLE
Fix leftover threads after repo scan

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -353,6 +353,8 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
         threads.emplace_back(worker);
     for (auto& t : threads)
         t.join();
+    threads.clear();
+    threads.shrink_to_fit();
     scanning_flag = false;
     {
         std::lock_guard<std::mutex> lk(action_mtx);


### PR DESCRIPTION
## Summary
- join scanning threads and clear the vector to release resources

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68782290bdd48325859f158ea3e34ffb