### PR TITLE
Handle long system sleep without exiting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ and shows progress either in an interactive TUI or with plain console output.
 - YAML or JSON configuration files
 - Detailed logging with resource tracking
 - Throttling and CPU/memory limits
+- Automatically resumes after system sleep/hibernation
 
 ## Usage
 

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -351,8 +351,8 @@ int run_event_loop(const Options& opts) {
     while (running) {
         auto now = std::chrono::steady_clock::now();
         if (now - last_loop > std::chrono::minutes(10)) {
-            log_info("Detected long pause; restarting");
-            break;
+            log_info("Detected long pause; resuming");
+            countdown_ms = std::chrono::milliseconds(0);
         }
         last_loop = now;
         auto elapsed = now - start_time;


### PR DESCRIPTION
## Summary
- resume instead of exiting after long pauses in the UI loop
- document automatic resume capability in README

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688afd82da0083259a45b306cf60105b