### PR TITLE
Implement repo name censoring option

### DIFF
--- a/include/options.hpp
+++ b/include/options.hpp
@@ -47,6 +47,8 @@ struct Options {
     bool show_commit_author = false;
     bool show_pull_author = false;
     bool show_repo_count = false;
+    bool censor_names = false;
+    char censor_char = '*';
     bool session_dates_only = false;
     bool show_datetime_line = true;
     bool show_header = true;

--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -32,6 +32,6 @@ void draw_tui(const std::vector<std::filesystem::path>& all_repos,
               bool show_affinity, bool track_vmem, bool show_commit_date, bool show_commit_author,
               bool session_dates_only, bool no_colors, const std::string& custom_color,
               const std::string& status_msg, int runtime_sec, bool show_datetime_line,
-              bool show_header, bool show_repo_count);
+              bool show_header, bool show_repo_count, bool censor_names, char censor_char);
 
 #endif // TUI_HPP

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,8 @@ Most options have single-letter shorthands. Run `autogitpull --help` for a compl
 - `--row-order` `<mode>` – Row ordering (alpha/reverse).
 - `--color` `<ansi>` – Override status color.
 - `--no-colors` (`-C`) – Disable ANSI colors.
+- `--censor-names` – Mask repository names in output.
+- `--censor-char` `<ch>` – Character used for masking.
 
 #### Config
 - `--auto-config` – Auto detect YAML or JSON config.

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -66,6 +66,8 @@ void print_help(const char* prog) {
         {"--row-order", "", "<mode>", "Row ordering (alpha/reverse)", "Display"},
         {"--color", "", "<ansi>", "Override status color", "Display"},
         {"--no-colors", "-C", "", "Disable ANSI colors", "Display"},
+        {"--censor-names", "", "", "Mask repository names", "Display"},
+        {"--censor-char", "", "<ch>", "Character for name masking", "Display"},
         {"--check-only", "-x", "", "Only check for updates", "Actions"},
         {"--no-hash-check", "-N", "", "Always pull without hash check", "Actions"},
         {"--force-pull", "-f", "", "Discard local changes when pulling", "Actions"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -200,6 +200,8 @@ Options parse_options(int argc, char* argv[]) {
                                       "--session-dates-only",
                                       "--print-skipped",
                                       "--show-pull-author",
+                                      "--censor-names",
+                                      "--censor-char",
                                       "--keep-first"};
     const std::map<char, std::string> short_opts{{'p', "--include-private"},
                                                  {'k', "--show-skipped"},
@@ -431,6 +433,15 @@ Options parse_options(int argc, char* argv[]) {
         parser.has_flag("--session-dates-only") || cfg_flag("--session-dates-only");
     opts.cli_print_skipped = parser.has_flag("--print-skipped") || cfg_flag("--print-skipped");
     opts.show_pull_author = parser.has_flag("--show-pull-author") || cfg_flag("--show-pull-author");
+    opts.censor_names = parser.has_flag("--censor-names") || cfg_flag("--censor-names");
+    if (parser.has_flag("--censor-char") || cfg_opts.count("--censor-char")) {
+        std::string val = parser.get_option("--censor-char");
+        if (val.empty())
+            val = cfg_opt("--censor-char");
+        if (val.empty())
+            throw std::runtime_error("--censor-char requires a character");
+        opts.censor_char = val[0];
+    }
     opts.wait_empty = parser.has_flag("--wait-empty") || cfg_flag("--wait-empty");
     if (opts.wait_empty) {
         std::string val = parser.get_option("--wait-empty");

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -47,7 +47,7 @@ void draw_tui(const std::vector<fs::path>& all_repos,
               bool show_affinity, bool track_vmem, bool show_commit_date, bool show_commit_author,
               bool session_dates_only, bool no_colors, const std::string& custom_color,
               const std::string& status_msg, int runtime_sec, bool show_datetime_line,
-              bool show_header, bool show_repo_count) {
+              bool show_header, bool show_repo_count, bool censor_names, char censor_char) {
     std::ostringstream out;
     auto choose = [&](const char* def) {
         return no_colors ? "" : (custom_color.empty() ? def : custom_color.c_str());
@@ -195,8 +195,10 @@ void draw_tui(const std::vector<fs::path>& all_repos,
             status_s = "RemoteUp";
             break;
         }
-        out << color << " [" << std::left << std::setw(9) << status_s << "]  "
-            << p.filename().string() << reset;
+        std::string name = p.filename().string();
+        if (censor_names)
+            name.assign(name.size(), censor_char);
+        out << color << " [" << std::left << std::setw(9) << status_s << "]  " << name << reset;
         if (!ri.branch.empty()) {
             out << "  (" << ri.branch;
             if (!ri.commit.empty())

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -314,3 +314,17 @@ TEST_CASE("parse_options wait empty with limit") {
     REQUIRE(opts.wait_empty);
     REQUIRE(opts.wait_empty_limit == 5);
 }
+
+TEST_CASE("parse_options censor names flag") {
+    const char* argv[] = {"prog", "path", "--censor-names"};
+    Options opts = parse_options(3, const_cast<char**>(argv));
+    REQUIRE(opts.censor_names);
+    REQUIRE(opts.censor_char == '*');
+}
+
+TEST_CASE("parse_options censor char") {
+    const char* argv[] = {"prog", "path", "--censor-char", "#"};
+    Options opts = parse_options(4, const_cast<char**>(argv));
+    REQUIRE(!opts.censor_names);
+    REQUIRE(opts.censor_char == '#');
+}

--- a/tests/ui_output_tests.cpp
+++ b/tests/ui_output_tests.cpp
@@ -4,9 +4,10 @@
 #include "ui_loop.hpp"
 // Forward declaration of draw_cli from ui_loop.cpp
 void draw_cli(const std::vector<fs::path>& all_repos,
-              const std::map<fs::path, RepoInfo>& repo_infos, int seconds_left, bool scanning,
-              const std::string& action, bool show_skipped, int runtime_sec, bool show_repo_count,
-              bool session_dates_only);
+              const std::map<fs::path, RepoInfo>& repo_infos, int seconds_left,
+              bool scanning, const std::string& action, bool show_skipped,
+              int runtime_sec, bool show_repo_count, bool session_dates_only,
+              bool censor_names, char censor_char);
 
 TEST_CASE("draw_cli shows active repo count") {
     std::vector<fs::path> repos = {"/a", "/b", "/c"};
@@ -16,7 +17,7 @@ TEST_CASE("draw_cli shows active repo count") {
     infos[repos[2]] = RepoInfo{repos[2], RS_PENDING, "", "", "", "", "", "", 0, false};
     std::ostringstream oss;
     auto* old = std::cout.rdbuf(oss.rdbuf());
-    draw_cli(repos, infos, 10, false, "Idle", true, -1, true, false);
+    draw_cli(repos, infos, 10, false, "Idle", true, -1, true, false, false, '*');
     std::cout.rdbuf(old);
     std::string out = oss.str();
     REQUIRE(out.rfind("Repos: 2/3\n", 0) == 0);


### PR DESCRIPTION
## Summary
- add `censor_names` boolean and `censor-char` option
- hide repository names when censoring enabled in TUI/CLI
- document the new options in help text and README
- test option parsing

## Testing
- `make format`
- `make lint`
- `make test`
- `make` *(fails: undefined reference to `gssapi` symbols)*

------
https://chatgpt.com/codex/tasks/task_e_688bde5c33648325b74d02c6041c5d6d