### PR TITLE
Fix log dir creation in event loop

### DIFF
--- a/src/autogitpull.cpp
+++ b/src/autogitpull.cpp
@@ -658,7 +658,8 @@ int run_event_loop(const Options& opts) {
     }
     setup_environment(opts);
     setup_logging(opts);
-    fs::create_directories(opts.log_dir);
+    if (!opts.log_dir.empty())
+        fs::create_directories(opts.log_dir);
     std::vector<fs::path> all_repos;
     std::map<fs::path, RepoInfo> repo_infos;
     prepare_repos(opts, all_repos, repo_infos);


### PR DESCRIPTION
## Summary
- avoid creating directories when log path is empty in `run_event_loop`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687a1325aee48325b1318a64b316dd86