### PR TITLE
Add lock override and streamlined CLI

### DIFF
--- a/include/options.hpp
+++ b/include/options.hpp
@@ -12,6 +12,7 @@ struct Options {
     bool show_skipped = false;
     bool show_version = false;
     bool remove_lock = false;
+    bool ignore_lock = false;
     bool cli = false;
     bool silent = false;
     bool recursive_scan = false;

--- a/include/scanner.hpp
+++ b/include/scanner.hpp
@@ -23,7 +23,7 @@ void process_repo(const std::filesystem::path& p,
                   std::atomic<bool>& running, std::string& action, std::mutex& action_mtx,
                   bool include_private, const std::filesystem::path& log_dir, bool check_only,
                   bool hash_check, size_t down_limit, size_t up_limit, size_t disk_limit,
-                  bool silent, bool force_pull, bool skip_timeout,
+                  bool silent, bool cli_mode, bool force_pull, bool skip_timeout,
                   std::chrono::seconds updated_since);
 
 void scan_repos(const std::vector<std::filesystem::path>& all_repos,
@@ -33,7 +33,7 @@ void scan_repos(const std::vector<std::filesystem::path>& all_repos,
                 std::mutex& action_mtx, bool include_private, const std::filesystem::path& log_dir,
                 bool check_only, bool hash_check, size_t concurrency, int cpu_percent_limit,
                 size_t mem_limit, size_t down_limit, size_t up_limit, size_t disk_limit,
-                bool silent, bool force_pull, bool skip_timeout,
+                bool silent, bool cli_mode, bool force_pull, bool skip_timeout,
                 std::chrono::seconds updated_since);
 
 #endif // SCANNER_HPP

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -64,6 +64,7 @@ void print_help(const char* prog) {
         {"--service-config", "", "<file>", "Config file for service install", "Actions"},
         {"--remove-lock", "-R", "", "Remove directory lock file and exit", "Actions"},
         {"--kill-all", "", "", "Terminate running instance and exit", "Actions"},
+        {"--ignore-lock", "", "", "Don't create or check lock file", "Actions"},
         {"--log-dir", "-d", "<path>", "Directory for pull logs", "Logging"},
         {"--log-file", "-l", "<path>", "File for general logs", "Logging"},
         {"--log-level", "-L", "<level>", "Set log verbosity", "Logging"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -93,6 +93,7 @@ Options parse_options(int argc, char* argv[]) {
                                       "--background",
                                       "--reattach",
                                       "--remove-lock",
+                                      "--ignore-lock",
                                       "--show-runtime",
                                       "--show-repo-count",
                                       "--max-runtime",
@@ -309,6 +310,7 @@ Options parse_options(int argc, char* argv[]) {
     opts.show_skipped = parser.has_flag("--show-skipped") || cfg_flag("--show-skipped");
     opts.show_version = parser.has_flag("--show-version") || cfg_flag("--show-version");
     opts.remove_lock = parser.has_flag("--remove-lock") || cfg_flag("--remove-lock");
+    opts.ignore_lock = parser.has_flag("--ignore-lock") || cfg_flag("--ignore-lock");
     opts.check_only = parser.has_flag("--check-only") || cfg_flag("--check-only");
     opts.hash_check = !(parser.has_flag("--no-hash-check") || cfg_flag("--no-hash-check"));
     opts.force_pull = parser.has_flag("--force-pull") || parser.has_flag("--discard-dirty") ||

--- a/tests/memory_leak.cpp
+++ b/tests/memory_leak.cpp
@@ -40,7 +40,7 @@ TEST_CASE("scan_repos memory stability") {
         scanning = true;
         running = true;
         scan_repos(repos, infos, skip, mtx, scanning, running, action, action_mtx, false,
-                   fs::path(), true, true, 1, 0, 0, 0, 0, 0, false, false, true,
+                   fs::path(), true, true, 1, 0, 0, 0, 0, 0, false, false, false, true,
                    std::chrono::seconds(0));
         size_t mem = procutil::get_memory_usage_mb();
         if (i == 0)

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -113,7 +113,13 @@ TEST_CASE("parse_options pull timeout") {
 }
 
 TEST_CASE("parse_options show repo count") {
-    const char* argv[] = {"prog", "--show-repo-count"};
-    Options opts = parse_options(2, const_cast<char**>(argv));
+    const char* argv[] = {"prog", "path", "--show-repo-count"};
+    Options opts = parse_options(3, const_cast<char**>(argv));
     REQUIRE(opts.show_repo_count);
+}
+
+TEST_CASE("parse_options ignore lock") {
+    const char* argv[] = {"prog", "path", "--ignore-lock"};
+    Options opts = parse_options(3, const_cast<char**>(argv));
+    REQUIRE(opts.ignore_lock);
 }

--- a/tests/process_tests.cpp
+++ b/tests/process_tests.cpp
@@ -5,6 +5,9 @@ static int g_monitor_count = 0;
 TEST_CASE("run_event_loop runtime limit") {
     fs::path dir = fs::temp_directory_path() / "runtime_limit_test";
     fs::create_directories(dir);
+    // create a minimal git repo so event loop does not exit immediately
+    std::string cmd = "git init -q " + (dir / "repo").string();
+    std::system(cmd.c_str());
     Options opts;
     opts.root = dir;
     opts.cli = true;

--- a/tests/repo_tests.cpp
+++ b/tests/repo_tests.cpp
@@ -123,7 +123,7 @@ TEST_CASE("scan_repos respects concurrency limit") {
 
     std::thread t([&]() {
         scan_repos(repos, infos, skip, mtx, scanning, running, act, act_mtx, false, fs::path(),
-                   true, true, concurrency, 0, 0, 0, 0, 0, true, false, true,
+                   true, true, concurrency, 0, 0, 0, 0, 0, true, false, false, true,
                    std::chrono::seconds(0));
     });
     while (scanning) {


### PR DESCRIPTION
## Summary
- initialize resource statistics at startup
- add `--ignore-lock` option
- log repo updates in CLI mode
- skip TUI redraw when `--cli` is used
- adjust tests for new option and runtime repo

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6887a6d03db08325b997aa0185519b6d