### PR TITLE
Fix cpplint issues in test file

### DIFF
--- a/tests/memory_leak.cpp
+++ b/tests/memory_leak.cpp
@@ -1,15 +1,15 @@
+#include <cstdlib>
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <set>
 #include <catch2/catch_test_macros.hpp>
 #include "git_utils.hpp"
 #include "repo.hpp"
 #include "resource_utils.hpp"
 #include "scanner.hpp"
-#include <filesystem>
-#include <map>
-#include <set>
-#include <mutex>
-#include <atomic>
-#include <fstream>
-#include <cstdlib>
 
 namespace fs = std::filesystem;
 


### PR DESCRIPTION
## Summary
- resolve cpplint errors in memory leak test

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688263702fc8832595824028ba2dfe41