### PR TITLE
Switch workflows to build2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,14 @@ jobs:
       - name: Set up build environment
         uses: aminya/setup-cpp@v1
 
+      - name: Set up build2
+        uses: build2/setup-build2-github-action@v2
+
       - name: Install dependencies
         run: ./scripts/install_deps.sh
 
       - name: Lint
-        run: make lint
+        run: b --for-each=test lint
 
       - name: Test
-        run: make test
+        run: b test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Set up C++ build environment
         uses: aminya/setup-cpp@v1
 
+      - name: Set up build2
+        uses: build2/setup-build2-github-action@v2
+
       - name: Install dependencies
         shell: bash
         run: |
@@ -45,26 +48,22 @@ jobs:
 
 
       - name: Lint
-        run: make lint
+        run: b --for-each=test lint
 
 
       - name: Test
-        run: make test
+        run: b test
 
       - name: Build
         shell: bash
         run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            cmd.exe /c scripts\compile.bat
-          else
-            ./scripts/compile.sh
-          fi
+          b install config.install.root=dist
 
       - name: Upload executable
         uses: actions/upload-artifact@v4
         with:
           name: autogitpull-${{ matrix.os }}
           path: |
-            autogitpull
-            autogitpull.exe
+            dist/bin/autogitpull
+            dist/bin/autogitpull.exe
 

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -39,6 +39,10 @@ jobs:
         if: steps.check_releases.outputs.skip_build != 'true'
         uses: aminya/setup-cpp@v1
 
+      - name: Set up build2
+        if: steps.check_releases.outputs.skip_build != 'true'
+        uses: build2/setup-build2-github-action@v2
+
       - name: Install dependencies
         if: steps.check_releases.outputs.skip_build != 'true'
         run: ./scripts/install_deps.sh
@@ -49,20 +53,16 @@ jobs:
 
       - name: Lint
         if: steps.check_releases.outputs.skip_build != 'true'
-        run: make lint
+        run: b --for-each=test lint
 
       - name: Build
         if: steps.check_releases.outputs.skip_build != 'true'
         run: |
-          mkdir build && cd build
-          cmake ..
-          make -j$(nproc)
+          b install config.install.root=dist
 
       - name: Run Tests
         if: steps.check_releases.outputs.skip_build != 'true'
-        run: |
-          cd build
-          ctest
+        run: b test
 
       - name: Get next rolling tag
         if: steps.check_releases.outputs.skip_build != 'true'
@@ -105,6 +105,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.NEXT_TAG }}
-          files: build/autogitpull
+          files: dist/bin/autogitpull
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- set up build2 in each workflow
- lint and test using build2
- build releases with `b install`
- drop compile scripts from the workflows

## Testing
- `make lint`
- `make test` *(fails: could not build tests)*

------
https://chatgpt.com/codex/tasks/task_e_687fd5c5b7dc83258b6d9af2c4ddcee1