### PR TITLE
Add kill-on-sleep option

### DIFF
--- a/include/options.hpp
+++ b/include/options.hpp
@@ -93,6 +93,7 @@ struct Options {
     int respawn_max = 0;
     std::chrono::minutes respawn_window{10};
     bool kill_all = false;
+    bool kill_on_sleep = false;
     bool list_instances = false;
     bool list_services = false;
     bool rescan_new = false;

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -89,6 +89,7 @@ void print_help(const char* prog) {
         {"--show-service", "", "", "Show installed service name", "Actions"},
         {"--remove-lock", "-R", "", "Remove directory lock file and exit", "Actions"},
         {"--kill-all", "", "", "Terminate running instance and exit", "Actions"},
+        {"--kill-on-sleep", "", "", "Exit if a system sleep is detected", "Actions"},
         {"--list-instances", "", "", "List running instance names and PIDs", "Actions"},
         {"--list-services", "", "", "List installed service units", "Actions"},
         {"--list-daemons", "", "", "Alias for --list-services", "Actions"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -116,6 +116,7 @@ Options parse_options(int argc, char* argv[]) {
                                       "--persist",
                                       "--respawn-limit",
                                       "--kill-all",
+                                      "--kill-on-sleep",
                                       "--list-instances",
                                       "--list-services",
                                       "--list-daemons",
@@ -324,6 +325,7 @@ Options parse_options(int argc, char* argv[]) {
         }
     }
     opts.kill_all = parser.has_flag("--kill-all") || cfg_flag("--kill-all");
+    opts.kill_on_sleep = parser.has_flag("--kill-on-sleep") || cfg_flag("--kill-on-sleep");
     opts.list_instances = parser.has_flag("--list-instances") || cfg_flag("--list-instances");
     opts.list_services = parser.has_flag("--list-services") || parser.has_flag("--list-daemons") ||
                          cfg_flag("--list-services") || cfg_flag("--list-daemons");

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -352,6 +352,10 @@ int run_event_loop(const Options& opts) {
         auto now = std::chrono::steady_clock::now();
         if (now - last_loop > std::chrono::minutes(10)) {
             log_info("Detected long pause; resuming");
+            if (opts.kill_on_sleep) {
+                log_info("Exiting due to system sleep");
+                break;
+            }
             countdown_ms = std::chrono::milliseconds(0);
         }
         last_loop = now;

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -108,6 +108,12 @@ TEST_CASE("parse_options kill-all option") {
     REQUIRE(opts.kill_all);
 }
 
+TEST_CASE("parse_options kill-on-sleep option") {
+    const char* argv[] = {"prog", "path", "--kill-on-sleep"};
+    Options opts = parse_options(3, const_cast<char**>(argv));
+    REQUIRE(opts.kill_on_sleep);
+}
+
 TEST_CASE("parse_options rescan-new option default") {
     const char* argv[] = {"prog", "path", "--rescan-new"};
     Options opts = parse_options(3, const_cast<char**>(argv));


### PR DESCRIPTION
## Summary
- add `kill_on_sleep` member to Options
- parse new `--kill-on-sleep` CLI flag
- document the flag in help text
- exit loop when long pause detected if `kill_on_sleep` is enabled
- test parsing the new flag

## Testing
- `make lint`
- `make test` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688b26ec05e08325b66b892a8077c9de