### PR TITLE
Document rolling release version

### DIFF
--- a/include/version.hpp
+++ b/include/version.hpp
@@ -3,11 +3,15 @@
 
 /* ------------------------------------------------------------------
    Public numeric version macros (safe for .rc files)               */
-#define AUTOGITPULL_VERSION_MAJOR 1
+#define AUTOGITPULL_VERSION_MAJOR 0
 #define AUTOGITPULL_VERSION_MINOR 0
 #define AUTOGITPULL_VERSION_PATCH 0
 
-#define AUTOGITPULL_VERSION_STR "1.0.0"
+/*
+ * Rolling release tag injected by the CI workflow.
+ * Example format: "2025.07.31-1".
+ */
+#define AUTOGITPULL_VERSION_STR "rolling"
 #define AUTOGITPULL_VERSION_RC                                                                     \
     AUTOGITPULL_VERSION_MAJOR, AUTOGITPULL_VERSION_MINOR, AUTOGITPULL_VERSION_PATCH, 0
 /* ------------------------------------------------------------------ */

--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 : 1
 name: autogitpull
-version: 1.0.0
+version: rolling
 summary: Automatic Git Puller & Monitor
 depends: libgit2
 depends: yaml-cpp

--- a/readme.md
+++ b/readme.md
@@ -379,6 +379,13 @@ When the program starts, each repository is listed with the **Pending** status
 until it is checked for the first time. Once a scan begins the status switches
 to **Checking** and later reflects the pull result.
 
+### Versioning
+
+autogitpull uses a rolling release model. Each push to the `main` branch
+triggers the CI workflow that tags the commit with a date-based string such as
+`2025.07.31-1`. The `--version` flag prints this tag so the program is always
+identified by the latest CI release.
+
 ## Production requirements
 
 - **Git** must be available in your `PATH` for libgit2 to interact with repositories.


### PR DESCRIPTION
## Summary
- mention rolling release in docs
- update manifest and version header

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688ba4a5075483258e7d32a12a25e7ca