### PR TITLE
Add optional persistence flag for services

### DIFF
--- a/include/linux_daemon.hpp
+++ b/include/linux_daemon.hpp
@@ -8,7 +8,8 @@ namespace procutil {
 bool daemonize();
 
 bool create_service_unit(const std::string& name, const std::string& exec_path,
-                         const std::string& config_file, const std::string& user = "root");
+                         const std::string& config_file, const std::string& user = "root",
+                         bool persist = true);
 
 bool remove_service_unit(const std::string& name);
 

--- a/include/windows_service.hpp
+++ b/include/windows_service.hpp
@@ -14,7 +14,7 @@ void WINAPI ServiceMain(DWORD argc, LPTSTR* argv);
 void WINAPI ServiceCtrlHandler(DWORD ctrl);
 
 bool install_service(const std::string& name, const std::string& exec_path,
-                     const std::string& config_file);
+                     const std::string& config_file, bool persist = true);
 bool uninstall_service(const std::string& name);
 int create_status_socket(const std::string& name);
 int connect_status_socket(const std::string& name);
@@ -23,7 +23,7 @@ void remove_status_socket(const std::string& name, int fd);
 inline int create_status_socket(const std::string&) { return -1; }
 inline int connect_status_socket(const std::string&) { return -1; }
 inline void remove_status_socket(const std::string&, int) {}
-inline bool install_service(const std::string&, const std::string&, const std::string&) {
+inline bool install_service(const std::string&, const std::string&, const std::string&, bool) {
     return false;
 }
 inline bool uninstall_service(const std::string&) { return false; }

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ and shows progress either in an interactive TUI or with plain console output.
 
 ## Usage
 
-`autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--ignore <dir>] [--recursive] [--max-depth <n>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <mask>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--download-limit <KB/s>] [--upload-limit <KB/s>] [--disk-limit <KB/s>] [--cli] [--single-run] [--silent] [--force-pull] [--remove-lock] [--debug-memory] [--dump-state] [--dump-large <n>] [--attach <name>] [--background <name>] [--reattach <name>] [--help]`
+`autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--ignore <dir>] [--recursive] [--max-depth <n>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n>] [--cpu-cores <mask>] [--mem-limit <MB>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--download-limit <KB/s>] [--upload-limit <KB/s>] [--disk-limit <KB/s>] [--cli] [--single-run] [--silent] [--force-pull] [--remove-lock] [--debug-memory] [--dump-state] [--dump-large <n>] [--attach <name>] [--background <name>] [--reattach <name>] [--persist] [--help]`
 
 Most options have single-letter shorthands. Run `autogitpull --help` to see a concise list.
 
@@ -64,6 +64,7 @@ Available options:
 - `--attach <name>` – connect to a running daemon started with the same name and print status updates.
 - `--background <name>` – run the tool in the background and allow reattachment.
 - `--reattach <name>` – connect to a background instance started with the same name.
+- `--persist` – automatically restart the process if it exits.
 - `--help` – show the usage information and exit.
 
 Repositories with uncommitted changes are skipped by default to avoid losing work. Use `--force-pull` (alias: `--discard-dirty`) to reset such repositories to the remote state.

--- a/src/linux_daemon.cpp
+++ b/src/linux_daemon.cpp
@@ -50,7 +50,7 @@ static std::string unit_path(const std::string& name) {
 }
 
 bool create_service_unit(const std::string& name, const std::string& exec_path,
-                         const std::string& config_file, const std::string& user) {
+                         const std::string& config_file, const std::string& user, bool persist) {
     std::ofstream out(unit_path(name));
     if (!out.is_open())
         return false;
@@ -58,7 +58,8 @@ bool create_service_unit(const std::string& name, const std::string& exec_path,
     out << "[Service]\nType=simple\nUser=" << user << "\nExecStart=" << exec_path;
     if (!config_file.empty())
         out << " --daemon-config " << config_file;
-    out << " --persist";
+    if (persist)
+        out << " --persist";
     out << "\nRestart=on-failure\n\n";
     out << "[Install]\nWantedBy=multi-user.target\n";
     out.close();
@@ -114,7 +115,7 @@ void remove_status_socket(const std::string& name, int fd) {
 bool daemonize() { return false; }
 
 bool create_service_unit(const std::string&, const std::string&, const std::string&,
-                         const std::string&) {
+                         const std::string&, bool) {
     return false;
 }
 

--- a/src/windows_service.cpp
+++ b/src/windows_service.cpp
@@ -42,14 +42,15 @@ void WINAPI ServiceMain(DWORD argc, LPTSTR* argv) {
 }
 
 bool install_service(const std::string& name, const std::string& exec_path,
-                     const std::string& config_file) {
+                     const std::string& config_file, bool persist) {
     SC_HANDLE scm = OpenSCManager(nullptr, nullptr, SC_MANAGER_CREATE_SERVICE);
     if (!scm)
         return false;
     std::string cmd = '"' + exec_path + '"';
     if (!config_file.empty())
         cmd += " --service-config \"" + config_file + "\"";
-    cmd += " --persist";
+    if (persist)
+        cmd += " --persist";
     SC_HANDLE svc =
         CreateServiceA(scm, name.c_str(), name.c_str(), SERVICE_ALL_ACCESS,
                        SERVICE_WIN32_OWN_PROCESS, SERVICE_AUTO_START, SERVICE_ERROR_NORMAL,

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -377,21 +377,24 @@ TEST_CASE("ArgParser recursive flag") {
 }
 
 TEST_CASE("ArgParser daemon flags") {
-    const char* argv[] = {"prog", "--install-daemon", "--daemon-config", "cfg"};
-    ArgParser parser(4, const_cast<char**>(argv),
-                     {"--install-daemon", "--uninstall-daemon", "--daemon-config"});
+    const char* argv[] = {"prog", "--install-daemon", "--daemon-config", "cfg", "--persist"};
+    ArgParser parser(5, const_cast<char**>(argv),
+                     {"--install-daemon", "--uninstall-daemon", "--daemon-config", "--persist"});
     REQUIRE(parser.has_flag("--install-daemon"));
     REQUIRE(parser.get_option("--daemon-config") == std::string("cfg"));
+    REQUIRE(parser.has_flag("--persist"));
     const char* argv2[] = {"prog", "--uninstall-daemon"};
     ArgParser parser2(2, const_cast<char**>(argv2), {"--install-daemon", "--uninstall-daemon"});
     REQUIRE(parser2.has_flag("--uninstall-daemon"));
 }
 
 TEST_CASE("parse_options service flags") {
-    const char* argv[] = {"prog", "path", "--install-service", "--service-config", "cfg"};
-    Options opts = parse_options(5, const_cast<char**>(argv));
+    const char* argv[] = {"prog", "path",     "--install-service", "--service-config",
+                          "cfg",  "--persist"};
+    Options opts = parse_options(6, const_cast<char**>(argv));
     REQUIRE(opts.install_service);
     REQUIRE(opts.service_config == std::string("cfg"));
+    REQUIRE(opts.persist);
     const char* argv2[] = {"prog", "path", "--uninstall-service"};
     Options opts2 = parse_options(3, const_cast<char**>(argv2));
     REQUIRE(opts2.uninstall_service);
@@ -621,7 +624,7 @@ TEST_CASE("scan_repos respects concurrency limit") {
 
     std::map<fs::path, RepoInfo> infos;
     for (const auto& p : repos)
-        infos[p] = RepoInfo{p, RS_PENDING, "", "", "", "", 0, false};
+        infos[p] = RepoInfo{p, RS_PENDING, "", "", "", "", "", "", 0, false};
     std::set<fs::path> skip;
     std::mutex mtx;
     std::atomic<bool> scanning(true);


### PR DESCRIPTION
## Summary
- add `persist` parameter to `create_service_unit` and `install_service`
- include `--persist` only when requested
- document the new flag in README
- update daemon/service option tests

## Testing
- `make lint`
- `make test` *(fails: autogitpull_tests segfaults)*

------
https://chatgpt.com/codex/tasks/task_e_687fe794e2d483259c83b8124627040e