### PR TITLE
Add startup PID lock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(autogitpull_lib STATIC
     src/time_utils.cpp
     src/config_utils.cpp
     src/debug_utils.cpp
+    src/lock_utils.cpp
     src/options.cpp
     src/parse_utils.cpp)
 target_include_directories(autogitpull_lib PUBLIC ${CMAKE_SOURCE_DIR}/include)
@@ -71,8 +72,9 @@ add_executable(memory_leak_test
     src/system_utils.cpp
     src/time_utils.cpp
     src/config_utils.cpp
-    src/debug_utils.cpp
     src/parse_utils.cpp
+    src/debug_utils.cpp
+    src/lock_utils.cpp
     src/tui.cpp)
 target_include_directories(memory_leak_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(memory_leak_test PRIVATE AUTOGITPULL_NO_MAIN)

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ SRC = \
     src/time_utils.cpp \
     src/config_utils.cpp \
     src/debug_utils.cpp \
+    src/lock_utils.cpp \
     src/options.cpp \
     src/parse_utils.cpp
 OBJ = $(SRC:.cpp=.o)

--- a/include/lock_utils.hpp
+++ b/include/lock_utils.hpp
@@ -1,0 +1,28 @@
+#ifndef LOCK_UTILS_HPP
+#define LOCK_UTILS_HPP
+#include <filesystem>
+
+namespace lockfile {
+
+class PidLock {
+  public:
+    explicit PidLock(const std::filesystem::path& dir);
+    PidLock(const PidLock&) = delete;
+    PidLock& operator=(const PidLock&) = delete;
+    ~PidLock();
+
+    bool acquired() const { return acquired_; }
+
+  private:
+    std::filesystem::path path_;
+#ifdef _WIN32
+    void* handle_;
+#else
+    int fd_;
+#endif
+    bool acquired_;
+};
+
+} // namespace lockfile
+
+#endif // LOCK_UTILS_HPP

--- a/scripts/compile-cl.bat
+++ b/scripts/compile-cl.bat
@@ -17,7 +17,8 @@ set "INC=%VCPKG_ROOT%\installed\x64-windows-static\include"
 set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
 if not exist dist mkdir dist
-cl /nologo /std:c++20 /EHsc /I"%INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
+cl /nologo /std:c++20 /EHsc /I"%INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^    src\lock_utils.cpp ^
+
     src\options.cpp src\parse_utils.cpp ^
     "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /Fedist\autogitpull.exe
 endlocal

--- a/scripts/compile-debug-cl.bat
+++ b/scripts/compile-debug-cl.bat
@@ -18,7 +18,8 @@ set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
 if not exist dist mkdir dist
 
-cl /nologo /std:c++20 /EHsc /Zi /I"%INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
+cl /nologo /std:c++20 /EHsc /Zi /I"%INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^    src\lock_utils.cpp ^
+
     src\options.cpp src\parse_utils.cpp ^
     "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /fsanitize=address /Fedist\autogitpull_debug.exe
 

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -37,7 +37,7 @@ if not exist dist mkdir dist
 
 %CXX% %CXXFLAGS% ^
     -I"%LIBGIT2_INC%" -Iinclude ^
-    src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\debug_utils.cpp src\parse_utils.cpp ^
+    src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\debug_utils.cpp src\lock_utils.cpp src\parse_utils.cpp ^
     src\config_utils.cpp src\options.cpp ^
     "%LIBGIT2_LIB%\libgit2.a" ^
     -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp ^

--- a/scripts/compile-debug.sh
+++ b/scripts/compile-debug.sh
@@ -15,6 +15,6 @@ mkdir -p dist
 $CXX -std=c++20 -O0 -g -fsanitize=address -Iinclude $PKG_CFLAGS \
     src/autogitpull.cpp src/git_utils.cpp src/tui.cpp src/logger.cpp \
     src/resource_utils.cpp src/system_utils.cpp src/time_utils.cpp \
-    src/config_utils.cpp src/debug_utils.cpp src/options.cpp \
+    src/config_utils.cpp src/debug_utils.cpp src/lock_utils.cpp src/options.cpp \
     src/parse_utils.cpp $PKG_LIBS \
     -fsanitize=address -o dist/autogitpull_debug

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -24,7 +24,7 @@ if not exist "%LIBGIT2_LIB%\libgit2.a" (
 )
 
 if not exist dist mkdir dist
-g++ -std=c++20 -static -I"%LIBGIT2_INC%" -Iinclude ..\src\autogitpull.cpp ..\src\git_utils.cpp ..\src\tui.cpp ..\src\logger.cpp ..\src\resource_utils.cpp ..\src\system_utils.cpp ..\src\time_utils.cpp ..\src\config_utils.cpp ..\src\debug_utils.cpp ..\src\options.cpp ..\src\parse_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp -o ..\dist\autogitpull.exe
+g++ -std=c++20 -static -I"%LIBGIT2_INC%" -Iinclude ..\src\autogitpull.cpp ..\src\git_utils.cpp ..\src\tui.cpp ..\src\logger.cpp ..\src\resource_utils.cpp ..\src\system_utils.cpp ..\src\time_utils.cpp ..\src\config_utils.cpp ..\src\debug_utils.cpp ..\src\lock_utils.cpp ..\src\options.cpp ..\src\parse_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp -o ..\dist\autogitpull.exe
 
 endlocal
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -15,5 +15,5 @@ mkdir -p dist
 $CXX -std=c++20 -Iinclude $PKG_CFLAGS \
     src/autogitpull.cpp src/git_utils.cpp src/tui.cpp src/logger.cpp \
     src/resource_utils.cpp src/system_utils.cpp src/time_utils.cpp \
-    src/config_utils.cpp src/debug_utils.cpp src/options.cpp \
+    src/config_utils.cpp src/debug_utils.cpp src/lock_utils.cpp src/options.cpp \
     src/parse_utils.cpp $PKG_LIBS -o dist/autogitpull

--- a/src/autogitpull.cpp
+++ b/src/autogitpull.cpp
@@ -28,6 +28,7 @@
 #include "thread_utils.hpp"
 #include "config_utils.hpp"
 #include "debug_utils.hpp"
+#include "lock_utils.hpp"
 #include "parse_utils.hpp"
 #include "options.hpp"
 
@@ -544,6 +545,11 @@ int run_event_loop(const Options& opts) {
         return 0;
     if (!fs::exists(opts.root) || !fs::is_directory(opts.root))
         throw std::runtime_error("Root path does not exist or is not a directory.");
+    lockfile::PidLock lock(opts.root);
+    if (!lock.acquired()) {
+        std::cerr << "Another instance is already running for " << opts.root << "\n";
+        return 1;
+    }
     if (opts.cpu_core_mask != 0)
         procutil::set_cpu_affinity(opts.cpu_core_mask);
     procutil::set_cpu_poll_interval(opts.cpu_poll_sec);

--- a/src/lock_utils.cpp
+++ b/src/lock_utils.cpp
@@ -1,0 +1,60 @@
+#include "lock_utils.hpp"
+#include <string>
+#include <cstring>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace lockfile {
+
+PidLock::PidLock(const std::filesystem::path& dir)
+    : path_(dir / "autogitpull.pid"), acquired_(false)
+#ifdef _WIN32
+      ,
+      handle_(nullptr)
+#else
+      ,
+      fd_(-1)
+#endif
+{
+#ifdef _WIN32
+    handle_ = CreateFileW(path_.wstring().c_str(), GENERIC_WRITE, 0, NULL, CREATE_NEW,
+                          FILE_ATTRIBUTE_NORMAL, NULL);
+    if (handle_ != INVALID_HANDLE_VALUE) {
+        DWORD pid = GetCurrentProcessId();
+        char buf[32];
+        DWORD written = 0;
+        _snprintf_s(buf, sizeof(buf), _TRUNCATE, "%lu", static_cast<unsigned long>(pid));
+        WriteFile(handle_, buf, static_cast<DWORD>(strlen(buf)), &written, NULL);
+        acquired_ = true;
+    } else {
+        handle_ = INVALID_HANDLE_VALUE;
+    }
+#else
+    fd_ = open(path_.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0644);
+    if (fd_ >= 0) {
+        std::string pid = std::to_string(getpid());
+        write(fd_, pid.c_str(), pid.size());
+        acquired_ = true;
+    }
+#endif
+}
+
+PidLock::~PidLock() {
+    if (!acquired_)
+        return;
+#ifdef _WIN32
+    if (handle_ != INVALID_HANDLE_VALUE)
+        CloseHandle(handle_);
+#else
+    if (fd_ >= 0)
+        close(fd_);
+#endif
+    std::error_code ec;
+    std::filesystem::remove(path_, ec);
+}
+
+} // namespace lockfile


### PR DESCRIPTION
## Summary
- implement PID file locking via new `lock_utils` module
- fail fast if another instance is running
- compile new source file

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68793eb2346483258211e8951ad59f38