### PR TITLE
Fix Windows build missing daemonize stub

### DIFF
--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -117,6 +117,7 @@ for %%F in (
     "%ROOT_DIR%\src\lock_utils.cpp"
     "%ROOT_DIR%\src\process_monitor.cpp"
     "%ROOT_DIR%\src\help_text.cpp"
+    "%ROOT_DIR%\src\linux_daemon.cpp"
     "%ROOT_DIR%\src\windows_service.cpp"
 ) do set "SRCS=!SRCS! %%~F"
 

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -36,12 +36,12 @@
 #include "options.hpp"
 #include "help_text.hpp"
 #include "lock_utils.hpp"
+#include "linux_daemon.hpp"
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include "linux_daemon.hpp"
 #else
 #include "windows_service.hpp"
 #endif


### PR DESCRIPTION
## Summary
- include `linux_daemon.hpp` on all platforms
- compile `linux_daemon.cpp` in the MinGW build script

## Testing
- `make lint`
- `make test` *(fails: `GIT_OPT_SET_TIMEOUT` not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68853b054ffc8325b90c79d377a2a1ad