### PR TITLE
Fix timeout option for older libgit2

### DIFF
--- a/src/git_utils.cpp
+++ b/src/git_utils.cpp
@@ -14,8 +14,12 @@ static unsigned int g_libgit_timeout = 0;
 
 void set_libgit_timeout(unsigned int seconds) {
     g_libgit_timeout = seconds;
+#ifdef GIT_OPT_SET_TIMEOUT
     if (g_libgit_timeout > 0)
         git_libgit2_opts(GIT_OPT_SET_TIMEOUT, g_libgit_timeout);
+#else
+    (void)g_libgit_timeout;
+#endif
 }
 
 struct ProgressData {
@@ -39,8 +43,10 @@ static int credential_cb(git_credential** out, const char* url, const char* user
 
 GitInitGuard::GitInitGuard() {
     git_libgit2_init();
+#ifdef GIT_OPT_SET_TIMEOUT
     if (g_libgit_timeout > 0)
         git_libgit2_opts(GIT_OPT_SET_TIMEOUT, g_libgit_timeout);
+#endif
 }
 
 GitInitGuard::~GitInitGuard() { git_libgit2_shutdown(); }


### PR DESCRIPTION
## Summary
- guard `git_libgit2_opts` usage with `GIT_OPT_SET_TIMEOUT`
- ensure build works with older libgit2

## Testing
- `make lint`
- `make deps`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68853c8ddd148325908bb5a8c6014d9f