### PR TITLE
Update CI with sequential jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,11 @@ on:
     branches: ["**"]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  format:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -17,10 +20,116 @@ jobs:
         uses: aminya/setup-cpp@v1
 
       - name: Install dependencies
-        run: ./scripts/install_deps.sh
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            scripts\install_deps.bat
+          else
+            ./scripts/install_deps.sh
+          fi
 
-      - name: Lint
+      - name: Install lint tools
+        run: pip install cpplint
+
+      - name: Install clang-format
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update && sudo apt-get install -y clang-format
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew install clang-format
+          elif [ "$RUNNER_OS" = "Windows" ]; then
+            choco install -y llvm
+          fi
+
+      - name: Auto Format
+        run: make format && git diff --exit-code
+
+  lint:
+    needs: format
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up build environment
+        uses: aminya/setup-cpp@v1
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            scripts\install_deps.bat
+          else
+            ./scripts/install_deps.sh
+          fi
+
+      - name: Install lint tools
+        run: pip install cpplint
+
+      - name: Install clang-format
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update && sudo apt-get install -y clang-format
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew install clang-format
+          elif [ "$RUNNER_OS" = "Windows" ]; then
+            choco install -y llvm
+          fi
+
+      - name: Auto Lint
         run: make lint
 
-      - name: Test
+  test:
+    needs: lint
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up build environment
+        uses: aminya/setup-cpp@v1
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            scripts\install_deps.bat
+          else
+            ./scripts/install_deps.sh
+          fi
+
+      - name: Auto Test
         run: make test
+
+  build:
+    needs: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up build environment
+        uses: aminya/setup-cpp@v1
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            scripts\install_deps.bat
+          else
+            ./scripts/install_deps.sh
+          fi
+
+      - name: Auto Build
+        run: make

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,10 @@ lint:
 	clang-format --dry-run --Werror $(FORMAT_FILES)
 	cpplint --linelength=100 $(FORMAT_FILES)
 
+format:
+	clang-format -i $(FORMAT_FILES)
+
 deps:
 	./scripts/install_deps.sh
 
-.PHONY: all clean lint deps test
+.PHONY: all clean lint format deps test

--- a/agents.md
+++ b/agents.md
@@ -2,23 +2,28 @@
 
 To maintain code quality, all commits must pass the following checks **before** they are committed:
 
-1. `make lint` – runs `clang-format` and `cpplint` using the project's `.clang-format` configuration.
-2. The full test suite via `make test`.
+1. `make format` – automatically formats all source files.
+2. `make lint` – runs `clang-format` and `cpplint` using the project's `.clang-format` configuration.
+3. The full test suite via `make test`.
+4. A full build via `make` to verify compilation.
 
 Run these commands locally from the repository root:
 
 ```bash
+make format
 make lint
 make test
+make
 ```
 
-`clang-format` (configured by `.clang-format`) and `cpplint` are mandatory tools. You can auto-format sources with:
+`clang-format` (configured by `.clang-format`) and `cpplint` are mandatory tools. You can auto-format sources manually with:
 
 ```bash
 clang-format -i <file.cpp> <file.hpp>
 ```
 
 If any command fails, fix the issues before committing. Pull requests failing any of these checks will be rejected.
+The CI pipeline runs four sequential jobs—auto-format, auto-lint, auto-test and auto-build—on Linux, macOS and Windows. Ensure each stage succeeds before merging.
 
 When adding new C++ source files, update all build scripts (`compile.sh`, `compile.bat`, and `compile-cl.bat`) so they compile the new files. Build script changes are mandatory.
 ## Repository Overview


### PR DESCRIPTION
## Summary
- split CI workflow into separate sequential jobs
- clarify contribution guidelines about the sequential CI steps

## Testing
- `make format`
- `make lint`
- `./scripts/install_deps.sh`
- `make test` *(failed: build interrupted)*
- `make` *(failed: undefined reference errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b68e2f9f083258e02e5221924c509