### PR TITLE
Add service and daemon status options

### DIFF
--- a/include/options.hpp
+++ b/include/options.hpp
@@ -81,6 +81,8 @@ struct Options {
     bool force_stop_daemon = false;
     bool restart_daemon = false;
     bool force_restart_daemon = false;
+    bool service_status = false;
+    bool daemon_status = false;
     bool show_service = false;
     bool run_background = false;
     bool reattach = false;

--- a/readme.md
+++ b/readme.md
@@ -140,11 +140,13 @@ Most options have single-letter shorthands. Run `autogitpull --help` for a compl
 - `--force-stop-service` – Force stop service.
 - `--restart-service` – Restart service.
 - `--force-restart-service` – Force restart service.
+- `--service-status` – Check if the service exists and is running.
 - `--start-daemon` – Start daemon unit.
 - `--stop-daemon` – Stop daemon unit.
 - `--force-stop-daemon` – Force stop daemon.
 - `--restart-daemon` – Restart daemon unit.
 - `--force-restart-daemon` – Force restart daemon.
+- `--daemon-status` – Check if the daemon exists and is running.
 - `--service-config` `<file>` – Config file for service install.
 - `--remove-lock` (`-R`) – Remove directory lock file and exit.
 - `--kill-all` – Terminate running instance and exit.

--- a/src/autogitpull.cpp
+++ b/src/autogitpull.cpp
@@ -51,6 +51,33 @@ int main(int argc, char* argv[]) {
                 std::cout << name << " " << (st.running ? "running" : "stopped") << "\n";
             return 0;
         }
+        if (opts.service_status) {
+#ifndef _WIN32
+            procutil::ServiceStatus st{};
+            procutil::service_unit_status(opts.daemon_name, st);
+#else
+            winservice::ServiceStatus st{};
+            winservice::service_status(opts.service_name, st);
+#endif
+            std::cout << (st.exists ? "exists" : "missing") << " "
+                      << (st.running ? "running" : "stopped") << "\n";
+            return 0;
+        }
+        if (opts.daemon_status) {
+#ifndef _WIN32
+            procutil::ServiceStatus st{};
+            procutil::service_unit_status(opts.daemon_name, st);
+            std::cout << (st.exists ? "exists" : "missing") << " "
+                      << (st.running ? "running" : "stopped") << "\n";
+            return 0;
+#else
+            winservice::ServiceStatus st{};
+            winservice::service_status(opts.service_name, st);
+            std::cout << (st.exists ? "exists" : "missing") << " "
+                      << (st.running ? "running" : "stopped") << "\n";
+            return 0;
+#endif
+        }
         if (opts.start_service) {
 #ifndef _WIN32
             return procutil::start_service_unit(opts.daemon_name) ? 0 : 1;

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -84,6 +84,8 @@ void print_help(const char* prog) {
         {"--force-stop-daemon", "", "", "Force stop daemon", "Actions"},
         {"--restart-daemon", "", "", "Restart daemon service", "Actions"},
         {"--force-restart-daemon", "", "", "Force restart daemon", "Actions"},
+        {"--service-status", "", "", "Check service existence and running state", "Actions"},
+        {"--daemon-status", "", "", "Check daemon existence and running state", "Actions"},
         {"--show-service", "", "", "Show installed service name", "Actions"},
         {"--remove-lock", "-R", "", "Remove directory lock file and exit", "Actions"},
         {"--kill-all", "", "", "Terminate running instance and exit", "Actions"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -102,6 +102,8 @@ Options parse_options(int argc, char* argv[]) {
                                       "--force-stop-daemon",
                                       "--restart-daemon",
                                       "--force-restart-daemon",
+                                      "--service-status",
+                                      "--daemon-status",
                                       "--show-service",
                                       "--attach",
                                       "--background",
@@ -218,6 +220,8 @@ Options parse_options(int argc, char* argv[]) {
     opts.restart_daemon = parser.has_flag("--restart-daemon") || cfg_flag("--restart-daemon");
     opts.force_restart_daemon =
         parser.has_flag("--force-restart-daemon") || cfg_flag("--force-restart-daemon");
+    opts.service_status = parser.has_flag("--service-status") || cfg_flag("--service-status");
+    opts.daemon_status = parser.has_flag("--daemon-status") || cfg_flag("--daemon-status");
     if (parser.has_flag("--daemon-config") || cfg_opts.count("--daemon-config")) {
         std::string val = parser.get_option("--daemon-config");
         if (val.empty())

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -47,6 +47,18 @@ TEST_CASE("parse_options show service flag") {
     REQUIRE(opts.show_service);
 }
 
+TEST_CASE("parse_options service status flag") {
+    const char* argv[] = {"prog", "path", "--service-status"};
+    Options opts = parse_options(3, const_cast<char**>(argv));
+    REQUIRE(opts.service_status);
+}
+
+TEST_CASE("parse_options daemon status flag") {
+    const char* argv[] = {"prog", "path", "--daemon-status"};
+    Options opts = parse_options(3, const_cast<char**>(argv));
+    REQUIRE(opts.daemon_status);
+}
+
 TEST_CASE("parse_options list services flags") {
     const char* argv[] = {"prog", "path", "--list-services"};
     Options opts = parse_options(3, const_cast<char**>(argv));


### PR DESCRIPTION
## Summary
- extend `Options` with `service_status` and `daemon_status`
- parse `--service-status` and `--daemon-status`
- output service/daemon status in `autogitpull`
- document the new flags and tests

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688a324969cc8325a6e570e7e728890d