### PR TITLE
Add missing Windows dependency installers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ graphics/icon.ico
 graphics/icon.icns
 graphics/icon.iconset/
 graphics/icon_*.png
+graphics/icon.o

--- a/scripts/install_nlohmann_json.bat
+++ b/scripts/install_nlohmann_json.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+
+REM Fetch nlohmann/json single header
+
+if not exist libs mkdir libs
+if not exist libs\nlohmann-json (
+    echo Cloning nlohmann/json...
+    git clone --depth 1 https://github.com/nlohmann/json libs\nlohmann-json
+)
+
+echo nlohmann-json headers installed under libs\nlohmann-json
+endlocal

--- a/scripts/install_yamlcpp_mingw.bat
+++ b/scripts/install_yamlcpp_mingw.bat
@@ -1,0 +1,39 @@
+@echo off
+setlocal
+
+REM Install yaml-cpp using MinGW and CMake
+
+where cmake >nul 2>nul
+if errorlevel 1 (
+    echo CMake is required! Please install cmake and ensure it is in PATH.
+    exit /b 1
+)
+
+if not exist libs mkdir libs
+if not exist libs\yaml-cpp (
+    echo Cloning yaml-cpp...
+    git clone --depth 1 https://github.com/jbeder/yaml-cpp libs\yaml-cpp
+)
+cd libs\yaml-cpp
+if exist build rmdir /s /q build
+mkdir build
+cd build
+cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=..\yaml-cpp_install ..
+if errorlevel 1 (
+    echo yaml-cpp CMake configuration failed!
+    exit /b 1
+)
+mingw32-make
+if errorlevel 1 (
+    echo yaml-cpp build failed!
+    exit /b 1
+)
+mingw32-make install
+if errorlevel 1 (
+    echo yaml-cpp install failed!
+    exit /b 1
+)
+cd ..\..
+
+echo yaml-cpp built and installed to libs\yaml-cpp_install
+endlocal


### PR DESCRIPTION
## Summary
- ignore generated icon object file
- add scripts to install yaml-cpp and nlohmann-json for MinGW

## Testing
- `make lint`
- `make test` *(fails: yaml-cpp package missing)*

------
https://chatgpt.com/codex/tasks/task_e_687bef30ceb48325b32fae7f5ac02d0f