### PR TITLE
Fix release workflow dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
@@ -23,7 +21,14 @@ jobs:
       - name: Set up C++ build environment
         uses: aminya/setup-cpp@v1
 
-
+      - name: Install dependencies
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            scripts\install_deps.bat
+          else
+            ./scripts/install_deps.sh
+          fi
       - name: Install lint tools
         run: pip install cpplint
 

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -8,15 +8,14 @@
 #define AUTOGITPULL_VERSION_PATCH 0
 
 #define AUTOGITPULL_VERSION_STR "1.0.0"
-#define AUTOGITPULL_VERSION_RC \
-    AUTOGITPULL_VERSION_MAJOR, AUTOGITPULL_VERSION_MINOR, \
-    AUTOGITPULL_VERSION_PATCH, 0
+#define AUTOGITPULL_VERSION_RC                                                                     \
+    AUTOGITPULL_VERSION_MAJOR, AUTOGITPULL_VERSION_MINOR, AUTOGITPULL_VERSION_PATCH, 0
 /* ------------------------------------------------------------------ */
 
 /* Everything below is **C++-only**.  Keep it out of windres runs.   */
 #ifndef RC_INVOKED
 /* Human-friendly version string for the C++ codebase */
 constexpr const char* AUTOGITPULL_VERSION = AUTOGITPULL_VERSION_STR;
-#endif  /* RC_INVOKED */
+#endif /* RC_INVOKED */
 
-#endif  /* AUTOGITPULL_VERSION_HPP */
+#endif /* AUTOGITPULL_VERSION_HPP */


### PR DESCRIPTION
## Summary
- run dependency installer in release workflow
- format version header to satisfy lint

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687bbf05dfc48325a704e58939af2918