### PR TITLE
Fix build2 imports

### DIFF
--- a/src/buildfile
+++ b/src/buildfile
@@ -1,4 +1,4 @@
-import libs = libgit2 yaml-cpp nlohmann-json
+import libs = libgit2%lib{git2} yaml-cpp%lib{yaml-cpp} nlohmann-json%lib{nlohmann_json}
 using rc
 
 


### PR DESCRIPTION
## Summary
- fix build2 buildfile imports for external dependencies

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688121c1add483258b86e6763199fa4e