### PR TITLE
Fix Windows compilation

### DIFF
--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -2,7 +2,7 @@
 #define LOGGER_HPP
 #include <string>
 
-enum class LogLevel { DEBUG = 0, INFO, WARNING, ERROR };
+enum class LogLevel { DEBUG = 0, INFO, WARNING, ERR };
 
 void init_logger(const std::string& path, LogLevel level = LogLevel::INFO);
 void set_log_level(LogLevel level);

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -1,10 +1,14 @@
 #include "config_utils.hpp"
+#if __has_include(<yaml-cpp/yaml.h>)
 #include <yaml-cpp/yaml.h>
+#define HAVE_YAMLCPP 1
+#endif
 #include <fstream>
 #include <nlohmann/json.hpp>
 
 bool load_yaml_config(const std::string& path, std::map<std::string, std::string>& opts,
                       std::string& error) {
+#ifdef HAVE_YAMLCPP
     try {
         YAML::Node root = YAML::LoadFile(path);
         if (!root.IsMap()) {
@@ -30,6 +34,12 @@ bool load_yaml_config(const std::string& path, std::map<std::string, std::string
         error = e.what();
         return false;
     }
+#else
+    (void)path;
+    (void)opts;
+    error = "YAML support not available";
+    return false;
+#endif
 }
 
 bool load_json_config(const std::string& path, std::map<std::string, std::string>& opts,

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -39,7 +39,7 @@ void log_info(const std::string& msg) { log(LogLevel::INFO, "INFO", msg); }
 
 void log_warning(const std::string& msg) { log(LogLevel::WARNING, "WARNING", msg); }
 
-void log_error(const std::string& msg) { log(LogLevel::ERROR, "ERROR", msg); }
+void log_error(const std::string& msg) { log(LogLevel::ERR, "ERROR", msg); }
 
 static void close_logger() {
     std::lock_guard<std::mutex> lk(g_log_mtx);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -142,7 +142,7 @@ Options parse_options(int argc, char* argv[]) {
         else if (val == "WARNING" || val == "WARN")
             opts.log_level = LogLevel::WARNING;
         else if (val == "ERROR")
-            opts.log_level = LogLevel::ERROR;
+            opts.log_level = LogLevel::ERR;
         else
             throw std::runtime_error("Invalid log level: " + val);
     }

--- a/src/resource_utils.cpp
+++ b/src/resource_utils.cpp
@@ -16,6 +16,9 @@
 #include <tlhelp32.h>
 #include <winternl.h>
 #include <vector>
+#ifndef STATUS_INFO_LENGTH_MISMATCH
+#define STATUS_INFO_LENGTH_MISMATCH ((NTSTATUS)0xC0000004)
+#endif
 #elif defined(__APPLE__)
 #include <mach/mach.h>
 #include <unistd.h>


### PR DESCRIPTION
## Summary
- avoid ERROR macro collision by renaming enum value to `ERR`
- make YAML support optional when headers are missing
- define `STATUS_INFO_LENGTH_MISMATCH` for MinGW

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a41d314b48325a4de27f006219611