### PR TITLE
Fix build2 configuration

### DIFF
--- a/bootstrap.build
+++ b/bootstrap.build
@@ -1,2 +1,3 @@
 project = autogitpull
 using cxx
+using config


### PR DESCRIPTION
## Summary
- add missing `using config` directive to bootstrap

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6883c58553d88325ad5e97ee7dfdce18