### PR TITLE
Fix Windows build scripts

### DIFF
--- a/graphics/icon.rc
+++ b/graphics/icon.rc
@@ -1,0 +1,2 @@
+IDI_ICON1 ICON "icon.ico"
+

--- a/scripts/compile-compress.bat
+++ b/scripts/compile-compress.bat
@@ -32,7 +32,10 @@ if not exist "%JSON_INC%\nlohmann\json.hpp" (
 
 if not exist "%SCRIPT_DIR%dist" mkdir "%SCRIPT_DIR%dist"
 
-windres "%SCRIPT_DIR%src\version.rc" -I "%SCRIPT_DIR%include" -O coff -o "%SCRIPT_DIR%src\version.o"
+windres ^
+    "%SCRIPT_DIR%src\version.rc" ^
+    -I "%SCRIPT_DIR%include" ^
+    -O coff -o "%SCRIPT_DIR%src\version.o"
 
 REM Compile with size optimizations
 "g++" -std=c++20 -Os -flto -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -s -DYAML_CPP_STATIC_DEFINE ^

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -43,7 +43,10 @@ if not exist "%SCRIPT_DIR%dist" (
 )
 
 REM Compile version resource
-windres "%SCRIPT_DIR%src\version.rc" -I "%SCRIPT_DIR%include" -O coff -o "%SCRIPT_DIR%src\version.o"
+windres ^
+    "%SCRIPT_DIR%src\version.rc" ^
+    -I "%SCRIPT_DIR%include" ^
+    -O coff -o "%SCRIPT_DIR%src\version.o"
 REM Compile application icon
 if not exist "%SCRIPT_DIR%graphics\icon.ico" (
     call "%SCRIPT_DIR%scripts\generate_icons.bat" || exit /b 1


### PR DESCRIPTION
## Summary
- fix resource line in `compile.bat`
- fix resource line in `compile-compress.bat`
- add missing `icon.rc`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687b9e378e2483258d192541982fc35e