### PR TITLE
Fix build2 configuration on macOS

### DIFF
--- a/bootstrap.build
+++ b/bootstrap.build
@@ -1,0 +1,2 @@
+project = autogitpull
+using cxx

--- a/tests/buildfile
+++ b/tests/buildfile
@@ -1,5 +1,5 @@
-import libs =../ src / lib{autogitpull } catch2
+import libs = ../src/lib{autogitpull} catch2
 
-    testexe{autogitpull - tests } :cxx{arg_parser_tests.cpp options_tests.cpp config_tests.cpp repo_tests.cpp process_tests.cpp utils_tests.cpp memory_leak.cpp }../ src / lib{autogitpull }
+testexe{autogitpull-tests}: cxx{arg_parser_tests.cpp options_tests.cpp config_tests.cpp repo_tests.cpp process_tests.cpp utils_tests.cpp memory_leak.cpp} ../src/lib{autogitpull}
 
-                                       test{autogitpull - tests } :testexe{autogitpull - tests }
+test{autogitpull-tests}: testexe{autogitpull-tests}


### PR DESCRIPTION
## Summary
- add missing `bootstrap.build` so build2 recognizes the project
- fix `tests/buildfile` paths

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6883c0671fd88325bef81700c9d7131d