### PR TITLE
Move clean scripts and update README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,8 +69,8 @@ will attempt to install a C++ compiler if one isn't present. Windows users get
 `scripts/install_deps.bat`, `scripts/install_libgit2_mingw.bat` and `scripts/run.bat`.
 
 Clean up intermediate files with `make clean`. You can also run
-`./clean.sh` on Unix-like systems or `clean.bat` on Windows to remove the
-generated binary, object files and the `build` directory.
+`scripts/clean.sh` on Unix-like systems or `scripts/clean.bat` on Windows to remove the
+generated binary, object files and the `build` and `dist` directories.
 
 ### Debug builds for leak analysis
 

--- a/scripts/clean.bat
+++ b/scripts/clean.bat
@@ -7,3 +7,6 @@ for %%f in (*.o *.obj) do (
 if exist build (
     rmdir /s /q build
 )
+if exist dist (
+    rmdir /s /q dist
+)

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -5,3 +5,6 @@ rm -f *.o *.obj
 if [ -d build ]; then
   rm -rf build
 fi
+if [ -d dist ]; then
+  rm -rf dist
+fi


### PR DESCRIPTION
## Summary
- move `clean.sh` and `clean.bat` to `scripts/`
- make them also remove the `dist` directory
- update documentation to point to new script locations

## Testing
- `make lint`
- `make test` *(fails: undefined reference)*

------
https://chatgpt.com/codex/tasks/task_e_68791cff256c8325b771313f7d49467a