### PR TITLE
Fix build2 tests buildfile

### DIFF
--- a/tests/buildfile
+++ b/tests/buildfile
@@ -1,5 +1,7 @@
-import libs =../ src / lib{autogitpull } catch2
+import libs = ../src/lib{autogitpull} catch2
 
-    testexe{autogitpull - tests } :cxx{arg_parser_tests.cpp options_tests.cpp config_tests.cpp repo_tests.cpp process_tests.cpp utils_tests.cpp memory_leak.cpp }../ src / lib{autogitpull }
+testexe{autogitpull-tests}: \
+  cxx{arg_parser_tests.cpp options_tests.cpp config_tests.cpp repo_tests.cpp process_tests.cpp utils_tests.cpp memory_leak.cpp} \
+  ../src/lib{autogitpull}
 
-                                       test{autogitpull - tests } :testexe{autogitpull - tests }
+test{autogitpull-tests}: testexe{autogitpull-tests}


### PR DESCRIPTION
## Summary
- correct build2 syntax in tests/buildfile to resolve macOS build error

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6883c0671fd88325bef81700c9d7131d