### PR TITLE
Fix mingw build issues

### DIFF
--- a/scripts/compile-debug-cl.bat
+++ b/scripts/compile-debug-cl.bat
@@ -18,7 +18,7 @@ set "LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib"
 
 if not exist dist mkdir dist
 
-cl /nologo /std:c++20 /EHsc /Zi /I"%INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
+cl /nologo /std:c++20 /EHsc /Zi /D YAML_CPP_STATIC_DEFINE /I"%INC%" -Iinclude src\autogitpull.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
     src\options.cpp src\parse_utils.cpp src\lock_utils.cpp src\linux_daemon.cpp ^
     "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /fsanitize=address /Fedist\autogitpull_debug.exe
 

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -41,7 +41,7 @@ rem 3. Build with clang++ and AddressSanitizer
 
 rem Common flags
 set "CXX=clang++"
-set "CXXFLAGS=-std=c++20 -O0 -g -fsanitize=address"
+set "CXXFLAGS=-std=c++20 -O0 -g -fsanitize=address -DYAML_CPP_STATIC_DEFINE"
 set "LDFLAGS=-fsanitize=address"
 
 if not exist dist mkdir dist

--- a/scripts/compile-debug.sh
+++ b/scripts/compile-debug.sh
@@ -12,7 +12,7 @@ fi
 PKG_CFLAGS="$(pkg-config --cflags libgit2 2>/dev/null || echo '') $(pkg-config --cflags yaml-cpp 2>/dev/null || echo '')"
 PKG_LIBS="$(pkg-config --libs libgit2 2>/dev/null || echo '-lgit2') $(pkg-config --libs yaml-cpp 2>/dev/null || echo '-lyaml-cpp')"
 mkdir -p dist
-$CXX -std=c++20 -O0 -g -fsanitize=address -Iinclude $PKG_CFLAGS \
+$CXX -std=c++20 -O0 -g -fsanitize=address -DYAML_CPP_STATIC_DEFINE -Iinclude $PKG_CFLAGS \
     src/autogitpull.cpp src/git_utils.cpp src/tui.cpp src/logger.cpp \
     src/resource_utils.cpp src/system_utils.cpp src/time_utils.cpp \
     src/config_utils.cpp src/debug_utils.cpp src/options.cpp \

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -42,7 +42,7 @@ if not exist "%SCRIPT_DIR%dist" (
 )
 
 REM Compile sources
-g++ -std=c++20 -static ^
+g++ -std=c++20 -static -DYAML_CPP_STATIC_DEFINE ^
     -I "%LIBGIT2_INC%" ^
     -I "%YAMLCPP_INC%" ^
     -I "%JSON_INC%" ^

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -12,7 +12,7 @@ fi
 PKG_CFLAGS="$(pkg-config --cflags libgit2 2>/dev/null || echo '') $(pkg-config --cflags yaml-cpp 2>/dev/null || echo '')"
 PKG_LIBS="$(pkg-config --libs libgit2 2>/dev/null || echo '-lgit2') $(pkg-config --libs yaml-cpp 2>/dev/null || echo '-lyaml-cpp')"
 mkdir -p dist
-$CXX -std=c++20 -O2 -DNDEBUG -Iinclude $PKG_CFLAGS \
+$CXX -std=c++20 -O2 -DNDEBUG -DYAML_CPP_STATIC_DEFINE -Iinclude $PKG_CFLAGS \
     src/autogitpull.cpp src/git_utils.cpp src/tui.cpp src/logger.cpp \
     src/resource_utils.cpp src/system_utils.cpp src/time_utils.cpp \
     src/config_utils.cpp src/debug_utils.cpp src/options.cpp \

--- a/src/windows_service.cpp
+++ b/src/windows_service.cpp
@@ -6,12 +6,13 @@
 #include "options.hpp"
 #include "logger.hpp"
 
+extern std::atomic<bool>* g_running_ptr;
+
 namespace winservice {
 
 static SERVICE_STATUS_HANDLE g_status_handle = nullptr;
 static SERVICE_STATUS g_status{};
 static Options g_opts;
-extern std::atomic<bool>* g_running_ptr;
 
 static void report_status(DWORD state) {
     g_status.dwCurrentState = state;


### PR DESCRIPTION
## Summary
- ensure Windows service accesses global running flag
- compile scripts define `YAML_CPP_STATIC_DEFINE` for mingw static yaml-cpp

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a5e4d0204832589679996338cd464