### PR TITLE
Add zlib dependency

### DIFF
--- a/licenses/zlib.txt
+++ b/licenses/zlib.txt
@@ -1,0 +1,27 @@
+
+/* zlib.h -- interface of the 'zlib' general purpose compression library
+version 1.3.1, January 22nd, 2024
+
+Copyright (C) 1995-2024 Jean-loup Gailly and Mark Adler
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+claim that you wrote the original software. If you use this software
+in a product, an acknowledgment in the product documentation would be
+appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+Jean-loup Gailly        Mark Adler
+jloup@gzip.org          madler@alumni.caltech.edu
+
+*/
+

--- a/manifest
+++ b/manifest
@@ -6,3 +6,4 @@ depends: libgit2
 depends: yaml-cpp
 depends: nlohmann-json
 depends: catch2
+depends: zlib

--- a/readme.md
+++ b/readme.md
@@ -232,9 +232,10 @@ The resulting executable will appear in the `dist/` directory.
 
 Unit tests use [Catch2](https://github.com/catchorg/Catch2). If the library is
 not installed, CMake will automatically download it using `FetchContent`.
-`make test` requires the development packages for `libgit2`, `yaml-cpp` and
-`nlohmann-json`. Use `scripts/install_deps.sh` (Linux/macOS) or `scripts/install_deps.bat`
-(Windows) to install them before configuring and building the tests.
+`make test` requires the development packages for `libgit2`, `yaml-cpp`,
+`nlohmann-json` and `zlib`. Use `scripts/install_deps.sh` (Linux/macOS) or
+`scripts/install_deps.bat` (Windows) to install them before configuring and
+building the tests.
 Once the dependencies are in place, run `ctest`:
 
 ```bash
@@ -294,5 +295,5 @@ to **Checking** and later reflects the pull result.
 
 autogitpull is licensed under the MIT license (see `LICENSE`). The project
 bundles the license texts for its third-party dependencies under
-the `licenses/` directory, including `libgit2.txt`, `yaml-cpp.txt` and
-`nlohmann-json.txt`.
+the `licenses/` directory, including `libgit2.txt`, `yaml-cpp.txt`,
+`nlohmann-json.txt` and `zlib.txt`.

--- a/scripts/install_deps.bat
+++ b/scripts/install_deps.bat
@@ -9,6 +9,7 @@ rem Check if each dependency is installed under vcpkg
 set "LIBGIT2_INSTALLED=false"
 set "YAMLCPP_INSTALLED=false"
 set "JSON_INSTALLED=false"
+set "ZLIB_INSTALLED=false"
 
 if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\git2.lib" (
     set "LIBGIT2_INSTALLED=true"
@@ -19,9 +20,12 @@ if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\yaml-cpp.lib" (
 if exist "%VCPKG_ROOT%\installed\x64-windows-static\include\nlohmann\json.hpp" (
     set "JSON_INSTALLED=true"
 )
+if exist "%VCPKG_ROOT%\installed\x64-windows-static\lib\zlib.lib" (
+    set "ZLIB_INSTALLED=true"
+)
 
-if "%LIBGIT2_INSTALLED%"=="true" if "%YAMLCPP_INSTALLED%"=="true" if "%JSON_INSTALLED%"=="true" (
-    echo libgit2, yaml-cpp and nlohmann-json already installed.
+if "%LIBGIT2_INSTALLED%"=="true" if "%YAMLCPP_INSTALLED%"=="true" if "%JSON_INSTALLED%"=="true" if "%ZLIB_INSTALLED%"=="true" (
+    echo libgit2, yaml-cpp, nlohmann-json and zlib already installed.
     goto :eof
 )
 
@@ -29,6 +33,7 @@ set "PKGS="
 if "%LIBGIT2_INSTALLED%"=="false" set "PKGS=%PKGS% libgit2:x64-windows-static"
 if "%YAMLCPP_INSTALLED%"=="false" set "PKGS=%PKGS% yaml-cpp:x64-windows-static"
 if "%JSON_INSTALLED%"=="false" set "PKGS=%PKGS% nlohmann-json"
+if "%ZLIB_INSTALLED%"=="false" set "PKGS=%PKGS% zlib"
 
 if exist vcpkg (
     echo Installing%PKGS% via vcpkg...

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -17,10 +17,11 @@ if ! command -v cpplint >/dev/null; then
 fi
 
 
-# Check if libgit2, yaml-cpp and nlohmann-json are installed
+# Check if libgit2, yaml-cpp, nlohmann-json and zlib are installed
 libgit2_installed=false
 yamlcpp_installed=false
 json_installed=false
+zlib_installed=false
 
 if command -v pkg-config >/dev/null; then
     if pkg-config --exists libgit2; then
@@ -32,10 +33,13 @@ if command -v pkg-config >/dev/null; then
     if pkg-config --exists nlohmann_json; then
         json_installed=true
     fi
+    if pkg-config --exists zlib; then
+        zlib_installed=true
+    fi
 fi
 
-if $libgit2_installed && $yamlcpp_installed && $json_installed; then
-    echo "libgit2, yaml-cpp and nlohmann-json already installed"
+if $libgit2_installed && $yamlcpp_installed && $json_installed && $zlib_installed; then
+    echo "libgit2, yaml-cpp, nlohmann-json and zlib already installed"
     exit 0
 fi
 
@@ -47,6 +51,7 @@ case "$os" in
             $libgit2_installed || packages+=(libgit2-dev)
             $yamlcpp_installed || packages+=(libyaml-cpp-dev)
             $json_installed || packages+=(nlohmann-json3-dev)
+            $zlib_installed || packages+=(zlib1g-dev)
             sudo apt-get update
             sudo apt-get install -y "${packages[@]}"
         elif command -v yum >/dev/null; then
@@ -54,12 +59,14 @@ case "$os" in
             $libgit2_installed || packages+=(libgit2-devel)
             $yamlcpp_installed || packages+=(yaml-cpp-devel)
             $json_installed || packages+=(nlohmann-json-devel)
+            $zlib_installed || packages+=(zlib-devel)
             sudo yum install -y "${packages[@]}"
         elif command -v zypper >/dev/null; then
             packages=()
             $libgit2_installed || packages+=(libgit2-devel)
             $yamlcpp_installed || packages+=(yaml-cpp-devel)
             $json_installed || packages+=(nlohmann_json-devel)
+            $zlib_installed || packages+=(zlib-devel)
             sudo zypper install -y "${packages[@]}"
         else
             echo "Unsupported Linux distribution. Please install libgit2, yaml-cpp, and nlohmann-json manually."
@@ -72,6 +79,7 @@ case "$os" in
             $libgit2_installed || packages+=(libgit2)
             $yamlcpp_installed || packages+=(yaml-cpp)
             $json_installed || packages+=(nlohmann-json)
+            $zlib_installed || packages+=(zlib)
             brew install "${packages[@]}"
         else
             echo "Homebrew not found. Please install libgit2, yaml-cpp, and nlohmann-json manually."

--- a/src/buildfile
+++ b/src/buildfile
@@ -1,4 +1,4 @@
-import libs = libgit2%lib{git2} yaml-cpp%lib{yaml-cpp} nlohmann-json%lib{nlohmann_json}
+import libs = libgit2%lib{git2} yaml-cpp%lib{yaml-cpp} nlohmann-json%lib{nlohmann_json} libz%lib{z}
 
 lib_sources = git_utils logger resource_utils system_utils time_utils \
               config_utils debug_utils scanner ui_loop options parse_utils \


### PR DESCRIPTION
## Summary
- add zlib as a build2 dependency
- update buildfiles to link with zlib
- extend install scripts to install zlib
- mention zlib in documentation and add license

## Testing
- `make lint`
- `make test` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688277018c1883258e9b67c9bc07dab0