### PR TITLE
Fix dependency check logic

### DIFF
--- a/scripts/install_deps.bat
+++ b/scripts/install_deps.bat
@@ -4,28 +4,38 @@ where cpplint >nul 2>nul
 if errorlevel 1 (
     pip install cpplint
 )
-rem vcpkg places static libraries under .lib
+rem Check if each dependency is installed under vcpkg
+set "LIBGIT2_INSTALLED=false"
+set "YAMLCPP_INSTALLED=false"
+set "JSON_INSTALLED=false"
+
 if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
+    set "LIBGIT2_INSTALLED=true"
+)
 if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\yaml-cpp.lib" (
+    set "YAMLCPP_INSTALLED=true"
+)
 if exist "%VCPKG_ROOT%\installed\x64-windows-static\include\nlohmann\json.hpp" (
+    set "JSON_INSTALLED=true"
+)
+
+if "%LIBGIT2_INSTALLED%"=="true" if "%YAMLCPP_INSTALLED%"=="true" if "%JSON_INSTALLED%"=="true" (
     echo libgit2, yaml-cpp and nlohmann-json already installed.
     goto :eof
 )
-)
-)
 
-if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
-    echo libgit2 already installed.
-    goto :eof
-)
+set "PKGS="
+if "%LIBGIT2_INSTALLED%"=="false" set "PKGS=%PKGS% libgit2:x64-windows-static"
+if "%YAMLCPP_INSTALLED%"=="false" set "PKGS=%PKGS% yaml-cpp:x64-windows-static"
+if "%JSON_INSTALLED%"=="false" set "PKGS=%PKGS% nlohmann-json"
 
 if exist vcpkg (
-    echo Installing libgit2, yaml-cpp and nlohmann-json via vcpkg...
-    vcpkg\vcpkg install libgit2:x64-windows-static yaml-cpp:x64-windows-static nlohmann-json
+    echo Installing%PKGS% via vcpkg...
+    vcpkg\vcpkg install%PKGS%
     goto :eof
 )
 
-echo libgit2 not found. Downloading vcpkg to install...
+echo Dependencies not fully installed. Downloading vcpkg to install missing ones...
 where git >nul 2>nul
 if errorlevel 1 (
     echo Git is required to download vcpkg. Please install Git and retry.
@@ -36,5 +46,5 @@ git clone https://github.com/microsoft/vcpkg
 cd vcpkg
 call bootstrap-vcpkg.bat
 cd ..
-vcpkg\vcpkg install libgit2:x64-windows-static yaml-cpp:x64-windows-static nlohmann-json
+vcpkg\vcpkg install%PKGS%
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -15,9 +15,26 @@ if ! command -v cpplint >/dev/null; then
     fi
 fi
 
-# Install libgit2 if missing
-if command -v pkg-config >/dev/null && pkg-config --exists libgit2; then
-    echo "libgit2 already installed"
+
+# Check if libgit2, yaml-cpp and nlohmann-json are installed
+libgit2_installed=false
+yamlcpp_installed=false
+json_installed=false
+
+if command -v pkg-config >/dev/null; then
+    if pkg-config --exists libgit2; then
+        libgit2_installed=true
+    fi
+    if pkg-config --exists yaml-cpp; then
+        yamlcpp_installed=true
+    fi
+    if pkg-config --exists nlohmann_json; then
+        json_installed=true
+    fi
+fi
+
+if $libgit2_installed && $yamlcpp_installed && $json_installed; then
+    echo "libgit2, yaml-cpp and nlohmann-json already installed"
     exit 0
 fi
 
@@ -25,12 +42,24 @@ os="$(uname -s)"
 case "$os" in
     Linux*)
         if command -v apt-get >/dev/null; then
+            packages=()
+            $libgit2_installed || packages+=(libgit2-dev)
+            $yamlcpp_installed || packages+=(libyaml-cpp-dev)
+            $json_installed || packages+=(nlohmann-json3-dev)
             sudo apt-get update
-            sudo apt-get install -y libgit2-dev libyaml-cpp-dev nlohmann-json3-dev
+            sudo apt-get install -y "${packages[@]}"
         elif command -v yum >/dev/null; then
-            sudo yum install -y libgit2-devel yaml-cpp-devel nlohmann-json-devel
+            packages=()
+            $libgit2_installed || packages+=(libgit2-devel)
+            $yamlcpp_installed || packages+=(yaml-cpp-devel)
+            $json_installed || packages+=(nlohmann-json-devel)
+            sudo yum install -y "${packages[@]}"
         elif command -v zypper >/dev/null; then
-            sudo zypper install -y libgit2-devel yaml-cpp-devel nlohmann_json-devel
+            packages=()
+            $libgit2_installed || packages+=(libgit2-devel)
+            $yamlcpp_installed || packages+=(yaml-cpp-devel)
+            $json_installed || packages+=(nlohmann_json-devel)
+            sudo zypper install -y "${packages[@]}"
         else
             echo "Unsupported Linux distribution. Please install libgit2, yaml-cpp, and nlohmann-json manually."
             exit 1
@@ -38,7 +67,11 @@ case "$os" in
         ;;
     Darwin*)
         if command -v brew >/dev/null; then
-            brew install libgit2 yaml-cpp nlohmann-json
+            packages=()
+            $libgit2_installed || packages+=(libgit2)
+            $yamlcpp_installed || packages+=(yaml-cpp)
+            $json_installed || packages+=(nlohmann-json)
+            brew install "${packages[@]}"
         else
             echo "Homebrew not found. Please install libgit2, yaml-cpp, and nlohmann-json manually."
             exit 1


### PR DESCRIPTION
## Summary
- detect libgit2, yaml-cpp, and nlohmann-json individually in `install_deps.sh`
- only skip install if all deps present
- mirror the same behavior for Windows batch script
- install any missing packages using the appropriate package manager

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a6fc7c0f8832580db595ed07fe231