### PR TITLE
Add TUI options and build2 improvements

### DIFF
--- a/include/options.hpp
+++ b/include/options.hpp
@@ -42,6 +42,8 @@ struct Options {
     bool show_vmem = false;
     bool show_commit_date = false;
     bool show_commit_author = false;
+    bool show_datetime_line = true;
+    bool show_header = true;
     bool no_colors = false;
     std::string custom_color;
     std::vector<std::filesystem::path> ignore_dirs;

--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -30,6 +30,7 @@ void draw_tui(const std::vector<std::filesystem::path>& all_repos,
               int seconds_left, bool scanning, const std::string& action, bool show_skipped,
               bool show_version, bool track_cpu, bool track_mem, bool track_threads, bool track_net,
               bool show_affinity, bool track_vmem, bool show_commit_date, bool show_commit_author,
-              bool no_colors, const std::string& custom_color, int runtime_sec);
+              bool no_colors, const std::string& custom_color, int runtime_sec,
+              bool show_datetime_line, bool show_header);
 
 #endif // TUI_HPP

--- a/scripts/build2.sh
+++ b/scripts/build2.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+
+if [ ! -f "${ROOT_DIR}/graphics/icon.ico" ] || [ ! -f "${ROOT_DIR}/graphics/icon.icns" ]; then
+    "${SCRIPT_DIR}/generate_icons.sh"
+fi
+
+cd "${ROOT_DIR}"
+
+if [ ! -f build/config.build ] ; then
+    b configure
+fi
+b install config.install.root="${ROOT_DIR}/dist"

--- a/src/buildfile
+++ b/src/buildfile
@@ -1,4 +1,5 @@
 import libs = libgit2 yaml-cpp nlohmann-json
+using rc
 
 
 lib_sources = git_utils logger resource_utils system_utils time_utils \
@@ -7,5 +8,7 @@ lib_sources = git_utils logger resource_utils system_utils time_utils \
 
 lib{autogitpull}: cxx{$lib_sources} $libs
 
+rc{icon}: ../graphics/icon.rc
+rc{version}: version.rc
 
-exe{autogitpull}: cxx{autogitpull} lib{autogitpull}
+exe{autogitpull}: cxx{autogitpull} lib{autogitpull} rc{icon} rc{version}

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -77,6 +77,8 @@ void print_help(const char* prog) {
         {"--show-commit-date", "", "", "Display last commit time", "General"},
         {"--disk-limit", "", "<KB/s>", "Limit disk throughput", "Resource limits"},
         {"--show-commit-author", "", "", "Display last commit author", "General"},
+        {"--hide-date-time", "", "", "Hide date/time line in TUI", "General"},
+        {"--hide-header", "", "", "Hide status header", "General"},
         {"--row-order", "", "<mode>", "Row ordering (alpha/reverse)", "General"},
         {"--color", "", "<ansi>", "Override status color", "General"},
         {"--no-colors", "", "", "Disable ANSI colors", "General"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -100,6 +100,8 @@ Options parse_options(int argc, char* argv[]) {
                                       "--kill-all",
                                       "--show-commit-date",
                                       "--show-commit-author",
+                                      "--hide-date-time",
+                                      "--hide-header",
                                       "--vmem",
                                       "--no-colors",
                                       "--color",
@@ -457,6 +459,9 @@ Options parse_options(int argc, char* argv[]) {
     opts.show_commit_date = parser.has_flag("--show-commit-date") || cfg_flag("--show-commit-date");
     opts.show_commit_author =
         parser.has_flag("--show-commit-author") || cfg_flag("--show-commit-author");
+    opts.show_datetime_line =
+        !(parser.has_flag("--hide-date-time") || cfg_flag("--hide-date-time"));
+    opts.show_header = !(parser.has_flag("--hide-header") || cfg_flag("--hide-header"));
     opts.show_vmem = parser.has_flag("--vmem") || cfg_flag("--vmem");
     opts.no_colors = parser.has_flag("--no-colors") || cfg_flag("--no-colors");
     if (parser.has_flag("--color") || cfg_opts.count("--color")) {

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -45,7 +45,8 @@ void draw_tui(const std::vector<fs::path>& all_repos,
               bool scanning, const std::string& action, bool show_skipped, bool show_version,
               bool track_cpu, bool track_mem, bool track_threads, bool track_net,
               bool show_affinity, bool track_vmem, bool show_commit_date, bool show_commit_author,
-              bool no_colors, const std::string& custom_color, int runtime_sec) {
+              bool no_colors, const std::string& custom_color, int runtime_sec,
+              bool show_datetime_line, bool show_header) {
     std::ostringstream out;
     auto choose = [&](const char* def) {
         return no_colors ? "" : (custom_color.empty() ? def : custom_color.c_str());
@@ -63,7 +64,8 @@ void draw_tui(const std::vector<fs::path>& all_repos,
     if (show_version)
         out << " v" << AUTOGITPULL_VERSION;
     out << reset << "\n";
-    out << "Date: " << cyan << timestamp() << reset << "\n";
+    if (show_datetime_line)
+        out << "Date: " << cyan << timestamp() << reset << "\n";
     out << "Monitoring: " << yellow
         << (all_repos.empty() ? "" : all_repos[0].parent_path().string()) << reset << "\n";
     out << "Interval: " << interval << "s    (Ctrl+C to exit)\n";
@@ -113,11 +115,13 @@ void draw_tui(const std::vector<fs::path>& all_repos,
         };
         out << "Net: D " << fmt(usage.download_bytes) << "  U " << fmt(usage.upload_bytes) << "\n";
     }
-    out << "--------------------------------------------------------------";
-    out << "-------------------\n";
-    out << bold << "  Status     Repo" << reset << "\n";
-    out << "--------------------------------------------------------------";
-    out << "-------------------\n";
+    if (show_header) {
+        out << "--------------------------------------------------------------";
+        out << "-------------------\n";
+        out << bold << " [" << std::left << std::setw(9) << "Status" << "]  Repo" << reset << "\n";
+        out << "--------------------------------------------------------------";
+        out << "-------------------\n";
+    }
     for (const auto& p : all_repos) {
         RepoInfo ri;
         auto it = repo_infos.find(p);
@@ -208,8 +212,10 @@ void draw_tui(const std::vector<fs::path>& all_repos,
             out << " (" << ri.progress << "%)";
         out << "\n";
     }
-    out << "--------------------------------------------------------------";
-    out << "-------------------\n";
+    if (show_header) {
+        out << "--------------------------------------------------------------";
+        out << "-------------------\n";
+    }
     std::cout << out.str() << std::flush;
     // Explicitly clear the string buffer to avoid stale allocations
     out.str("");

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -194,7 +194,8 @@ static void update_ui(const Options& opts, const std::vector<fs::path>& all_repo
         draw_tui(all_repos, repo_infos, opts.interval, sec_left, scanning, act, opts.show_skipped,
                  opts.show_version, opts.cpu_tracker, opts.mem_tracker, opts.thread_tracker,
                  opts.net_tracker, opts.cpu_core_mask != 0, opts.show_vmem, opts.show_commit_date,
-                 opts.show_commit_author, opts.no_colors, opts.custom_color, runtime_sec);
+                 opts.show_commit_author, opts.no_colors, opts.custom_color, runtime_sec,
+                 opts.show_datetime_line, opts.show_header);
     } else if (!opts.silent && opts.cli && cli_countdown_ms <= std::chrono::milliseconds(0)) {
         draw_cli(all_repos, repo_infos, sec_left, scanning, act, opts.show_skipped, runtime_sec);
         cli_countdown_ms = opts.refresh_ms;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -621,7 +621,7 @@ TEST_CASE("scan_repos respects concurrency limit") {
 
     std::map<fs::path, RepoInfo> infos;
     for (const auto& p : repos)
-        infos[p] = RepoInfo{p, RS_PENDING, "", "", "", "", 0, false};
+        infos[p] = RepoInfo{p, RS_PENDING, "", "", "", "", "", "", 0, false};
     std::set<fs::path> skip;
     std::mutex mtx;
     std::atomic<bool> scanning(true);


### PR DESCRIPTION
## Summary
- align table header in TUI output
- add `--hide-date-time` and `--hide-header` CLI options
- compile Windows resources in build2
- include icons generation in build2 script
- update tests for new RepoInfo fields

## Testing
- `make lint`
- `make test` *(fails: autogitpull_tests segfaults)*

------
https://chatgpt.com/codex/tasks/task_e_687fea20a3e883259515046cc6521809