### PR TITLE
Ensure worker threads join before reuse

### DIFF
--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -351,8 +351,10 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
     threads.reserve(concurrency);
     for (size_t i = 0; i < concurrency; ++i)
         threads.emplace_back(worker);
-    for (auto& t : threads)
-        t.join();
+    for (auto& t : threads) {
+        if (t.joinable())
+            t.join();
+    }
     threads.clear();
     threads.shrink_to_fit();
     scanning_flag = false;


### PR DESCRIPTION
## Summary
- use joinable check when joining worker threads in scan_repos

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68782b14b8648325a741dde8a6abfd95