### PR TITLE
Remove ThreadGuard copy and move

### DIFF
--- a/include/thread_utils.hpp
+++ b/include/thread_utils.hpp
@@ -9,6 +9,10 @@ struct ThreadGuard {
     std::thread t;
     ThreadGuard() = default;
     explicit ThreadGuard(std::thread&& t_) : t(std::move(t_)) {}
+    ThreadGuard(const ThreadGuard&) = delete;
+    ThreadGuard& operator=(const ThreadGuard&) = delete;
+    ThreadGuard(ThreadGuard&&) = delete;
+    ThreadGuard& operator=(ThreadGuard&&) = delete;
     ~ThreadGuard() {
         if (t.joinable())
             t.join();


### PR DESCRIPTION
## Summary
- delete ThreadGuard copy/move constructors and assignments

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68792b0b2e488325bbc59a78ae216a3a