### PR TITLE
Show active repo count in UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NOT Catch2_FOUND)
     FetchContent_MakeAvailable(Catch2)
 endif()
 add_executable(autogitpull_tests
-  tests/arg_parser_tests.cpp tests/utils_tests.cpp tests/options_tests.cpp tests/config_tests.cpp tests/repo_tests.cpp tests/process_tests.cpp src/autogitpull.cpp src/tui.cpp)
+  tests/arg_parser_tests.cpp tests/utils_tests.cpp tests/options_tests.cpp tests/config_tests.cpp tests/repo_tests.cpp tests/process_tests.cpp tests/ui_output_tests.cpp src/autogitpull.cpp src/tui.cpp)
 target_include_directories(autogitpull_tests PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(autogitpull_tests PRIVATE AUTOGITPULL_NO_MAIN)
 target_link_libraries(autogitpull_tests PRIVATE Catch2::Catch2WithMain autogitpull_lib)

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -69,8 +69,16 @@ void draw_tui(const std::vector<fs::path>& all_repos,
         out << "Date: " << cyan << timestamp() << reset << "\n";
     out << "Monitoring: " << yellow
         << (all_repos.empty() ? "" : all_repos[0].parent_path().string()) << reset << "\n";
-    if (show_repo_count)
-        out << "Repos: " << all_repos.size() << "\n";
+    if (show_repo_count) {
+        size_t active = 0;
+        for (const auto& p : all_repos) {
+            auto it = repo_infos.find(p);
+            RepoStatus st = it != repo_infos.end() ? it->second.status : RS_PENDING;
+            if (st != RS_SKIPPED)
+                ++active;
+        }
+        out << "Repos: " << active << "/" << all_repos.size() << "\n";
+    }
     out << "Interval: " << interval << "s    (Ctrl+C to exit)\n";
     out << "Status: ";
     if (scanning || action != "Idle")

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -99,8 +99,16 @@ void draw_cli(const std::vector<fs::path>& all_repos,
               const std::map<fs::path, RepoInfo>& repo_infos, int seconds_left, bool scanning,
               const std::string& action, bool show_skipped, int runtime_sec, bool show_repo_count,
               bool session_dates_only) {
-    if (show_repo_count)
-        std::cout << "Repos: " << all_repos.size() << "\n";
+    if (show_repo_count) {
+        size_t active = 0;
+        for (const auto& p : all_repos) {
+            auto it = repo_infos.find(p);
+            RepoStatus st = it != repo_infos.end() ? it->second.status : RS_PENDING;
+            if (st != RS_SKIPPED)
+                ++active;
+        }
+        std::cout << "Repos: " << active << "/" << all_repos.size() << "\n";
+    }
     std::cout << "Status: ";
     if (scanning || action != "Idle")
         std::cout << action;

--- a/tests/ui_output_tests.cpp
+++ b/tests/ui_output_tests.cpp
@@ -1,0 +1,23 @@
+#include <sstream>
+#include <iostream>
+#include "test_common.hpp"
+#include "ui_loop.hpp"
+// Forward declaration of draw_cli from ui_loop.cpp
+void draw_cli(const std::vector<fs::path>& all_repos,
+              const std::map<fs::path, RepoInfo>& repo_infos, int seconds_left, bool scanning,
+              const std::string& action, bool show_skipped, int runtime_sec, bool show_repo_count,
+              bool session_dates_only);
+
+TEST_CASE("draw_cli shows active repo count") {
+    std::vector<fs::path> repos = {"/a", "/b", "/c"};
+    std::map<fs::path, RepoInfo> infos;
+    infos[repos[0]] = RepoInfo{repos[0], RS_UP_TO_DATE, "", "", "", "", "", "", 0, false};
+    infos[repos[1]] = RepoInfo{repos[1], RS_SKIPPED, "", "", "", "", "", "", 0, false};
+    infos[repos[2]] = RepoInfo{repos[2], RS_PENDING, "", "", "", "", "", "", 0, false};
+    std::ostringstream oss;
+    auto* old = std::cout.rdbuf(oss.rdbuf());
+    draw_cli(repos, infos, 10, false, "Idle", true, -1, true, false);
+    std::cout.rdbuf(old);
+    std::string out = oss.str();
+    REQUIRE(out.rfind("Repos: 2/3\n", 0) == 0);
+}


### PR DESCRIPTION
## Summary
- show number of active repos versus total in TUI/CLI
- test CLI repo count formatting

## Testing
- `make test`
- `make LIBGIT2_STATIC_AVAILABLE=no`


------
https://chatgpt.com/codex/tasks/task_e_688bd6e4753c8325b115754fbda0c787