### PR TITLE
Fix compile scripts include paths

### DIFF
--- a/scripts/compile-cl.bat
+++ b/scripts/compile-cl.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 set "SCRIPT_DIR=%~dp0"
+set "ROOT_DIR=%SCRIPT_DIR%.."
+cd /d "%ROOT_DIR%"
 
 where cl >nul 2>nul
 if errorlevel 1 (

--- a/scripts/compile-debug-cl.bat
+++ b/scripts/compile-debug-cl.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 set "SCRIPT_DIR=%~dp0"
+set "ROOT_DIR=%SCRIPT_DIR%.."
+cd /d "%ROOT_DIR%"
 
 where cl >nul 2>nul
 if errorlevel 1 (

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 set "SCRIPT_DIR=%~dp0"
+set "ROOT_DIR=%SCRIPT_DIR%.."
+cd /d "%ROOT_DIR%"
 
 rem ──────────────────────────────────────────────────────────────
 rem 1. Ensure clang/clang++ is available
@@ -17,8 +19,8 @@ if errorlevel 1 (
 
 rem ──────────────────────────────────────────────────────────────
 rem 2. libgit2 paths
-set "LIBGIT2_INC=libs\libgit2\_install\include"
-set "LIBGIT2_LIB=libs\libgit2\_install\lib"
+set "LIBGIT2_INC=%ROOT_DIR%\libs\libgit2\_install\include"
+set "LIBGIT2_LIB=%ROOT_DIR%\libs\libgit2\_install\lib"
 
 if not exist "%LIBGIT2_LIB%\libgit2.a" (
     call "%SCRIPT_DIR%install_libgit2_mingw.bat"

--- a/scripts/compile-debug.sh
+++ b/scripts/compile-debug.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
 CXX=${CXX:-g++}
 if ! command -v "$CXX" >/dev/null; then
     if command -v clang++ >/dev/null; then

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 set "SCRIPT_DIR=%~dp0"
+set "ROOT_DIR=%SCRIPT_DIR%.."
+cd /d "%ROOT_DIR%"
 
 where g++ >nul 2>nul
 if errorlevel 1 (
@@ -14,8 +16,8 @@ if errorlevel 1 (
 )
 
 rem Path to libgit2 built with install_libgit2_mingw.bat
-set "LIBGIT2_INC=..\libs\libgit2\_install\include"
-set "LIBGIT2_LIB=..\libs\libgit2\_install\lib"
+set "LIBGIT2_INC=%ROOT_DIR%\libs\libgit2\_install\include"
+set "LIBGIT2_LIB=%ROOT_DIR%\libs\libgit2\_install\lib"
 
 rem Build libgit2 if not already installed
 if not exist "%LIBGIT2_LIB%\libgit2.a" (
@@ -24,7 +26,7 @@ if not exist "%LIBGIT2_LIB%\libgit2.a" (
 )
 
 if not exist dist mkdir dist
-g++ -std=c++20 -static -I"%LIBGIT2_INC%" -Iinclude ..\src\autogitpull.cpp ..\src\git_utils.cpp ..\src\tui.cpp ..\src\logger.cpp ..\src\resource_utils.cpp ..\src\system_utils.cpp ..\src\time_utils.cpp ..\src\config_utils.cpp ..\src\debug_utils.cpp ..\src\parse_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp -o ..\dist\autogitpull.exe
+g++ -std=c++20 -static -I"%LIBGIT2_INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp src\parse_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp -o dist\autogitpull.exe
 
 endlocal
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
 CXX=${CXX:-g++}
 if ! command -v "$CXX" >/dev/null; then
     if command -v clang++ >/dev/null; then


### PR DESCRIPTION
## Summary
- ensure Windows and Unix compile scripts run from repo root
- update script paths for headers and sources

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687931e4d66883258ac27cd423f271e7