### PR TITLE
Allow runtime interval changes

### DIFF
--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -277,6 +277,7 @@ int run_event_loop(const Options& opts) {
     procutil::get_memory_usage_mb();
     procutil::get_thread_count();
     setup_logging(opts);
+    int interval = opts.interval;
     if (!opts.log_dir.empty())
         fs::create_directories(opts.log_dir);
     std::vector<fs::path> all_repos;
@@ -294,9 +295,9 @@ int run_event_loop(const Options& opts) {
     }
     while (valid_count == 0 && opts.wait_empty) {
         if (!opts.silent)
-            std::cout << "No valid repositories found. Retrying in " << opts.interval << "s..."
+            std::cout << "No valid repositories found. Retrying in " << interval << "s..."
                       << std::endl;
-        std::this_thread::sleep_for(std::chrono::seconds(opts.interval));
+        std::this_thread::sleep_for(std::chrono::seconds(interval));
         prepare_repos(opts, all_repos, repo_infos);
         valid_count = 0;
         for (const auto& p : all_repos) {
@@ -309,7 +310,7 @@ int run_event_loop(const Options& opts) {
         return 0;
     }
     if (opts.cli && !opts.silent) {
-        std::cout << "Interval: " << opts.interval << "s"
+        std::cout << "Interval: " << interval << "s"
                   << " Refresh: " << opts.refresh_ms.count() << "ms";
         if (opts.pull_timeout.count() > 0)
             std::cout << " Timeout: " << opts.pull_timeout.count() << "s";
@@ -342,7 +343,6 @@ int run_event_loop(const Options& opts) {
     std::unique_ptr<AltScreenGuard> guard;
     if (!opts.cli && !opts.silent)
         guard = std::make_unique<AltScreenGuard>();
-    int interval = opts.interval;
     std::string user_message;
     bool confirm_quit = false;
 #ifndef _WIN32


### PR DESCRIPTION
## Summary
- introduce mutable `interval` variable in run_event_loop
- use the variable for wait-empty retry messages
- show current interval in CLI output
- pass the current interval through update_ui and draw_tui

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688b9f1a650c8325aa15c9f2699a62a8