### PR TITLE
Implement auto config search

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -39,6 +39,61 @@ Options parse_options(int argc, char* argv[]) {
             throw std::runtime_error("Failed to load config: " + err);
     }
 
+    // Look for automatic config files if requested
+    const std::set<std::string> auto_known{"--root", "--auto-config"};
+    const std::map<char, std::string> auto_short{{'o', "--root"}};
+    ArgParser auto_parser(argc, argv, auto_known, auto_short);
+    auto cfg_flag_pre = [&](const std::string& k) {
+        auto it = cfg_opts.find(k);
+        if (it == cfg_opts.end())
+            return false;
+        std::string v = it->second;
+        std::transform(v.begin(), v.end(), v.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        return v == "" || v == "1" || v == "true" || v == "yes";
+    };
+
+    bool want_auto = auto_parser.has_flag("--auto-config") || cfg_flag_pre("--auto-config");
+    fs::path root_hint;
+    if (auto_parser.has_flag("--root"))
+        root_hint = auto_parser.get_option("--root");
+    else if (!auto_parser.positional().empty())
+        root_hint = auto_parser.positional().front();
+    if (root_hint.empty() && cfg_opts.count("--root"))
+        root_hint = cfg_opts["--root"];
+
+    if (want_auto) {
+        auto find_cfg = [](const fs::path& dir) -> fs::path {
+            if (dir.empty())
+                return {};
+            fs::path y = dir / ".autogitpull.yaml";
+            if (fs::exists(y))
+                return y;
+            fs::path j = dir / ".autogitpull.json";
+            if (fs::exists(j))
+                return j;
+            return {};
+        };
+        fs::path exe_dir;
+        if (argv && argv[0])
+            exe_dir = fs::absolute(argv[0]).parent_path();
+        fs::path cfg_path = find_cfg(root_hint);
+        if (cfg_path.empty())
+            cfg_path = find_cfg(fs::current_path());
+        if (cfg_path.empty())
+            cfg_path = find_cfg(exe_dir);
+        if (!cfg_path.empty()) {
+            std::string err;
+            if (cfg_path.extension() == ".yaml") {
+                if (!load_yaml_config(cfg_path.string(), cfg_opts, cfg_repo_opts, err))
+                    throw std::runtime_error("Failed to load config: " + err);
+            } else {
+                if (!load_json_config(cfg_path.string(), cfg_opts, cfg_repo_opts, err))
+                    throw std::runtime_error("Failed to load config: " + err);
+            }
+        }
+    }
+
     const std::set<std::string> known{"--include-private",
                                       "--show-skipped",
                                       "--show-version",


### PR DESCRIPTION
## Summary
- extend option parsing to look for `.autogitpull.yaml` or `.autogitpull.json`
- search in root directory, cwd and executable directory
- add regression tests for lookup order

## Testing
- `make format`
- `make lint`
- `make test`
- `make LIBGIT2_STATIC_AVAILABLE=no`

------
https://chatgpt.com/codex/tasks/task_e_688bcba90d3883259ee11369b566d1ec