### PR TITLE
Add pull timeout CLI option

### DIFF
--- a/include/git_utils.hpp
+++ b/include/git_utils.hpp
@@ -21,6 +21,8 @@ struct GitInitGuard {
     ~GitInitGuard(); ///< Calls `git_libgit2_shutdown()`
 };
 
+void set_libgit_timeout(unsigned int seconds);
+
 // RAII wrappers for libgit2 resources
 template <typename T, void (*Free)(T*)> struct GitHandle {
     T* h;

--- a/include/options.hpp
+++ b/include/options.hpp
@@ -71,6 +71,7 @@ struct Options {
     std::chrono::minutes rescan_interval{5};
     bool use_syslog = false;
     int syslog_facility = 0;
+    std::chrono::seconds pull_timeout{0};
     bool skip_timeout = true;
     bool show_help = false;
     bool print_version = false;

--- a/src/autogitpull.cpp
+++ b/src/autogitpull.cpp
@@ -16,6 +16,8 @@ int main(int argc, char* argv[]) {
     git::GitInitGuard git_guard;
     try {
         Options opts = parse_options(argc, argv);
+        if (opts.pull_timeout.count() > 0)
+            git::set_libgit_timeout(static_cast<unsigned int>(opts.pull_timeout.count()));
         if (opts.show_help) {
             print_help(argv[0]);
             return 0;

--- a/src/git_utils.cpp
+++ b/src/git_utils.cpp
@@ -10,6 +10,14 @@ using namespace std;
 
 namespace git {
 
+static unsigned int g_libgit_timeout = 0;
+
+void set_libgit_timeout(unsigned int seconds) {
+    g_libgit_timeout = seconds;
+    if (g_libgit_timeout > 0)
+        git_libgit2_opts(GIT_OPT_SET_TIMEOUT, g_libgit_timeout);
+}
+
 struct ProgressData {
     const std::function<void(int)>* cb;
     std::chrono::steady_clock::time_point start;
@@ -29,7 +37,11 @@ static int credential_cb(git_credential** out, const char* url, const char* user
     return git_credential_default_new(out);
 }
 
-GitInitGuard::GitInitGuard() { git_libgit2_init(); }
+GitInitGuard::GitInitGuard() {
+    git_libgit2_init();
+    if (g_libgit_timeout > 0)
+        git_libgit2_opts(GIT_OPT_SET_TIMEOUT, g_libgit_timeout);
+}
 
 GitInitGuard::~GitInitGuard() { git_libgit2_shutdown(); }
 

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -88,6 +88,7 @@ void print_help(const char* prog) {
         {"--vmem", "", "", "Show virtual memory usage", "Tracking"},
         {"--syslog", "", "", "Log to syslog", "Logging"},
         {"--syslog-facility", "", "<n>", "Syslog facility", "Logging"},
+        {"--pull-timeout", "-O", "<sec>", "Network operation timeout", "General"},
         {"--help", "-h", "", "Show this message", "General"}};
 
     std::map<std::string, std::vector<const OptionInfo*>> groups;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -109,6 +109,7 @@ Options parse_options(int argc, char* argv[]) {
                                       "--row-order",
                                       "--syslog",
                                       "--syslog-facility",
+                                      "--pull-timeout",
                                       "--dont-skip-timeouts"};
     const std::map<char, std::string> short_opts{{'p', "--include-private"},
                                                  {'k', "--show-skipped"},
@@ -148,7 +149,8 @@ Options parse_options(int argc, char* argv[]) {
                                                  {'x', "--check-only"},
                                                  {'m', "--debug-memory"},
                                                  {'w', "--rescan-new"},
-                                                 {'X', "--no-cpu-tracker"}};
+                                                 {'X', "--no-cpu-tracker"},
+                                                 {'O', "--pull-timeout"}};
     ArgParser parser(argc, argv, known, short_opts);
 
     auto cfg_flag = [&](const std::string& k) {
@@ -538,6 +540,16 @@ Options parse_options(int argc, char* argv[]) {
         if (!ok2)
             throw std::runtime_error("Invalid value for --syslog-facility");
         opts.syslog_facility = fac;
+    }
+    if (parser.has_flag("--pull-timeout") || cfg_opts.count("--pull-timeout")) {
+        std::string val = parser.get_option("--pull-timeout");
+        if (val.empty())
+            val = cfg_opt("--pull-timeout");
+        bool ok2 = false;
+        int sec = parse_int(val, 1, INT_MAX, ok2);
+        if (!ok2)
+            throw std::runtime_error("Invalid value for --pull-timeout");
+        opts.pull_timeout = std::chrono::seconds(sec);
     }
     opts.skip_timeout =
         !(parser.has_flag("--dont-skip-timeouts") || cfg_flag("--dont-skip-timeouts"));

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -105,3 +105,9 @@ TEST_CASE("parse_options dont skip timeouts") {
     Options opts = parse_options(3, const_cast<char**>(argv));
     REQUIRE_FALSE(opts.skip_timeout);
 }
+
+TEST_CASE("parse_options pull timeout") {
+    const char* argv[] = {"prog", "path", "--pull-timeout", "60"};
+    Options opts = parse_options(4, const_cast<char**>(argv));
+    REQUIRE(opts.pull_timeout == std::chrono::seconds(60));
+}


### PR DESCRIPTION
## Summary
- add `set_libgit_timeout` helper and call from GitInitGuard
- expose `pull_timeout` in options and parse new `--pull-timeout` flag
- document the flag in help output
- respect timeout in main via `set_libgit_timeout`
- test new option parsing

## Testing
- `make lint`
- `make test` *(fails: could not find yaml-cpp)*

------
https://chatgpt.com/codex/tasks/task_e_6883c4439f2c8325ae0eb457e55dabf8