### PR TITLE
Place build artifacts under dist directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,15 @@ FORMAT_FILES = $(SRC) include/*.hpp
 all: autogitpull
 
 autogitpull: $(OBJ)
-	$(CXX) $(CXXFLAGS) $(OBJ) $(LDFLAGS) -o $@
+	mkdir -p dist
+	$(CXX) $(CXXFLAGS) $(OBJ) $(LDFLAGS) -o dist/autogitpull
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(OBJ) autogitpull
+	rm -f $(OBJ)
+	rm -rf dist
 
 lint:
 	clang-format --dry-run --Werror $(FORMAT_FILES)

--- a/readme.md
+++ b/readme.md
@@ -60,8 +60,8 @@ succeeds without manual tweaks.
 
 Run `make` (Linux/macOS), `scripts/compile.bat` (MinGW) or `scripts/compile-cl.bat` (MSVC) to
 build the project. `scripts/compile.bat` invokes `scripts/install_libgit2_mingw.bat` when
-`libgit2` is missing. The binary is produced as `autogitpull` (or
-`autogitpull.exe` on Windows).
+`libgit2` is missing. The binary is produced in `dist` as `dist/autogitpull` (or
+`dist/autogitpull.exe` on Windows).
 
 The repository also ships with `scripts/compile.sh` for Unix-like environments which
 will attempt to install a C++ compiler if one isn't present. Windows users get
@@ -76,7 +76,7 @@ generated binary, object files and the `build` directory.
 
 The scripts `scripts/compile-debug.sh`, `scripts/compile-debug.bat` and `scripts/compile-debug-cl.bat`
 compile the program with AddressSanitizer and debug information enabled. They
-produce `autogitpull_debug` (or `autogitpull_debug.exe` on Windows). Use these
+produce `dist/autogitpull_debug` (or `dist/autogitpull_debug.exe` on Windows). Use these
 builds when running leak detection tools:
 
 ```bash
@@ -96,13 +96,13 @@ On Linux with `g++`:
 g++ -std=c++20 autogitpull.cpp git_utils.cpp tui.cpp logger.cpp \
     $(pkg-config --cflags libgit2) \
     $(pkg-config --static --libs libgit2 2>/dev/null || pkg-config --libs libgit2) \
-    -pthread -o autogitpull
+    -pthread -o dist/autogitpull
 ```
 
 On macOS with `clang++`:
 
 ```bash
-clang++ -std=c++20 autogitpull.cpp git_utils.cpp tui.cpp logger.cpp $(pkg-config --cflags --libs libgit2) -pthread -o autogitpull
+clang++ -std=c++20 autogitpull.cpp git_utils.cpp tui.cpp logger.cpp $(pkg-config --cflags --libs libgit2) -pthread -o dist/autogitpull
 ```
 
 On Windows with MSVC's `cl`:

--- a/scripts/compile-cl.bat
+++ b/scripts/compile-cl.bat
@@ -16,6 +16,7 @@ if not exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
 set "INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
 set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
+if not exist dist mkdir dist
 cl /nologo /std:c++20 /EHsc /I"%INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
-    "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /Feautogitpull.exe
+    "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /Fedist\autogitpull.exe
 endlocal

--- a/scripts/compile-debug-cl.bat
+++ b/scripts/compile-debug-cl.bat
@@ -16,7 +16,9 @@ if not exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
 set "INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
 set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
+if not exist dist mkdir dist
+
 cl /nologo /std:c++20 /EHsc /Zi /I"%INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
-    "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /fsanitize=address /Feautogitpull_debug.exe
+    "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /fsanitize=address /Fedist\autogitpull_debug.exe
 
 endlocal

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -33,6 +33,8 @@ set "CXX=clang++"
 set "CXXFLAGS=-std=c++20 -O0 -g -fsanitize=address"
 set "LDFLAGS=-fsanitize=address"
 
+if not exist dist mkdir dist
+
 %CXX% %CXXFLAGS% ^
     -I"%LIBGIT2_INC%" -Iinclude ^
     src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\debug_utils.cpp ^
@@ -40,13 +42,13 @@ set "LDFLAGS=-fsanitize=address"
     "%LIBGIT2_LIB%\libgit2.a" ^
     -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp ^
     %LDFLAGS% ^
-    -o autogitpull_debug.exe
+    -o dist\autogitpull_debug.exe
 
 if errorlevel 1 (
     echo Build failed.
     exit /b 1
 ) else (
-    echo Build succeeded: autogitpull_debug.exe
+    echo Build succeeded: dist\autogitpull_debug.exe
 )
 
 endlocal

--- a/scripts/compile-debug.sh
+++ b/scripts/compile-debug.sh
@@ -11,8 +11,9 @@ if ! command -v "$CXX" >/dev/null; then
 fi
 PKG_CFLAGS="$(pkg-config --cflags libgit2 2>/dev/null || echo '') $(pkg-config --cflags yaml-cpp 2>/dev/null || echo '')"
 PKG_LIBS="$(pkg-config --libs libgit2 2>/dev/null || echo '-lgit2') $(pkg-config --libs yaml-cpp 2>/dev/null || echo '-lyaml-cpp')"
+mkdir -p dist
 $CXX -std=c++20 -O0 -g -fsanitize=address -Iinclude $PKG_CFLAGS \
     src/autogitpull.cpp src/git_utils.cpp src/tui.cpp src/logger.cpp \
     src/resource_utils.cpp src/system_utils.cpp src/time_utils.cpp \
     src/config_utils.cpp src/debug_utils.cpp $PKG_LIBS \
-    -fsanitize=address -o autogitpull_debug
+    -fsanitize=address -o dist/autogitpull_debug

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -23,7 +23,8 @@ if not exist "%LIBGIT2_LIB%\libgit2.a" (
     if errorlevel 1 exit /b 1
 )
 
-g++ -std=c++20 -static -I"%LIBGIT2_INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp -o autogitpull.exe
+if not exist dist mkdir dist
+g++ -std=c++20 -static -I"%LIBGIT2_INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp -o dist\autogitpull.exe
 
 endlocal
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -11,7 +11,8 @@ if ! command -v "$CXX" >/dev/null; then
 fi
 PKG_CFLAGS="$(pkg-config --cflags libgit2 2>/dev/null || echo '') $(pkg-config --cflags yaml-cpp 2>/dev/null || echo '')"
 PKG_LIBS="$(pkg-config --libs libgit2 2>/dev/null || echo '-lgit2') $(pkg-config --libs yaml-cpp 2>/dev/null || echo '-lyaml-cpp')"
+mkdir -p dist
 $CXX -std=c++20 -Iinclude $PKG_CFLAGS \
     src/autogitpull.cpp src/git_utils.cpp src/tui.cpp src/logger.cpp \
     src/resource_utils.cpp src/system_utils.cpp src/time_utils.cpp \
-    src/config_utils.cpp src/debug_utils.cpp $PKG_LIBS -o autogitpull
+    src/config_utils.cpp src/debug_utils.cpp $PKG_LIBS -o dist/autogitpull

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -1,1 +1,1 @@
-autogitpull.exe "C:\path\to\your\dev"
+dist\autogitpull.exe "C:\path\to\your\dev"


### PR DESCRIPTION
## Summary
- output final binary to `dist/` in Makefile
- update clean rule to remove the new folder
- adjust compile scripts to place executables in `dist/`
- update run script and readme for new locations
- ignore the `dist/` folder in version control

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687915dc13708325a350e1381f33fc73