### PR TITLE
Fix ci missing cpplint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -243,6 +243,9 @@ make lint
 
 The CI workflow also executes this command and will fail on formatting or lint errors.
 
+`scripts/install_deps.sh` and `scripts/install_deps.bat` automatically install
+`cpplint` if it is missing.
+
 ### Status labels
 
 When the program starts, each repository is listed with the **Pending** status

--- a/scripts/install_deps.bat
+++ b/scripts/install_deps.bat
@@ -1,4 +1,9 @@
 @echo off
+rem Install cpplint if missing
+where cpplint >nul 2>nul
+if errorlevel 1 (
+    pip install cpplint
+)
 rem vcpkg places static libraries under .lib
 if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
 if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\yaml-cpp.lib" (

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
+
+# Install cpplint if missing
+if ! command -v cpplint >/dev/null; then
+    if command -v pip3 >/dev/null; then
+        pip3 install --user cpplint
+        export PATH="$HOME/.local/bin:$PATH"
+    elif command -v pip >/dev/null; then
+        pip install --user cpplint
+        export PATH="$HOME/.local/bin:$PATH"
+    else
+        echo "pip not found. Please install cpplint manually." >&2
+    fi
+fi
+
 # Install libgit2 if missing
 if command -v pkg-config >/dev/null && pkg-config --exists libgit2; then
     echo "libgit2 already installed"


### PR DESCRIPTION
## Summary
- install cpplint in dependency scripts
- document automatic cpplint install in README

## Testing
- `make lint`
- `make test` *(fails: building Catch2 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687a68ae50c08325b57733937723d014