### PR TITLE
Fix repo scanning to ignore files

### DIFF
--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -57,6 +57,11 @@ std::vector<fs::path> build_repo_list(const fs::path& root, bool recursive,
                 ec.clear();
                 continue;
             }
+            if (!it->is_directory(ec)) {
+                if (ec)
+                    ec.clear();
+                continue;
+            }
             fs::path p = it->path();
             if (std::find(ignore.begin(), ignore.end(), p) != ignore.end())
                 continue;

--- a/tests/repo_tests.cpp
+++ b/tests/repo_tests.cpp
@@ -51,6 +51,19 @@ TEST_CASE("build_repo_list ignores directories") {
     fs::remove_all(root);
 }
 
+TEST_CASE("build_repo_list skips files") {
+    fs::path root = fs::temp_directory_path() / "file_scan_test";
+    fs::remove_all(root);
+    fs::create_directories(root / "repo");
+    std::ofstream(root / "file.txt") << "ignore";
+
+    std::vector<fs::path> repos = build_repo_list(root, false, {}, 0);
+    REQUIRE(std::find(repos.begin(), repos.end(), root / "repo") != repos.end());
+    REQUIRE(std::find(repos.begin(), repos.end(), root / "file.txt") == repos.end());
+
+    fs::remove_all(root);
+}
+
 TEST_CASE("recursive iterator finds nested repo") {
     git::GitInitGuard guard;
     fs::path root = fs::temp_directory_path() / "recursive_test";


### PR DESCRIPTION
## Summary
- skip non-directory entries when building repo lists
- add regression test for skipping files

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688a5ba8c9e8832590f95ae4157df2cf