### PR TITLE
Add polling intervals for memory and threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ valgrind ./build/memory_leak_test
 Valgrind should finish with the message `All heap blocks were freed -- no leaks
 are possible`.
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms>] [--log-dir <path>] [--log-file <path>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <mask>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--cli] [--silent] [--help]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <mask>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--cli] [--silent] [--help]`
 
 Available options:
 
@@ -163,6 +163,8 @@ Available options:
 - `--cpu-percent <n>` – approximate CPU usage limit (1–100).
 - `--cpu-cores <mask>` – set CPU affinity mask (e.g. `0x3` binds to cores 0 and 1).
 - `--cpu-poll <s>` – how often to sample CPU usage in seconds (default 5).
+- `--mem-poll <s>` – how often to sample memory usage in seconds (default 5).
+- `--thread-poll <s>` – how often to sample thread count in seconds (default 5).
 - `--mem-limit <MB>` – abort if memory usage exceeds this amount.
 - `--check-only` – only check for updates without pulling.
 - `--no-hash-check` – always pull without comparing commit hashes first.

--- a/resource_utils.hpp
+++ b/resource_utils.hpp
@@ -6,6 +6,8 @@ namespace procutil {
 
 double get_cpu_percent();
 void set_cpu_poll_interval(unsigned int seconds);
+void set_memory_poll_interval(unsigned int seconds);
+void set_thread_poll_interval(unsigned int seconds);
 std::size_t get_memory_usage_mb();
 std::size_t get_thread_count();
 


### PR DESCRIPTION
## Summary
- allow configuring memory/thread polling intervals
- cache memory and thread metrics in `resource_utils`
- expose new CLI flags `--mem-poll` and `--thread-poll`
- document new options

## Testing
- `make lint`
- `npm run format`
- `make test` *(fails: libgit2 missing before install; build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68782e9876b88325863a22196f3fe1fa