### PR TITLE
Fix build2 RC usage on macOS

### DIFF
--- a/src/buildfile
+++ b/src/buildfile
@@ -1,5 +1,8 @@
 import libs = libgit2%lib{git2} yaml-cpp%lib{yaml-cpp} nlohmann-json%lib{nlohmann_json}
-using rc
+
+if ($cxx.target.class == 'windows')
+  using rc
+endif
 
 
 lib_sources = git_utils logger resource_utils system_utils time_utils \
@@ -9,7 +12,10 @@ lib_sources = git_utils logger resource_utils system_utils time_utils \
 
 lib{autogitpull}: cxx{$lib_sources} $libs
 
-rc{icon}: ../graphics/icon.rc
-rc{version}: version.rc
-
-exe{autogitpull}: cxx{autogitpull} lib{autogitpull} rc{icon} rc{version}
+if ($cxx.target.class == 'windows')
+  rc{icon}: ../graphics/icon.rc
+  rc{version}: version.rc
+  exe{autogitpull}: cxx{autogitpull} lib{autogitpull} rc{icon} rc{version}
+else
+  exe{autogitpull}: cxx{autogitpull} lib{autogitpull}
+endif


### PR DESCRIPTION
## Summary
- avoid loading the `rc` build2 module when not on Windows
- only build Windows resource files when the rc module is available

## Testing
- `make lint`
- `make test` *(fails: could not find yaml-cpp)*

------
https://chatgpt.com/codex/tasks/task_e_6882745f723c8325b68e15a558775b51