### PR TITLE
Fix CLI mode to stop drawing TUI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ and shows progress either in an interactive TUI or with plain console output.
 ## Features
 
 - Periodic scanning and automatic `git pull`
-- Optional CLI mode without the TUI
+ - Optional CLI mode that prints logs without the TUI
 - YAML or JSON configuration files
 - Detailed logging with resource tracking
 - Throttling and CPU/memory limits
@@ -51,7 +51,7 @@ Available options:
 - `--no-thread-tracker` – disable thread count display in the TUI.
 - `--net-tracker` – show total network usage since startup.
 - `--disk-limit <KB/s>` – throttle disk reads and writes.
-- `--cli` – output text updates to stdout instead of the TUI.
+- `--cli` – disable the TUI and only print log messages.
 - `--single-run` – perform one scan cycle and exit.
 - `--silent` – disable all console output; only logs are written.
 - `--force-pull` – discard local changes when pulling updates.

--- a/src/autogitpull.cpp
+++ b/src/autogitpull.cpp
@@ -313,9 +313,6 @@ static void update_ui(const Options& opts, const std::vector<fs::path>& all_repo
         draw_tui(all_repos, repo_infos, opts.interval, sec_left, scanning, act, opts.show_skipped,
                  opts.show_version, opts.cpu_tracker, opts.mem_tracker, opts.thread_tracker,
                  opts.net_tracker, opts.cpu_core_mask != 0);
-    } else if (!opts.silent && opts.cli && cli_countdown_ms <= std::chrono::milliseconds(0)) {
-        draw_cli(all_repos, repo_infos, sec_left, scanning, act, opts.show_skipped);
-        cli_countdown_ms = std::chrono::milliseconds(1000);
     }
 }
 


### PR DESCRIPTION
## Summary
- update docs for CLI mode behaviour
- avoid drawing TUI-style output in CLI mode

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687cdaf72afc83258bc15bd063a3b6ab