### PR TITLE
Add enable-hotkeys option

### DIFF
--- a/include/options.hpp
+++ b/include/options.hpp
@@ -54,6 +54,7 @@ struct Options {
     std::string custom_color;
     std::vector<std::filesystem::path> ignore_dirs;
     bool enable_history = false;
+    bool enable_hotkeys = false;
     bool auto_config = false;
     bool auto_reload_config = false;
     bool rerun_last = false;

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -47,6 +47,7 @@ void print_help(const char* prog) {
         {"--rerun-last", "", "", "Reuse args from .autogitpull.config", "Config"},
         {"--save-args", "", "", "Save args to config file", "Config"},
         {"--enable-history", "", "", "Enable command history", "Config"},
+        {"--enable-hotkeys", "", "", "Enable TUI hotkeys", "Config"},
         {"--config-yaml", "-y", "<file>", "Load options from YAML file", "Config"},
         {"--config-json", "-j", "<file>", "Load options from JSON file", "Config"},
         {"--show-skipped", "-k", "", "Show skipped repositories", "Display"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -141,6 +141,7 @@ Options parse_options(int argc, char* argv[]) {
                                       "--rerun-last",
                                       "--save-args",
                                       "--enable-history",
+                                      "--enable-hotkeys",
                                       "--session-dates-only",
                                       "--print-skipped",
                                       "--show-pull-author",
@@ -362,6 +363,7 @@ Options parse_options(int argc, char* argv[]) {
     opts.rerun_last = parser.has_flag("--rerun-last") || cfg_flag("--rerun-last");
     opts.save_args = parser.has_flag("--save-args") || cfg_flag("--save-args");
     opts.enable_history = parser.has_flag("--enable-history") || cfg_flag("--enable-history");
+    opts.enable_hotkeys = parser.has_flag("--enable-hotkeys") || cfg_flag("--enable-hotkeys");
     opts.session_dates_only =
         parser.has_flag("--session-dates-only") || cfg_flag("--session-dates-only");
     opts.cli_print_skipped = parser.has_flag("--print-skipped") || cfg_flag("--print-skipped");

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -212,6 +212,12 @@ TEST_CASE("parse_options ignore lock") {
     REQUIRE(opts.ignore_lock);
 }
 
+TEST_CASE("parse_options enable hotkeys") {
+    const char* argv[] = {"prog", "path", "--enable-hotkeys"};
+    Options opts = parse_options(3, const_cast<char**>(argv));
+    REQUIRE(opts.enable_hotkeys);
+}
+
 TEST_CASE("parse_options repo overrides") {
     fs::path cfg = fs::temp_directory_path() / "opts_repo.json";
     {


### PR DESCRIPTION
## Summary
- add `enable_hotkeys` field in `Options`
- parse `--enable-hotkeys` from CLI/config
- document the flag in help text
- test parsing the new option

## Testing
- `make lint`
- `make test` *(fails: could not complete build)*

------
https://chatgpt.com/codex/tasks/task_e_688b6aceece08325a7cae03467599b82