### PR TITLE
Improve RAII wrappers for threads and libgit2

### DIFF
--- a/git_utils.hpp
+++ b/git_utils.hpp
@@ -22,9 +22,20 @@ struct GitInitGuard {
 };
 
 // RAII wrappers for libgit2 resources
-using repo_ptr = std::unique_ptr<git_repository, decltype(&git_repository_free)>;
-using remote_ptr = std::unique_ptr<git_remote, decltype(&git_remote_free)>;
-using object_ptr = std::unique_ptr<git_object, decltype(&git_object_free)>;
+template <typename T, void (*Free)(T*)> struct GitHandle {
+    T* h;
+    explicit GitHandle(T* h_ = nullptr) : h(h_) {}
+    ~GitHandle() {
+        if (h)
+            Free(h);
+    }
+    T* get() const { return h; }
+};
+
+using repo_ptr = GitHandle<git_repository, git_repository_free>;
+using remote_ptr = GitHandle<git_remote, git_remote_free>;
+using object_ptr = GitHandle<git_object, git_object_free>;
+using reference_ptr = GitHandle<git_reference, git_reference_free>;
 
 // The utility functions below assume libgit2 is already initialized.
 

--- a/thread_utils.hpp
+++ b/thread_utils.hpp
@@ -1,0 +1,18 @@
+#ifndef THREAD_UTILS_HPP
+#define THREAD_UTILS_HPP
+#include <thread>
+
+/**
+ * @brief RAII wrapper that joins the thread on destruction.
+ */
+struct ThreadGuard {
+    std::thread t;
+    ThreadGuard() = default;
+    explicit ThreadGuard(std::thread&& t_) : t(std::move(t_)) {}
+    ~ThreadGuard() {
+        if (t.joinable())
+            t.join();
+    }
+};
+
+#endif // THREAD_UTILS_HPP


### PR DESCRIPTION
## Summary
- add `GitHandle` template for libgit2 resources
- add `reference_ptr` for `git_reference`
- create `ThreadGuard` RAII helper
- use `ThreadGuard` in main loop

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878298c51b08325993fac70321bc682