### PR TITLE
Fix compile-debug.bat toolchain

### DIFF
--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -3,7 +3,7 @@ setlocal
 set "SCRIPT_DIR=%~dp0"
 set "ROOT_DIR=%SCRIPT_DIR%.."
 
-set "CXX=clang++"
+set "CXX=g++"
 where %CXX% >nul 2>nul || (
     echo Compiler %CXX% not found.
     exit /b 1


### PR DESCRIPTION
## Summary
- use g++ instead of clang++ when building debug binaries on Windows

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888efc2c864832591dfe6d2a61416c9