### PR TITLE
Improve CPU polling and memory accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Available options:
 - `--max-threads <n>` – cap the scanning worker threads.
 - `--cpu-percent <n>` – approximate CPU usage limit (1–100).
 - `--cpu-cores <mask>` – set CPU affinity mask (e.g. `0x3` binds to cores 0 and 1).
+- `--cpu-poll <s>` – how often to sample CPU usage in seconds (default 5).
 - `--mem-limit <MB>` – abort if memory usage exceeds this amount.
 - `--check-only` – only check for updates without pulling.
 - `--no-hash-check` – always pull without comparing commit hashes first.

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -368,17 +368,35 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
 int main(int argc, char* argv[]) {
     git::GitInitGuard git_guard;
     try {
-        const std::set<std::string> known{
-            "--include-private", "--show-skipped",      "--show-version",
-            "--version",         "--interval",          "--refresh-rate",
-            "--log-dir",         "--log-file",          "--concurrency",
-            "--check-only",      "--no-hash-check",     "--log-level",
-            "--verbose",         "--max-threads",       "--cpu-percent",
-            "--cpu-cores",       "--mem-limit",         "--no-cpu-tracker",
-            "--no-mem-tracker",  "--no-thread-tracker", "--help",
-            "--threads",         "--single-thread",     "--net-tracker",
-            "--download-limit",  "--upload-limit",      "--cli",
-            "--silent"};
+        const std::set<std::string> known{"--include-private",
+                                          "--show-skipped",
+                                          "--show-version",
+                                          "--version",
+                                          "--interval",
+                                          "--refresh-rate",
+                                          "--cpu-poll",
+                                          "--log-dir",
+                                          "--log-file",
+                                          "--concurrency",
+                                          "--check-only",
+                                          "--no-hash-check",
+                                          "--log-level",
+                                          "--verbose",
+                                          "--max-threads",
+                                          "--cpu-percent",
+                                          "--cpu-cores",
+                                          "--mem-limit",
+                                          "--no-cpu-tracker",
+                                          "--no-mem-tracker",
+                                          "--no-thread-tracker",
+                                          "--help",
+                                          "--threads",
+                                          "--single-thread",
+                                          "--net-tracker",
+                                          "--download-limit",
+                                          "--upload-limit",
+                                          "--cli",
+                                          "--silent"};
         ArgParser parser(argc, argv, known);
 
         bool cli = parser.has_flag("--cli");
@@ -394,7 +412,7 @@ int main(int argc, char* argv[]) {
                 << "Usage: " << argv[0]
                 << " <root-folder> [--include-private] [--show-skipped] [--show-version] "
                    "[--version]"
-                << " [--interval <seconds>] [--refresh-rate <ms>]"
+                << " [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>]"
                 << " [--log-dir <path>] [--log-file <path>]"
                 << " [--log-level <level>] [--verbose]"
                 << " [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>]"
@@ -413,7 +431,7 @@ int main(int argc, char* argv[]) {
                     << "Usage: " << argv[0]
                     << " <root-folder> [--include-private] [--show-skipped] [--show-version] "
                        "[--version]"
-                    << " [--interval <seconds>] [--refresh-rate <ms>]"
+                    << " [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>]"
                     << " [--log-dir <path>] [--log-file <path>]"
                     << " [--log-level <level>] [--verbose]"
                     << " [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>]"
@@ -479,6 +497,7 @@ int main(int argc, char* argv[]) {
         bool net_tracker = false;
         int interval = 30;
         std::chrono::milliseconds refresh_ms(250);
+        unsigned int cpu_poll_sec = 5;
         if (parser.has_flag("--interval")) {
             std::string val = parser.get_option("--interval");
             if (val.empty()) {
@@ -506,6 +525,21 @@ int main(int argc, char* argv[]) {
             } catch (...) {
                 if (!silent)
                     std::cerr << "Invalid value for --refresh-rate: " << val << "\n";
+                return 1;
+            }
+        }
+        if (parser.has_flag("--cpu-poll")) {
+            std::string val = parser.get_option("--cpu-poll");
+            if (val.empty()) {
+                if (!silent)
+                    std::cerr << "--cpu-poll requires a value in seconds\n";
+                return 1;
+            }
+            try {
+                cpu_poll_sec = static_cast<unsigned int>(std::stoul(val));
+            } catch (...) {
+                if (!silent)
+                    std::cerr << "Invalid value for --cpu-poll: " << val << "\n";
                 return 1;
             }
         }
@@ -694,6 +728,8 @@ int main(int argc, char* argv[]) {
         }
         if (cpu_core_mask != 0)
             procutil::set_cpu_affinity(cpu_core_mask);
+
+        procutil::set_cpu_poll_interval(cpu_poll_sec);
 
         if (net_tracker)
             procutil::init_network_usage();

--- a/resource_utils.hpp
+++ b/resource_utils.hpp
@@ -5,6 +5,7 @@
 namespace procutil {
 
 double get_cpu_percent();
+void set_cpu_poll_interval(unsigned int seconds);
 std::size_t get_memory_usage_mb();
 std::size_t get_thread_count();
 


### PR DESCRIPTION
## Summary
- add configurable CPU polling interval via `--cpu-poll`
- cache CPU usage between polls
- fix memory usage reporting on Linux using VmRSS
- document new CLI option

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68782988692c8325945e45e005a1bc30