### PR TITLE
Adjust libgit2 paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 dist/
+libs/

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -17,8 +17,8 @@ if errorlevel 1 (
 
 rem ──────────────────────────────────────────────────────────────
 rem 2. libgit2 paths
-set "LIBGIT2_INC=libgit2_install\include"
-set "LIBGIT2_LIB=libgit2_install\lib"
+set "LIBGIT2_INC=libs\libgit2_install\include"
+set "LIBGIT2_LIB=libs\libgit2_install\lib"
 
 if not exist "%LIBGIT2_LIB%\libgit2.a" (
     call "%SCRIPT_DIR%install_libgit2_mingw.bat"

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -14,8 +14,8 @@ if errorlevel 1 (
 )
 
 rem Path to libgit2 built with install_libgit2_mingw.bat
-set "LIBGIT2_INC=libgit2\_install\include"
-set "LIBGIT2_LIB=libgit2\_install\lib"
+set "LIBGIT2_INC=libs\libgit2_install\include"
+set "LIBGIT2_LIB=libs\libgit2_install\lib"
 
 rem Build libgit2 if not already installed
 if not exist "%LIBGIT2_LIB%\libgit2.a" (

--- a/scripts/install_libgit2_mingw.bat
+++ b/scripts/install_libgit2_mingw.bat
@@ -19,12 +19,14 @@ if errorlevel 1 (
 )
 
 REM Download libgit2 if not present
-if not exist libgit2 (
+if not exist libs mkdir libs
+REM Clone libgit2 into libs\libgit2 if missing
+if not exist libs\libgit2 (
     echo Cloning libgit2...
-    git clone --depth 1 https://github.com/libgit2/libgit2
+    git clone --depth 1 https://github.com/libgit2/libgit2 libs\libgit2
 )
 
-cd libgit2
+cd libs\libgit2
 
 REM Clean any old builds
 if exist build rmdir /s /q build
@@ -33,7 +35,7 @@ mkdir build
 cd build
 
 REM Configure for static build with MinGW
-cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=..\_install ..
+cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=..\libgit2_install ..
 if errorlevel 1 (
     echo CMake configuration failed!
     exit /b 1
@@ -52,5 +54,5 @@ if errorlevel 1 (
     exit /b 1
 )
 
-echo libgit2 built and installed to libgit2\_install
+echo libgit2 built and installed to libs\libgit2_install
 cd ..\..


### PR DESCRIPTION
## Summary
- store libgit2 sources under `libs/` when building on Windows
- install libgit2 into `libs/libgit2_install`
- update compile scripts to include the new install path
- ignore the libs directory

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68791d182fd08325aeb7f99457cf7d1a