### PR TITLE
Fix compile-compress build and pass lint

### DIFF
--- a/scripts/compile-compress.bat
+++ b/scripts/compile-compress.bat
@@ -8,7 +8,8 @@ rem  compresses the result using UPX.
 rem *************************************************************
 
 set "SCRIPT_DIR=%~dp0"
-set "CXXFLAGS=-std=c++20 -Os -flto -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -s -DYAML_CPP_STATIC_DEFINE -Wl,--gc-sections -pipe -static -static-libgcc -static-libstdc++"
+rem Enable exceptions and RTTI to support normal build features
+set "CXXFLAGS=-std=c++20 -Os -flto -ffunction-sections -fdata-sections -s -DYAML_CPP_STATIC_DEFINE -Wl,--gc-sections -pipe -static -static-libgcc -static-libstdc++"
 
 pushd "%SCRIPT_DIR%" || exit /b 1
 call "%SCRIPT_DIR%compile.bat" %* || exit /b 1


### PR DESCRIPTION
## Summary
- enable exceptions in `compile-compress.bat`
- ensure clang-format passes for `ui_loop.cpp`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888c98b56748325a474f61e753b1645