### PR TITLE
Implement TUI hotkeys

### DIFF
--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -31,6 +31,7 @@ void draw_tui(const std::vector<std::filesystem::path>& all_repos,
               bool show_version, bool track_cpu, bool track_mem, bool track_threads, bool track_net,
               bool show_affinity, bool track_vmem, bool show_commit_date, bool show_commit_author,
               bool session_dates_only, bool no_colors, const std::string& custom_color,
-              int runtime_sec, bool show_datetime_line, bool show_header, bool show_repo_count);
+              const std::string& status_msg, int runtime_sec, bool show_datetime_line,
+              bool show_header, bool show_repo_count);
 
 #endif // TUI_HPP

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -46,7 +46,8 @@ void draw_tui(const std::vector<fs::path>& all_repos,
               bool track_cpu, bool track_mem, bool track_threads, bool track_net,
               bool show_affinity, bool track_vmem, bool show_commit_date, bool show_commit_author,
               bool session_dates_only, bool no_colors, const std::string& custom_color,
-              int runtime_sec, bool show_datetime_line, bool show_header, bool show_repo_count) {
+              const std::string& status_msg, int runtime_sec, bool show_datetime_line,
+              bool show_header, bool show_repo_count) {
     std::ostringstream out;
     auto choose = [&](const char* def) {
         return no_colors ? "" : (custom_color.empty() ? def : custom_color.c_str());
@@ -80,6 +81,8 @@ void draw_tui(const std::vector<fs::path>& all_repos,
     if (runtime_sec >= 0)
         out << " - Runtime " << format_duration_short(std::chrono::seconds(runtime_sec));
     out << "\n";
+    if (!status_msg.empty())
+        out << status_msg << "\n";
     if (track_cpu || track_mem || track_threads || show_affinity || track_vmem) {
         out << "CPU: ";
         if (track_cpu)


### PR DESCRIPTION
## Summary
- support non-blocking keyboard input for the TUI
- display user status messages and updated interval in the UI
- add runtime hotkeys for rescanning and quitting

## Testing
- `make lint`
- `make test` *(fails: yaml-cpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_688b97e5019483259ecb3b128df41eb9