### PR TITLE
Add build2 build files and manifest update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ graphics/icon.icns
 graphics/icon.iconset/
 graphics/icon_*.png
 graphics/icon.o
+*/.bld

--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 : 1
 name: autogitpull
-version: 0.1.0
+version: 1.0.0
 summary: Automatic Git Puller & Monitor
 depends: libgit2
 depends: yaml-cpp

--- a/src/buildfile
+++ b/src/buildfile
@@ -1,8 +1,9 @@
-import libs = libgit2 yaml - cpp nlohmann - json
+import libs = libgit2 yaml-cpp nlohmann-json
 
-#Object files used for the main library
-    libsources = git_utils logger resource_utils system_utils time_utils config_utils debug_utils options parse_utils lock_utils process_monitor
+lib_sources = git_utils logger resource_utils system_utils time_utils \
+              config_utils debug_utils scanner ui_loop options parse_utils \
+              lock_utils process_monitor linux_daemon windows_service tui
 
-    lib{autogitpull } :cxx{$libsources } lib{autogitpull } :cxx{linux_daemon } @ !windows cxx{windows_service } @windows
+lib{autogitpull}: cxx{$lib_sources} $libs
 
-    exe{autogitpull } :cxx{autogitpull tui } lib{autogitpull }
+exe{autogitpull}: cxx{autogitpull} lib{autogitpull}

--- a/tests/buildfile
+++ b/tests/buildfile
@@ -1,5 +1,6 @@
 import libs = ../src/lib{autogitpull} catch2
 
-exe{autogitpull_tests}: cxx{tests.cpp} ../src/lib{autogitpull}
+testexe{autogitpull-tests}: \
+  cxx{tests.cpp memory_leak.cpp} ../src/lib{autogitpull}
 
-test{autogitpull_tests}: exe{autogitpull_tests}
+test{autogitpull-tests}: testexe{autogitpull-tests}


### PR DESCRIPTION
## Summary
- update package manifest
- set up build2 root buildfile
- add build2 rules for `src/` library and executable
- add build2 test target
- ignore `.bld` directories

## Testing
- `make lint`
- `make test` *(fails: yaml-cpp not found)*
- `b configure` *(fails: command not found)*
- `b install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fa58503408325adb22836779c6c09