### PR TITLE
Clear TUI buffer

### DIFF
--- a/tui.cpp
+++ b/tui.cpp
@@ -176,4 +176,8 @@ void draw_tui(const std::vector<fs::path>& all_repos,
     out << "--------------------------------------------------------------";
     out << "-------------------\n";
     std::cout << out.str() << std::flush;
+    // Explicitly clear the string buffer to avoid stale allocations
+    out.str("");
+    out.clear();
+    std::ostringstream().swap(out);
 }


### PR DESCRIPTION
## Summary
- clear the `ostringstream` used by `draw_tui` after rendering to avoid any lingering memory allocations

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68782344637c8325ad8e2b1c57b38cad