### PR TITLE
Add Linux daemon support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ add_library(autogitpull_lib STATIC
     src/options.cpp
     src/parse_utils.cpp
     src/lock_utils.cpp)
+if(NOT WIN32)
+    target_sources(autogitpull_lib PRIVATE src/linux_daemon.cpp)
+endif()
 target_include_directories(autogitpull_lib PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(autogitpull_lib PRIVATE PkgConfig::LIBGIT2 yaml-cpp nlohmann_json::nlohmann_json pthread)
 
@@ -76,6 +79,9 @@ add_executable(memory_leak_test
     src/parse_utils.cpp
     src/lock_utils.cpp
     src/tui.cpp)
+if(NOT WIN32)
+    target_sources(memory_leak_test PRIVATE src/linux_daemon.cpp)
+endif()
 target_include_directories(memory_leak_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(memory_leak_test PRIVATE AUTOGITPULL_NO_MAIN)
 target_compile_options(memory_leak_test PRIVATE -fsanitize=address)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ SRC = \
     src/debug_utils.cpp \
     src/options.cpp \
     src/parse_utils.cpp \
-    src/lock_utils.cpp
+    src/lock_utils.cpp \
+    src/linux_daemon.cpp
 OBJ = $(SRC:.cpp=.o)
 FORMAT_FILES = $(SRC) include/*.hpp
 

--- a/include/linux_daemon.hpp
+++ b/include/linux_daemon.hpp
@@ -1,0 +1,17 @@
+#ifndef LINUX_DAEMON_HPP
+#define LINUX_DAEMON_HPP
+
+#include <string>
+
+namespace procutil {
+
+bool daemonize();
+
+bool create_service_unit(const std::string& name, const std::string& exec_path,
+                         const std::string& config_file, const std::string& user = "root");
+
+bool remove_service_unit(const std::string& name);
+
+} // namespace procutil
+
+#endif // LINUX_DAEMON_HPP

--- a/include/options.hpp
+++ b/include/options.hpp
@@ -43,6 +43,9 @@ struct Options {
     bool dump_state = false;
     size_t dump_threshold = 0;
     bool single_run = false;
+    bool install_daemon = false;
+    bool uninstall_daemon = false;
+    std::string daemon_config;
     bool show_help = false;
     bool print_version = false;
 };

--- a/scripts/compile-cl.bat
+++ b/scripts/compile-cl.bat
@@ -18,6 +18,6 @@ set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
 if not exist dist mkdir dist
 cl /nologo /std:c++20 /EHsc /I"%INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
-    src\options.cpp src\parse_utils.cpp src\lock_utils.cpp ^
+    src\options.cpp src\parse_utils.cpp src\lock_utils.cpp src\linux_daemon.cpp ^
     "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /Fedist\autogitpull.exe
 endlocal

--- a/scripts/compile-debug-cl.bat
+++ b/scripts/compile-debug-cl.bat
@@ -19,7 +19,7 @@ set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 if not exist dist mkdir dist
 
 cl /nologo /std:c++20 /EHsc /Zi /I"%INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
-    src\options.cpp src\parse_utils.cpp src\lock_utils.cpp ^
+    src\options.cpp src\parse_utils.cpp src\lock_utils.cpp src\linux_daemon.cpp ^
     "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /fsanitize=address /Fedist\autogitpull_debug.exe
 
 endlocal

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -37,7 +37,7 @@ if not exist dist mkdir dist
 
 %CXX% %CXXFLAGS% ^
     -I"%LIBGIT2_INC%" -Iinclude ^
-    src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\debug_utils.cpp src\parse_utils.cpp src\lock_utils.cpp ^
+    src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\debug_utils.cpp src\parse_utils.cpp src\lock_utils.cpp src\linux_daemon.cpp ^
     src\config_utils.cpp src\options.cpp ^
     "%LIBGIT2_LIB%\libgit2.a" ^
     -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp ^

--- a/scripts/compile-debug.sh
+++ b/scripts/compile-debug.sh
@@ -16,5 +16,5 @@ $CXX -std=c++20 -O0 -g -fsanitize=address -Iinclude $PKG_CFLAGS \
     src/autogitpull.cpp src/git_utils.cpp src/tui.cpp src/logger.cpp \
     src/resource_utils.cpp src/system_utils.cpp src/time_utils.cpp \
     src/config_utils.cpp src/debug_utils.cpp src/options.cpp \
-    src/parse_utils.cpp src/lock_utils.cpp $PKG_LIBS \
+    src/parse_utils.cpp src/lock_utils.cpp src/linux_daemon.cpp $PKG_LIBS \
     -fsanitize=address -o dist/autogitpull_debug

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -24,7 +24,7 @@ if not exist "%LIBGIT2_LIB%\libgit2.a" (
 )
 
 if not exist dist mkdir dist
-g++ -std=c++20 -static -I"%LIBGIT2_INC%" -Iinclude ..\src\autogitpull.cpp ..\src\git_utils.cpp ..\src\tui.cpp ..\src\logger.cpp ..\src\resource_utils.cpp ..\src\system_utils.cpp ..\src\time_utils.cpp ..\src\config_utils.cpp ..\src\debug_utils.cpp ..\src\options.cpp ..\src\parse_utils.cpp ..\src\lock_utils.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp -o ..\dist\autogitpull.exe
+ g++ -std=c++20 -static -I"%LIBGIT2_INC%" -Iinclude ..\src\autogitpull.cpp ..\src\git_utils.cpp ..\src\tui.cpp ..\src\logger.cpp ..\src\resource_utils.cpp ..\src\system_utils.cpp ..\src\time_utils.cpp ..\src\config_utils.cpp ..\src\debug_utils.cpp ..\src\options.cpp ..\src\parse_utils.cpp ..\src\lock_utils.cpp ..\src\linux_daemon.cpp "%LIBGIT2_LIB%\libgit2.a" -lz -lssh2 -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -lyaml-cpp -o ..\dist\autogitpull.exe
 
 endlocal
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -16,4 +16,5 @@ $CXX -std=c++20 -Iinclude $PKG_CFLAGS \
     src/autogitpull.cpp src/git_utils.cpp src/tui.cpp src/logger.cpp \
     src/resource_utils.cpp src/system_utils.cpp src/time_utils.cpp \
     src/config_utils.cpp src/debug_utils.cpp src/options.cpp \
-    src/parse_utils.cpp src/lock_utils.cpp $PKG_LIBS -o dist/autogitpull
+    src/parse_utils.cpp src/lock_utils.cpp src/linux_daemon.cpp \
+    $PKG_LIBS -o dist/autogitpull

--- a/src/linux_daemon.cpp
+++ b/src/linux_daemon.cpp
@@ -1,0 +1,82 @@
+#include "linux_daemon.hpp"
+#include <fstream>
+#ifndef _WIN32
+#include <unistd.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#endif
+
+namespace procutil {
+
+#ifndef _WIN32
+bool daemonize() {
+    pid_t pid = fork();
+    if (pid < 0)
+        return false;
+    if (pid > 0)
+        _exit(0);
+
+    if (setsid() < 0)
+        return false;
+
+    signal(SIGCHLD, SIG_IGN);
+    signal(SIGHUP, SIG_IGN);
+    pid = fork();
+    if (pid < 0)
+        return false;
+    if (pid > 0)
+        _exit(0);
+
+    umask(0);
+    if (chdir("/") != 0)
+        return false;
+
+    close(STDIN_FILENO);
+    close(STDOUT_FILENO);
+    close(STDERR_FILENO);
+
+    open("/dev/null", O_RDONLY);
+    open("/dev/null", O_WRONLY);
+    open("/dev/null", O_RDWR);
+    return true;
+}
+
+static std::string unit_path(const std::string& name) {
+    return "/etc/systemd/system/" + name + ".service";
+}
+
+bool create_service_unit(const std::string& name, const std::string& exec_path,
+                         const std::string& config_file, const std::string& user) {
+    std::ofstream out(unit_path(name));
+    if (!out.is_open())
+        return false;
+    out << "[Unit]\nDescription=autogitpull daemon\nAfter=network.target\n\n";
+    out << "[Service]\nType=simple\nUser=" << user << "\nExecStart=" << exec_path;
+    if (!config_file.empty())
+        out << " --daemon-config " << config_file;
+    out << "\nRestart=on-failure\n\n";
+    out << "[Install]\nWantedBy=multi-user.target\n";
+    out.close();
+    std::system("systemctl daemon-reload > /dev/null 2>&1");
+    return true;
+}
+
+bool remove_service_unit(const std::string& name) {
+    std::string path = unit_path(name);
+    std::remove(path.c_str());
+    std::system("systemctl daemon-reload > /dev/null 2>&1");
+    return true;
+}
+#else
+bool daemonize() { return false; }
+
+bool create_service_unit(const std::string&, const std::string&, const std::string&,
+                         const std::string&) {
+    return false;
+}
+
+bool remove_service_unit(const std::string&) { return false; }
+#endif
+
+} // namespace procutil

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -39,17 +39,18 @@ Options parse_options(int argc, char* argv[]) {
     }
 
     const std::set<std::string> known{
-        "--include-private", "--show-skipped",   "--show-version",      "--version",
-        "--interval",        "--refresh-rate",   "--cpu-poll",          "--mem-poll",
-        "--thread-poll",     "--log-dir",        "--log-file",          "--concurrency",
-        "--check-only",      "--no-hash-check",  "--log-level",         "--verbose",
-        "--max-threads",     "--cpu-percent",    "--cpu-cores",         "--mem-limit",
-        "--no-cpu-tracker",  "--no-mem-tracker", "--no-thread-tracker", "--help",
-        "--threads",         "--single-thread",  "--net-tracker",       "--download-limit",
-        "--upload-limit",    "--disk-limit",     "--max-depth",         "--cli",
-        "--single-run",      "--silent",         "--recursive",         "--config-yaml",
-        "--config-json",     "--ignore",         "--force-pull",        "--discard-dirty",
-        "--debug-memory",    "--dump-state",     "--dump-large"};
+        "--include-private",  "--show-skipped",   "--show-version",      "--version",
+        "--interval",         "--refresh-rate",   "--cpu-poll",          "--mem-poll",
+        "--thread-poll",      "--log-dir",        "--log-file",          "--concurrency",
+        "--check-only",       "--no-hash-check",  "--log-level",         "--verbose",
+        "--max-threads",      "--cpu-percent",    "--cpu-cores",         "--mem-limit",
+        "--no-cpu-tracker",   "--no-mem-tracker", "--no-thread-tracker", "--help",
+        "--threads",          "--single-thread",  "--net-tracker",       "--download-limit",
+        "--upload-limit",     "--disk-limit",     "--max-depth",         "--cli",
+        "--single-run",       "--silent",         "--recursive",         "--config-yaml",
+        "--config-json",      "--ignore",         "--force-pull",        "--discard-dirty",
+        "--debug-memory",     "--dump-state",     "--dump-large",        "--install-daemon",
+        "--uninstall-daemon", "--daemon-config"};
     const std::map<char, std::string> short_opts{
         {'p', "--include-private"}, {'k', "--show-skipped"}, {'v', "--show-version"},
         {'V', "--version"},         {'i', "--interval"},     {'r', "--refresh-rate"},
@@ -79,6 +80,14 @@ Options parse_options(int argc, char* argv[]) {
     opts.single_run = parser.has_flag("--single-run") || cfg_flag("--single-run");
     if (opts.single_run)
         opts.cli = true;
+    opts.install_daemon = parser.has_flag("--install-daemon") || cfg_flag("--install-daemon");
+    opts.uninstall_daemon = parser.has_flag("--uninstall-daemon") || cfg_flag("--uninstall-daemon");
+    if (parser.has_flag("--daemon-config") || cfg_opts.count("--daemon-config")) {
+        std::string val = parser.get_option("--daemon-config");
+        if (val.empty())
+            val = cfg_opt("--daemon-config");
+        opts.daemon_config = val;
+    }
     opts.silent = parser.has_flag("--silent") || cfg_flag("--silent");
     opts.recursive_scan = parser.has_flag("--recursive") || cfg_flag("--recursive");
     opts.show_help = parser.has_flag("--help");

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -362,6 +362,17 @@ TEST_CASE("ArgParser recursive flag") {
     REQUIRE(parser.has_flag("--recursive"));
 }
 
+TEST_CASE("ArgParser daemon flags") {
+    const char* argv[] = {"prog", "--install-daemon", "--daemon-config", "cfg"};
+    ArgParser parser(4, const_cast<char**>(argv),
+                     {"--install-daemon", "--uninstall-daemon", "--daemon-config"});
+    REQUIRE(parser.has_flag("--install-daemon"));
+    REQUIRE(parser.get_option("--daemon-config") == std::string("cfg"));
+    const char* argv2[] = {"prog", "--uninstall-daemon"};
+    ArgParser parser2(2, const_cast<char**>(argv2), {"--install-daemon", "--uninstall-daemon"});
+    REQUIRE(parser2.has_flag("--uninstall-daemon"));
+}
+
 TEST_CASE("YAML config loading") {
     fs::path cfg = fs::temp_directory_path() / "cfg.yaml";
     {


### PR DESCRIPTION
## Summary
- add `linux_daemon` helpers for daemonizing and systemd unit management
- expose daemon install options in CLI parsing
- compile new file via build scripts and CMake
- update Makefile and tests for new options

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68796143a8948325900a97bab1cf2716