### PR TITLE
Handle unknown short options

### DIFF
--- a/include/arg_parser.hpp
+++ b/include/arg_parser.hpp
@@ -71,7 +71,12 @@ class ArgParser {
                         unknown_flags_.push_back(arg);
                     }
                 }
-            } else if (arg.rfind('-', 0) == 0 && arg.size() >= 2 && short_map_.count(arg[1])) {
+            } else if (arg.rfind('-', 0) == 0 && arg.size() >= 2) {
+                if (!short_map_.count(arg[1])) {
+                    unknown_flags_.push_back("-" + std::string(1, arg[1]));
+                    continue;
+                }
+
                 size_t eq = arg.find('=');
                 std::string before =
                     arg.substr(1, eq != std::string::npos ? eq - 1 : std::string::npos);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -99,6 +99,14 @@ TEST_CASE("ArgParser unknown flag detection") {
     REQUIRE(parser.unknown_flags()[0] == "--foo");
 }
 
+TEST_CASE("ArgParser unknown short flag") {
+    const char* argv[] = {"prog", "-x"};
+    ArgParser parser(2, const_cast<char**>(argv), {"--bar"}, {{'a', "--bar"}});
+    REQUIRE(parser.positional().empty());
+    REQUIRE(parser.unknown_flags().size() == 1);
+    REQUIRE(parser.unknown_flags()[0] == "-x");
+}
+
 TEST_CASE("Git utils local repo") {
     git::GitInitGuard guard;
     fs::path repo = fs::temp_directory_path() / "git_utils_test_repo";


### PR DESCRIPTION
## Summary
- add detection for unknown short options in `ArgParser`
- test that unknown short flags are not treated as positional arguments

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687a11400bc883259cb4cf50c49d79a6