### PR TITLE
Add disk I/O limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# autogitpull
+#autogitpull
 Automatic Git Puller & Monitor
 
 ## Dependencies
@@ -142,7 +142,7 @@ valgrind ./build/memory_leak_test
 Valgrind should finish with the message `All heap blocks were freed -- no leaks
 are possible`.
 
-Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--recursive] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <mask>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--cli] [--silent] [--force-pull] [--help]`
+Usage: `autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--recursive] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <mask>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--download-limit <KB/s>] [--upload-limit <KB/s>] [--disk-limit <KB/s>] [--cli] [--silent] [--force-pull] [--help]`
 
 Most options have single-letter shorthands. Run `autogitpull --help` to see a concise list.
 
@@ -175,6 +175,7 @@ Available options:
 - `--no-mem-tracker` – disable memory usage display in the TUI.
 - `--no-thread-tracker` – disable thread count display in the TUI.
 - `--net-tracker` – show total network usage since startup.
+- `--disk-limit <KB/s>` – throttle disk reads and writes.
 - `--cli` – output text updates to stdout instead of the TUI.
 - `--silent` – disable all console output; only logs are written.
 - `--force-pull` – discard local changes when pulling updates.

--- a/git_utils.hpp
+++ b/git_utils.hpp
@@ -125,7 +125,7 @@ bool has_uncommitted_changes(const fs::path& repo);
 int try_pull(const fs::path& repo, std::string& out_pull_log,
              const std::function<void(int)>* progress_cb = nullptr, bool use_credentials = false,
              bool* auth_failed = nullptr, size_t down_limit_kbps = 0, size_t up_limit_kbps = 0,
-             bool force_pull = false);
+             size_t disk_limit_kbps = 0, bool force_pull = false);
 
 } // namespace git
 

--- a/resource_utils.hpp
+++ b/resource_utils.hpp
@@ -34,6 +34,14 @@ void init_network_usage();
  *         the call to @ref init_network_usage. */
 NetUsage get_network_usage();
 
+struct DiskUsage {
+    std::size_t read_bytes;
+    std::size_t write_bytes;
+};
+
+void init_disk_usage();
+DiskUsage get_disk_usage();
+
 } // namespace procutil
 
 #endif // RESOURCE_UTILS_HPP

--- a/tests/memory_leak.cpp
+++ b/tests/memory_leak.cpp
@@ -17,7 +17,7 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
                 std::atomic<bool>& running, std::string& action, std::mutex& action_mtx,
                 bool include_private, const fs::path& log_dir, bool check_only, bool hash_check,
                 size_t concurrency, int cpu_percent_limit, size_t mem_limit, size_t down_limit,
-                size_t up_limit, bool silent, bool force_pull);
+                size_t up_limit, size_t disk_limit, bool silent, bool force_pull);
 
 TEST_CASE("scan_repos memory stability") {
     git::GitInitGuard guard;
@@ -46,7 +46,7 @@ TEST_CASE("scan_repos memory stability") {
         scanning = true;
         running = true;
         scan_repos(repos, infos, skip, mtx, scanning, running, action, action_mtx, false,
-                   fs::path(), true, true, 1, 0, 0, 0, 0, false, false);
+                   fs::path(), true, true, 1, 0, 0, 0, 0, 0, false, false);
         size_t mem = procutil::get_memory_usage_mb();
         if (i == 0)
             baseline = mem;


### PR DESCRIPTION
## Summary
- extend CLI parser with `--disk-limit` to limit disk throughput
- throttle disk writes/reads in `git_utils` using new resource helpers
- document disk limit usage
- test new argument parsing

## Testing
- `make lint`
- `npm run format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6878e057a5188325ad8752e563b797d8