### PR TITLE
Fix windows build

### DIFF
--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -118,6 +118,7 @@ for %%F in (
     "%ROOT_DIR%\src\lock_utils.cpp"
     "%ROOT_DIR%\src\process_monitor.cpp"
     "%ROOT_DIR%\src\help_text.cpp"
+    "%ROOT_DIR%\src\linux_daemon.cpp"
     "%ROOT_DIR%\src\windows_service.cpp"
 ) do set "SRCS=!SRCS! %%~F"
 


### PR DESCRIPTION
## Summary
- add missing linux_daemon.cpp to `compile.bat` sources so MinGW build succeeds

## Testing
- `make lint`
- `make test` *(fails: yaml-cppConfig.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887895005808325b21005d4f5618e72