### PR TITLE
Fix Windows compile script

### DIFF
--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -48,8 +48,10 @@ REM Compile application icon
 if not exist "%SCRIPT_DIR%graphics\icon.ico" (
     call "%SCRIPT_DIR%scripts\generate_icons.bat" || exit /b 1
 )
+set "OBJ_FILES=%SCRIPT_DIR%src\version.o"
 if exist "%SCRIPT_DIR%graphics\icon.rc" (
     windres "%SCRIPT_DIR%graphics\icon.rc" -I "%SCRIPT_DIR%graphics" -O coff -o "%SCRIPT_DIR%graphics\icon.o"
+    set "OBJ_FILES=%OBJ_FILES% %SCRIPT_DIR%graphics\icon.o"
 )
 
 REM Compile sources
@@ -72,8 +74,7 @@ g++ -std=c++20 -static -DYAML_CPP_STATIC_DEFINE ^
     "%SCRIPT_DIR%src\lock_utils.cpp" ^
     "%SCRIPT_DIR%src\linux_daemon.cpp" ^
     "%SCRIPT_DIR%src\windows_service.cpp" ^
-    "%SCRIPT_DIR%src\version.o" ^
-    "%SCRIPT_DIR%graphics\icon.o" ^
+    %OBJ_FILES% ^
     "%LIBGIT2_LIB%\libgit2.a" ^
     "%YAMLCPP_LIB%\libyaml-cpp.a" ^
     -lssh2 -lz -lws2_32 -lwinhttp -lole32 -lrpcrt4 -lcrypt32 -lpsapi -ladvapi32 ^


### PR DESCRIPTION
## Summary
- handle missing icon.rc

## Testing
- `make lint`
- `make test` *(fails: Findyaml-cpp.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9a0af2c08325a2f90dfd8d91bcef