### PR TITLE
Fix lint errors and update keep-first flag parsing

### DIFF
--- a/include/options.hpp
+++ b/include/options.hpp
@@ -106,7 +106,6 @@ struct Options {
     std::chrono::seconds pull_timeout{0};
     bool skip_timeout = true;
     bool cli_print_skipped = false;
-    bool keep_first_valid = false;
     bool show_help = false;
     bool print_version = false;
     std::map<std::filesystem::path, RepoOptions> repo_overrides;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -353,7 +353,9 @@ Options parse_options(int argc, char* argv[]) {
         if (!ok)
             throw std::runtime_error("Invalid value for --updated-since");
     }
-    opts.keep_first_valid = parser.has_flag("--keep-first-valid") || cfg_flag("--keep-first-valid");
+    opts.keep_first_valid = parser.has_flag("--keep-first-valid") ||
+                            cfg_flag("--keep-first-valid") || parser.has_flag("--keep-first") ||
+                            cfg_flag("--keep-first");
     opts.auto_config = parser.has_flag("--auto-config") || cfg_flag("--auto-config");
     opts.auto_reload_config =
         parser.has_flag("--auto-reload-config") || cfg_flag("--auto-reload-config");
@@ -364,7 +366,6 @@ Options parse_options(int argc, char* argv[]) {
         parser.has_flag("--session-dates-only") || cfg_flag("--session-dates-only");
     opts.cli_print_skipped = parser.has_flag("--print-skipped") || cfg_flag("--print-skipped");
     opts.show_pull_author = parser.has_flag("--show-pull-author") || cfg_flag("--show-pull-author");
-    opts.keep_first_valid = parser.has_flag("--keep-first") || cfg_flag("--keep-first");
     opts.wait_empty = parser.has_flag("--wait-empty") || cfg_flag("--wait-empty");
     opts.silent = parser.has_flag("--silent") || cfg_flag("--silent");
     opts.recursive_scan = parser.has_flag("--recursive") || cfg_flag("--recursive");

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -200,7 +200,7 @@ TEST_CASE("parse_options print skipped and pull author") {
     REQUIRE(opts.show_pull_author);
 }
 
-TEST_CASE("parse_options keep first valid") {
+TEST_CASE("parse_options keep first alias") {
     const char* argv[] = {"prog", "path", "--keep-first"};
     Options opts = parse_options(3, const_cast<char**>(argv));
     REQUIRE(opts.keep_first_valid);


### PR DESCRIPTION
## Summary
- clean up `keep_first_valid` definition
- combine `--keep-first` flag handling with `--keep-first-valid`
- rename duplicate test case and fix lint issues

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688b3ea353c08325b6e2d7e2495c0c31