### PR TITLE
Fix clang-format missing on macOS CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,17 @@ jobs:
       - name: Install lint tools
         run: pip install cpplint
 
+      - name: Install clang-format
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update && sudo apt-get install -y clang-format
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew install clang-format
+          elif [ "$RUNNER_OS" = "Windows" ]; then
+            choco install -y llvm
+          fi
+
 
       - name: Lint
         run: make lint


### PR DESCRIPTION
## Summary
- install clang-format in the release workflow to support macOS runners

## Testing
- `make lint`
- `scripts/install_deps.sh`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687ab100cd0483258b71580e377d5245