### PR TITLE
Fix build2 zlib detection on macOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -214,6 +214,16 @@ b configure                         # only needed the first time
 b install config.install.root=dist  # places files under ./dist
 ```
 
+On macOS the Homebrew `zlib` package is *keg-only* and its `pkg-config` files
+are not on the default search path. The helper script `scripts/build2.sh`
+automatically prepends the required directory to `PKG_CONFIG_PATH`. If you run
+`b` manually ensure
+
+```bash
+export PKG_CONFIG_PATH="$(brew --prefix)/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH"
+```
+before invoking the build.
+
 Run `b test` to execute the unit tests. The helper script `scripts/build2.sh`
 performs these steps automatically when build2 is available.
 

--- a/scripts/build2.sh
+++ b/scripts/build2.sh
@@ -3,6 +3,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/.."
 
+# Ensure build2 can locate zlib installed by Homebrew on macOS.
+if [[ "$(uname -s)" == "Darwin" ]] && command -v brew >/dev/null; then
+    ZLIB_PKG="$(brew --prefix)/opt/zlib/lib/pkgconfig"
+    if [ -d "$ZLIB_PKG" ]; then
+        export PKG_CONFIG_PATH="$ZLIB_PKG:${PKG_CONFIG_PATH:-}"
+    fi
+fi
+
 if [ ! -f "${ROOT_DIR}/graphics/icon.ico" ] || [ ! -f "${ROOT_DIR}/graphics/icon.icns" ]; then
     "${SCRIPT_DIR}/generate_icons.sh"
 fi


### PR DESCRIPTION
## Summary
- set `PKG_CONFIG_PATH` for zlib in build2 helper script
- document zlib path requirements on macOS

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6883c2a50d188325bf3dcd3318321c7a