### PR TITLE
Improve repo scanning error handling

### DIFF
--- a/src/autogitpull.cpp
+++ b/src/autogitpull.cpp
@@ -109,13 +109,24 @@ std::vector<fs::path> build_repo_list(const fs::path& root, bool recursive,
                                       const std::vector<fs::path>& ignore, size_t max_depth) {
     std::vector<fs::path> result;
     if (recursive) {
-        for (fs::recursive_directory_iterator it(root), end; it != end; ++it) {
+        std::error_code ec;
+        fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied,
+                                            ec);
+        fs::recursive_directory_iterator end;
+        for (; it != end; it.increment(ec)) {
+            if (ec) {
+                ec.clear();
+                continue;
+            }
             if (max_depth > 0 && it.depth() >= static_cast<int>(max_depth)) {
                 it.disable_recursion_pending();
                 continue;
             }
-            if (!it->is_directory())
+            if (!it->is_directory(ec)) {
+                if (ec)
+                    ec.clear();
                 continue;
+            }
             fs::path p = it->path();
             if (std::find(ignore.begin(), ignore.end(), p) != ignore.end()) {
                 it.disable_recursion_pending();
@@ -124,8 +135,15 @@ std::vector<fs::path> build_repo_list(const fs::path& root, bool recursive,
             result.push_back(p);
         }
     } else {
-        for (const auto& entry : fs::directory_iterator(root)) {
-            fs::path p = entry.path();
+        std::error_code ec;
+        fs::directory_iterator it(root, fs::directory_options::skip_permission_denied, ec);
+        fs::directory_iterator end;
+        for (; it != end; it.increment(ec)) {
+            if (ec) {
+                ec.clear();
+                continue;
+            }
+            fs::path p = it->path();
             if (std::find(ignore.begin(), ignore.end(), p) != ignore.end())
                 continue;
             result.push_back(p);


### PR DESCRIPTION
## Summary
- handle directory access errors when scanning for repos

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a114cc3688325b708396159440d61