### PR TITLE
Add config file auto-detection for history

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -854,5 +854,27 @@ Options parse_options(int argc, char* argv[]) {
         }
         opts.repo_overrides[fs::path(repo)] = ro;
     }
+
+    if ((opts.rerun_last || opts.save_args || opts.enable_history) &&
+        opts.history_file == ".autogitpull.config") {
+        auto find_hist = [](const fs::path& dir) -> fs::path {
+            if (dir.empty())
+                return {};
+            fs::path c = dir / ".autogitpull.config";
+            if (fs::exists(c))
+                return c;
+            return {};
+        };
+        fs::path exe_dir;
+        if (argv && argv[0])
+            exe_dir = fs::absolute(argv[0]).parent_path();
+        fs::path hist = find_hist(opts.root);
+        if (hist.empty())
+            hist = find_hist(fs::current_path());
+        if (hist.empty())
+            hist = find_hist(exe_dir);
+        if (!hist.empty())
+            opts.history_file = hist.string();
+    }
     return opts;
 }

--- a/tests/history_tests.cpp
+++ b/tests/history_tests.cpp
@@ -1,5 +1,14 @@
 #include "test_common.hpp"
 
+struct DirGuard {
+    std::filesystem::path old;
+    explicit DirGuard(const std::filesystem::path& p)
+        : old(std::filesystem::current_path()) {
+        std::filesystem::current_path(p);
+    }
+    ~DirGuard() { std::filesystem::current_path(old); }
+};
+
 TEST_CASE("history append capped at 100") {
     fs::path file = fs::temp_directory_path() / "hist_test.txt";
     fs::remove(file);
@@ -24,4 +33,64 @@ TEST_CASE("parse_options enable history custom file") {
     Options opts = parse_options(3, const_cast<char**>(argv));
     REQUIRE(opts.enable_history);
     REQUIRE(opts.history_file == "myhist");
+}
+
+TEST_CASE("enable history auto-detect root") {
+    fs::path root_dir = fs::temp_directory_path() / "hist_root";
+    fs::path cwd_dir = fs::temp_directory_path() / "hist_cwd";
+    fs::path exe_dir = fs::temp_directory_path() / "hist_exe";
+    fs::create_directories(root_dir);
+    fs::create_directories(cwd_dir);
+    fs::create_directories(exe_dir);
+    std::ofstream(root_dir / ".autogitpull.config") << "line\n";
+    DirGuard guard(cwd_dir);
+    std::string exe = (exe_dir / "prog").string();
+    std::string root_s = root_dir.string();
+    char* argv[] = {const_cast<char*>(exe.c_str()), const_cast<char*>(root_s.c_str()), const_cast<char*>("--enable-history")};
+    Options opts = parse_options(3, argv);
+    REQUIRE(opts.history_file == (root_dir / ".autogitpull.config").string());
+    auto hist = read_history(opts.history_file);
+    REQUIRE(hist.size() == 1);
+    REQUIRE(hist[0] == "line");
+    fs::remove_all(root_dir);
+    fs::remove_all(cwd_dir);
+    fs::remove_all(exe_dir);
+}
+
+TEST_CASE("enable history auto-detect cwd fallback") {
+    fs::path root_dir = fs::temp_directory_path() / "hist_root2";
+    fs::path cwd_dir = fs::temp_directory_path() / "hist_cwd2";
+    fs::path exe_dir = fs::temp_directory_path() / "hist_exe2";
+    fs::create_directories(root_dir);
+    fs::create_directories(cwd_dir);
+    fs::create_directories(exe_dir);
+    std::ofstream(cwd_dir / ".autogitpull.config") << "line2\n";
+    DirGuard guard(cwd_dir);
+    std::string exe = (exe_dir / "prog").string();
+    std::string root_s = root_dir.string();
+    char* argv[] = {const_cast<char*>(exe.c_str()), const_cast<char*>(root_s.c_str()), const_cast<char*>("--enable-history")};
+    Options opts = parse_options(3, argv);
+    REQUIRE(opts.history_file == (cwd_dir / ".autogitpull.config").string());
+    fs::remove_all(root_dir);
+    fs::remove_all(cwd_dir);
+    fs::remove_all(exe_dir);
+}
+
+TEST_CASE("enable history auto-detect exe fallback") {
+    fs::path root_dir = fs::temp_directory_path() / "hist_root3";
+    fs::path cwd_dir = fs::temp_directory_path() / "hist_cwd3";
+    fs::path exe_dir = fs::temp_directory_path() / "hist_exe3";
+    fs::create_directories(root_dir);
+    fs::create_directories(cwd_dir);
+    fs::create_directories(exe_dir);
+    std::ofstream(exe_dir / ".autogitpull.config") << "line3\n";
+    DirGuard guard(cwd_dir);
+    std::string exe = (exe_dir / "prog").string();
+    std::string root_s = root_dir.string();
+    char* argv[] = {const_cast<char*>(exe.c_str()), const_cast<char*>(root_s.c_str()), const_cast<char*>("--enable-history")};
+    Options opts = parse_options(3, argv);
+    REQUIRE(opts.history_file == (exe_dir / ".autogitpull.config").string());
+    fs::remove_all(root_dir);
+    fs::remove_all(cwd_dir);
+    fs::remove_all(exe_dir);
 }


### PR DESCRIPTION
## Summary
- auto-detect `.autogitpull.config` for `--enable-history`, `--rerun-last`, and `--save-args`
- update command history tests for path auto detection

## Testing
- `make format`
- `make lint`
- `make test`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_688ccaeee28483258c132b1c7a741bb0