### PR TITLE
Implement exit confirmation prompt

### DIFF
--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -73,7 +73,7 @@ void draw_tui(const std::vector<fs::path>& all_repos,
         out << "Repos: " << all_repos.size() << "\n";
     out << "Interval: " << interval << "s    (Ctrl+C to exit)\n";
     out << "Status: ";
-    if (scanning)
+    if (scanning || action != "Idle")
         out << COLOR_YELLOW << action << COLOR_RESET;
     else
         out << green << "Idle" << reset;

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -102,7 +102,7 @@ void draw_cli(const std::vector<fs::path>& all_repos,
     if (show_repo_count)
         std::cout << "Repos: " << all_repos.size() << "\n";
     std::cout << "Status: ";
-    if (scanning)
+    if (scanning || action != "Idle")
         std::cout << action;
     else
         std::cout << "Idle";
@@ -343,7 +343,6 @@ int run_event_loop(const Options& opts) {
     std::unique_ptr<AltScreenGuard> guard;
     if (!opts.cli && !opts.silent)
         guard = std::make_unique<AltScreenGuard>();
-    int interval = opts.interval;
     std::string user_message;
     bool confirm_quit = false;
     std::chrono::steady_clock::time_point confirm_until;


### PR DESCRIPTION
## Summary
- show `current_action` even when not scanning
- remove duplicate `interval` declaration and sync CLI status

## Testing
- `make format`
- `make lint`
- `make test`
- `make` *(fails: undefined reference to gssapi symbols)*

------
https://chatgpt.com/codex/tasks/task_e_688bc55830d483258879b3e3c51fc037