### PR TITLE
Enhance CLI usability and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ are possible`.
 
 Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <mask>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--cli] [--silent] [--help]`
 
+Most options have single-letter shorthands. Run `autogitpull --help` to see a concise list.
+
 Available options:
 
 - `--include-private` – include private or non-GitHub repositories in the scan.

--- a/autogitpull.cpp
+++ b/autogitpull.cpp
@@ -69,6 +69,23 @@ std::string status_label(RepoStatus status) {
     return "";
 }
 
+/** Print the command line help text. */
+void print_help(const char* prog) {
+    std::cout << "Usage: " << prog << " <root-folder> [options]\n\n"
+              << "Options:\n"
+              << "  -p, --include-private   Include private repositories\n"
+              << "  -k, --show-skipped      Show skipped repositories\n"
+              << "  -v, --show-version      Display program version in TUI\n"
+              << "  -V, --version           Print program version and exit\n"
+              << "  -i, --interval <sec>    Delay between scans\n"
+              << "  -r, --refresh-rate <ms> TUI refresh rate\n"
+              << "  -d, --log-dir <path>    Directory for pull logs\n"
+              << "  -l, --log-file <path>   File for general logs\n"
+              << "  -c, --cli               Use console output\n"
+              << "  -s, --silent            Disable console output\n"
+              << "  -h, --help              Show this message\n";
+}
+
 void draw_cli(const std::vector<fs::path>& all_repos,
               const std::map<fs::path, RepoInfo>& repo_infos, int seconds_left, bool scanning,
               const std::string& action, bool show_skipped) {
@@ -386,7 +403,12 @@ int main(int argc, char* argv[]) {
             "--threads",         "--single-thread",     "--net-tracker",
             "--download-limit",  "--upload-limit",      "--cli",
             "--silent"};
-        ArgParser parser(argc, argv, known);
+        const std::map<char, std::string> short_opts{
+            {'p', "--include-private"}, {'k', "--show-skipped"}, {'v', "--show-version"},
+            {'V', "--version"},         {'i', "--interval"},     {'r', "--refresh-rate"},
+            {'d', "--log-dir"},         {'l', "--log-file"},     {'c', "--cli"},
+            {'s', "--silent"},          {'h', "--help"}};
+        ArgParser parser(argc, argv, known, short_opts);
 
         bool cli = parser.has_flag("--cli");
         bool silent = parser.has_flag("--silent");
@@ -397,40 +419,13 @@ int main(int argc, char* argv[]) {
         }
 
         if (parser.has_flag("--help")) {
-            std::cout
-                << "Usage: " << argv[0]
-                << " <root-folder> [--include-private] [--show-skipped] [--show-version] "
-                   "[--version]"
-                << " [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>]"
-                << " [--mem-poll <s>] [--thread-poll <s>]"
-                << " [--log-dir <path>] [--log-file <path>]"
-                << " [--log-level <level>] [--verbose]"
-                << " [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>]"
-                << " [--cpu-percent <n>] [--cpu-cores <mask>]"
-                << " [--mem-limit <MB>] [--check-only] [--no-hash-check]"
-                << " [--no-cpu-tracker] [--no-mem-tracker]"
-                << " [--no-thread-tracker] [--net-tracker]"
-                << " [--download-limit <KB/s>] [--upload-limit <KB/s>]"
-                << " [--cli] [--silent] [--help]\n";
+            print_help(argv[0]);
             return 0;
         }
 
         if (parser.positional().size() != 1) {
             if (!silent)
-                std::cerr
-                    << "Usage: " << argv[0]
-                    << " <root-folder> [--include-private] [--show-skipped] [--show-version] "
-                       "[--version]"
-                    << " [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>]"
-                    << " [--mem-poll <s>] [--thread-poll <s>]"
-                    << " [--log-dir <path>] [--log-file <path>]"
-                    << " [--log-level <level>] [--verbose]"
-                    << " [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>]"
-                    << " [--cpu-percent <n>] [--cpu-cores <mask>]"
-                    << " [--mem-limit <MB>] [--check-only] [--no-hash-check]"
-                    << " [--no-cpu-tracker] [--no-mem-tracker]"
-                    << " [--no-thread-tracker] [--net-tracker]"
-                    << " [--download-limit <KB/s>] [--upload-limit <KB/s>] [--help]\n";
+                print_help(argv[0]);
             return 1;
         }
 

--- a/resource_utils.hpp
+++ b/resource_utils.hpp
@@ -4,11 +4,22 @@
 
 namespace procutil {
 
+/** @brief Return the approximate CPU usage of the current process. */
 double get_cpu_percent();
+
+/** @brief Set the polling interval for CPU usage in seconds. */
 void set_cpu_poll_interval(unsigned int seconds);
+
+/** @brief Set the polling interval for memory usage in seconds. */
 void set_memory_poll_interval(unsigned int seconds);
+
+/** @brief Set the polling interval for thread count in seconds. */
 void set_thread_poll_interval(unsigned int seconds);
+
+/** @brief Get the resident memory usage of the process in megabytes. */
 std::size_t get_memory_usage_mb();
+
+/** @brief Retrieve the number of threads currently in the process. */
 std::size_t get_thread_count();
 
 struct NetUsage {
@@ -16,7 +27,11 @@ struct NetUsage {
     std::size_t upload_bytes;
 };
 
+/** @brief Record the current network usage as the baseline. */
 void init_network_usage();
+
+/** @brief Return the amount of bytes downloaded and uploaded since
+ *         the call to @ref init_network_usage. */
 NetUsage get_network_usage();
 
 } // namespace procutil

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -63,6 +63,14 @@ TEST_CASE("ArgParser option with equals") {
     REQUIRE(parser.get_option("--opt") == "val");
 }
 
+TEST_CASE("ArgParser short options") {
+    const char* argv[] = {"prog", "-h", "-o", "42"};
+    ArgParser parser(4, const_cast<char**>(argv), {"--help", "--opt"},
+                     {{'h', "--help"}, {'o', "--opt"}});
+    REQUIRE(parser.has_flag("--help"));
+    REQUIRE(parser.get_option("--opt") == std::string("42"));
+}
+
 TEST_CASE("ArgParser unknown flag detection") {
     const char* argv[] = {"prog", "--foo"};
     ArgParser parser(2, const_cast<char**>(argv), {"--bar"});
@@ -263,8 +271,8 @@ TEST_CASE("scan_repos respects concurrency limit") {
     std::size_t max_seen = baseline;
 
     std::thread t([&]() {
-        scan_repos(repos, infos, skip, mtx, scanning, running, act, act_mtx, false,
-                   fs::path(), true, true, concurrency, 0, 0, 0, 0, true);
+        scan_repos(repos, infos, skip, mtx, scanning, running, act, act_mtx, false, fs::path(),
+                   true, true, concurrency, 0, 0, 0, 0, true);
     });
     while (scanning) {
         max_seen = std::max(max_seen, read_thread_count());


### PR DESCRIPTION
## Summary
- implement short option handling in `ArgParser`
- add Windows thread count using NtQuerySystemInformation
- improve command line help output
- document API functions with Doxygen style
- support short options in the main program
- note short options in README
- test short option parsing

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878381071748325b0a2b1c489e6a0c2