### PR TITLE
Ensure max-depth implies recursive scan

### DIFF
--- a/examples/example-config.json
+++ b/examples/example-config.json
@@ -27,6 +27,7 @@
   "cli": false,
   "silent": false,
   "recursive": false,
+  "max-depth": 0,
   "force-pull": false,
   "discard-dirty": false,
   "single-run": false,

--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -27,6 +27,7 @@ disk-limit: 0
 cli: false
 silent: false
 recursive: false
+max-depth: 0
 force-pull: false
 discard-dirty: false
 single-run: false

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ and shows progress either in an interactive TUI or with plain console output.
 
 ## Usage
 
-`autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--ignore <dir>] [--recursive] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <mask>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--download-limit <KB/s>] [--upload-limit <KB/s>] [--disk-limit <KB/s>] [--cli] [--single-run] [--silent] [--force-pull] [--debug-memory] [--dump-state] [--dump-large <n>] [--help]`
+`autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--ignore <dir>] [--recursive] [--max-depth <n>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <mask>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--download-limit <KB/s>] [--upload-limit <KB/s>] [--disk-limit <KB/s>] [--cli] [--single-run] [--silent] [--force-pull] [--debug-memory] [--dump-state] [--dump-large <n>] [--help]`
 
 Most options have single-letter shorthands. Run `autogitpull --help` to see a concise list.
 
@@ -31,6 +31,7 @@ Available options:
 - `--log-file <path>` – file for general messages.
 - `--ignore <dir>` – skip the given directory when collecting repositories. This option may be repeated.
 - `--recursive` – search subdirectories recursively for repositories.
+- `--max-depth <n>` – limit recursion depth; implies `--recursive`.
 - `--log-level <level>` – minimum message level written to the log (`DEBUG`, `INFO`, `WARNING`, `ERROR`).
 - `--verbose` – shorthand for `--log-level DEBUG`.
 - `--concurrency <n>` – number of repositories processed in parallel (default: hardware concurrency).

--- a/src/autogitpull.cpp
+++ b/src/autogitpull.cpp
@@ -751,6 +751,8 @@ Options parse_options(int argc, char* argv[]) {
         if (!ok)
             throw std::runtime_error("Invalid value for --max-depth");
     }
+    if (opts.max_depth > 0)
+        opts.recursive_scan = true;
     opts.cpu_tracker = !cfg_flag("--no-cpu-tracker");
     opts.mem_tracker = !cfg_flag("--no-mem-tracker");
     opts.thread_tracker = !cfg_flag("--no-thread-tracker");


### PR DESCRIPTION
## Summary
- enable recursive scanning when `--max-depth` is set
- document `--max-depth` option and show in examples

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68792fbb617883258cf61bfdaf982f15