### PR TITLE
Fix repo status reset on scan

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -309,8 +309,7 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
 
     {
         std::lock_guard<std::mutex> lk(mtx);
-        std::map<fs::path, RepoInfo> empty_map;
-        repo_infos.swap(empty_map);
+        // Retain repo_infos so statuses persist between scans
         std::set<fs::path> empty_set;
         skip_repos.swap(empty_set);
     }


### PR DESCRIPTION
## Summary
- keep existing repo status info across scans by avoiding map swap

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687828b3dd948325884b7d4bcad938c6