### PR TITLE
Support unit-suffixed refresh rate

### DIFF
--- a/examples/example-config.json
+++ b/examples/example-config.json
@@ -5,7 +5,7 @@
         "show-skipped": false,
         "show-version": false,
         "interval": 30,
-        "refresh-rate": 250,
+        "refresh-rate": "250ms",
         "cli": false,
         "single-run": false,
         "single-repo": false,

--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -2,7 +2,7 @@
 General : root : repos include - private : true show - skipped : false show -
                                                                  version
     : false interval : 30 refresh -
-      rate : 250 cli : false single - run : false single -
+      rate : 250ms cli : false single - run : false single -
                                             repo : false silent : false recursive
     : false max -
       depth : 0 row - order : default color : "" no - colors : false show - commit -

--- a/include/parse_utils.hpp
+++ b/include/parse_utils.hpp
@@ -34,4 +34,9 @@ unsigned long long parse_ull(const std::string& value, unsigned long long min,
 std::chrono::seconds parse_duration(const ArgParser& parser, const std::string& flag, bool& ok);
 std::chrono::seconds parse_duration(const std::string& value, bool& ok);
 
+// Parse milliseconds with optional unit suffix. Supports ms (default),
+// seconds with 's' and minutes with 'm'.
+std::chrono::milliseconds parse_time_ms(const ArgParser& parser, const std::string& flag, bool& ok);
+std::chrono::milliseconds parse_time_ms(const std::string& value, bool& ok);
+
 #endif // PARSE_UTILS_HPP

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ and shows progress either in an interactive TUI or with plain console output.
 
 ## Usage
 
-`autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--max-log-size <bytes>] [--ignore <dir>] [--recursive] [--max-depth <n>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n.n>] [--cpu-cores <mask>] [--mem-limit <M/G>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--download-limit <KB/MB>] [--upload-limit <KB/MB>] [--disk-limit <KB/MB>] [--total-traffic-limit <KB/MB/GB>] [--cli] [--single-run] [--silent] [--force-pull] [--remove-lock] [--hard-reset] [--confirm-reset] [--debug-memory] [--dump-state] [--dump-large <n>] [--attach <name>] [--background <name>] [--reattach <name>] [--persist[=name]] [--help]`
+`autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms|s|m>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--max-log-size <bytes>] [--ignore <dir>] [--recursive] [--max-depth <n>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n.n>] [--cpu-cores <mask>] [--mem-limit <M/G>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--download-limit <KB/MB>] [--upload-limit <KB/MB>] [--disk-limit <KB/MB>] [--total-traffic-limit <KB/MB/GB>] [--cli] [--single-run] [--silent] [--force-pull] [--remove-lock] [--hard-reset] [--confirm-reset] [--debug-memory] [--dump-state] [--dump-large <n>] [--attach <name>] [--background <name>] [--reattach <name>] [--persist[=name]] [--help]`
 
 ### TLDR usage tips
 
@@ -42,7 +42,7 @@ Most options have single-letter shorthands. Run `autogitpull --help` for a compl
 - `--include-private` (`-p`) – Include private repositories.
 - `--root` (`-o`) `<path>` – Root folder of repositories.
 - `--interval` (`-i`) `<sec>` – Delay between scans.
-- `--refresh-rate` (`-r`) `<ms>` – TUI refresh rate.
+- `--refresh-rate` (`-r`) `<ms|s|m>` – TUI refresh rate.
 - `--recursive` (`-e`) – Scan subdirectories recursively.
 - `--max-depth` (`-D`) `<n>` – Limit recursive scan depth.
 - `--ignore` (`-I`) `<dir>` – Directory to ignore (repeatable).

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -19,7 +19,7 @@ void print_help(const char* prog) {
         {"--include-private", "-p", "", "Include private repositories", "Basics"},
         {"--root", "-o", "<path>", "Root folder of repositories", "Basics"},
         {"--interval", "-i", "<sec>", "Delay between scans", "Basics"},
-        {"--refresh-rate", "-r", "<ms>", "TUI refresh rate", "Basics"},
+        {"--refresh-rate", "-r", "<ms|s|m>", "TUI refresh rate", "Basics"},
         {"--recursive", "-e", "", "Scan subdirectories recursively", "Basics"},
         {"--max-depth", "-D", "<n>", "Limit recursive scan depth", "Basics"},
         {"--ignore", "-I", "<dir>", "Directory to ignore (repeatable)", "Basics"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -665,16 +665,14 @@ Options parse_options(int argc, char* argv[]) {
             throw std::runtime_error("Invalid value for --interval");
     }
     if (cfg_opts.count("--refresh-rate")) {
-        int v = parse_int(cfg_opt("--refresh-rate"), 1, INT_MAX, ok);
-        if (!ok)
+        opts.refresh_ms = parse_time_ms(cfg_opt("--refresh-rate"), ok);
+        if (!ok || opts.refresh_ms.count() < 1)
             throw std::runtime_error("Invalid value for --refresh-rate");
-        opts.refresh_ms = std::chrono::milliseconds(v);
     }
     if (parser.has_flag("--refresh-rate")) {
-        int v = parse_int(parser, "--refresh-rate", 1, INT_MAX, ok);
-        if (!ok)
+        opts.refresh_ms = parse_time_ms(parser, "--refresh-rate", ok);
+        if (!ok || opts.refresh_ms.count() < 1)
             throw std::runtime_error("Invalid value for --refresh-rate");
-        opts.refresh_ms = std::chrono::milliseconds(v);
     }
     if (cfg_opts.count("--cpu-poll")) {
         opts.cpu_poll_sec = parse_uint(cfg_opt("--cpu-poll"), 1u, UINT_MAX, ok);

--- a/src/parse_utils.cpp
+++ b/src/parse_utils.cpp
@@ -165,6 +165,52 @@ std::chrono::seconds parse_duration(const ArgParser& parser, const std::string& 
     return parse_duration(parser.get_option(flag), ok);
 }
 
+std::chrono::milliseconds parse_time_ms(const std::string& value, bool& ok) {
+    ok = false;
+    if (value.empty())
+        return std::chrono::milliseconds(0);
+    std::string num = value;
+    enum Unit { MS, S, M } unit = MS;
+    if (num.size() > 1 && num.substr(num.size() - 2) == "ms") {
+        unit = MS;
+        num.resize(num.size() - 2);
+    } else if (num.back() == 's') {
+        unit = S;
+        num.pop_back();
+    } else if (num.back() == 'm') {
+        unit = M;
+        num.pop_back();
+    } else if (!std::isdigit(static_cast<unsigned char>(num.back()))) {
+        return std::chrono::milliseconds(0);
+    }
+    long long n = 0;
+    try {
+        n = std::stoll(num);
+    } catch (...) {
+        return std::chrono::milliseconds(0);
+    }
+    if (n < 0)
+        return std::chrono::milliseconds(0);
+    ok = true;
+    switch (unit) {
+    case S:
+        return std::chrono::milliseconds(n * 1000);
+    case M:
+        return std::chrono::milliseconds(n * 60000);
+    default:
+        return std::chrono::milliseconds(n);
+    }
+}
+
+std::chrono::milliseconds parse_time_ms(const ArgParser& parser, const std::string& flag,
+                                        bool& ok) {
+    if (!parser.has_flag(flag)) {
+        ok = false;
+        return std::chrono::milliseconds(0);
+    }
+    return parse_time_ms(parser.get_option(flag), ok);
+}
+
 static size_t unit_multiplier(const std::string& unit) {
     std::string u;
     for (char c : unit)

--- a/tests/arg_parser_tests.cpp
+++ b/tests/arg_parser_tests.cpp
@@ -204,3 +204,13 @@ TEST_CASE("parse_bytes units") {
     REQUIRE(parse_bytes("3G", 0, SIZE_MAX, ok) == 3ull * 1024 * 1024 * 1024);
     REQUIRE(ok);
 }
+
+TEST_CASE("parse_time_ms units") {
+    bool ok = false;
+    REQUIRE(parse_time_ms("250ms", ok) == std::chrono::milliseconds(250));
+    REQUIRE(ok);
+    REQUIRE(parse_time_ms("2s", ok) == std::chrono::milliseconds(2000));
+    REQUIRE(ok);
+    REQUIRE(parse_time_ms("1m", ok) == std::chrono::milliseconds(60000));
+    REQUIRE(ok);
+}

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -135,6 +135,12 @@ TEST_CASE("parse_options rescan-new custom interval") {
     REQUIRE(opts.rescan_interval == std::chrono::minutes(10));
 }
 
+TEST_CASE("parse_options refresh rate units") {
+    const char* argv[] = {"prog", "path", "--refresh-rate", "2s"};
+    Options opts = parse_options(4, const_cast<char**>(argv));
+    REQUIRE(opts.refresh_ms == std::chrono::seconds(2));
+}
+
 TEST_CASE("parse_options commit options") {
     const char* argv[] = {"prog",
                           "path",


### PR DESCRIPTION
## Summary
- add a new `parse_time_ms` helper for ms/s/m values
- use `parse_time_ms` for `--refresh-rate`
- document unit suffix support and update config examples
- test parsing helper and option handling

## Testing
- `make format`
- `make lint`
- `make test`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_688cd066e3dc83259da595da434dac95