### PR TITLE
Add clean scripts for Unix and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # autogitpull
+
 Automatic Git Puller & Monitor
 
 ## Dependencies
@@ -61,7 +62,9 @@ will attempt to install a C++ compiler if one isn't present. Windows users get
 `compile.bat` (MinGW) and `compile-cl.bat` (MSVC) along with
 `install_deps.bat`, `install_libgit2_mingw.bat` and `run.bat`.
 
-Clean up intermediate files with `make clean`.
+Clean up intermediate files with `make clean`. You can also run
+`./clean.sh` on Unix-like systems or `clean.bat` on Windows to remove the
+generated binary, object files and the `build` directory.
 
 ### Debug builds for leak analysis
 

--- a/clean.bat
+++ b/clean.bat
@@ -1,0 +1,9 @@
+@echo off
+if exist autogitpull.exe del /f /q autogitpull.exe
+if exist autogitpull del /f /q autogitpull
+for %%f in (*.o *.obj) do (
+    if exist "%%f" del /f /q "%%f"
+)
+if exist build (
+    rmdir /s /q build
+)

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+rm -f autogitpull autogitpull.exe
+rm -f *.o *.obj
+if [ -d build ]; then
+  rm -rf build
+fi


### PR DESCRIPTION
## Summary
- add `clean.sh` and `clean.bat` to remove build artifacts
- document the new clean scripts in the README

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878e1a1a1888325953f0bb589165ef1