### PR TITLE
Add alert confirmation flags

### DIFF
--- a/include/options.hpp
+++ b/include/options.hpp
@@ -117,11 +117,14 @@ struct Options {
     bool print_version = false;
     bool hard_reset = false;
     bool confirm_reset = false;
+    bool confirm_alert = false;
+    bool sudo_su = false;
     std::map<std::filesystem::path, RepoOptions> repo_overrides;
     enum SortMode { DEFAULT, ALPHA, REVERSE } sort_mode = DEFAULT;
 };
 
 Options parse_options(int argc, char* argv[]);
+bool alerts_allowed(const Options& opts);
 int run_event_loop(const Options& opts);
 
 #endif // OPTIONS_HPP

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ and shows progress either in an interactive TUI or with plain console output.
 
 ## Usage
 
-`autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms|s|m>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--max-log-size <bytes>] [--ignore <dir>] [--recursive] [--max-depth <n>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n.n>] [--cpu-cores <mask>] [--mem-limit <M/G>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--download-limit <KB/MB>] [--upload-limit <KB/MB>] [--disk-limit <KB/MB>] [--total-traffic-limit <KB/MB/GB>] [--cli] [--single-run] [--silent] [--force-pull] [--remove-lock] [--hard-reset] [--confirm-reset] [--debug-memory] [--dump-state] [--dump-large <n>] [--attach <name>] [--background <name>] [--reattach <name>] [--persist[=name]] [--help]`
+`autogitpull <root-folder> [--include-private] [--show-skipped] [--show-version] [--version] [--interval <seconds>] [--refresh-rate <ms|s|m>] [--cpu-poll <s>] [--mem-poll <s>] [--thread-poll <s>] [--log-dir <path>] [--log-file <path>] [--max-log-size <bytes>] [--ignore <dir>] [--recursive] [--max-depth <n>] [--log-level <level>] [--verbose] [--concurrency <n>] [--threads <n>] [--single-thread] [--max-threads <n>] [--cpu-percent <n.n>] [--cpu-cores <mask>] [--mem-limit <M/G>] [--check-only] [--no-hash-check] [--no-cpu-tracker] [--no-mem-tracker] [--no-thread-tracker] [--net-tracker] [--download-limit <KB/MB>] [--upload-limit <KB/MB>] [--disk-limit <KB/MB>] [--total-traffic-limit <KB/MB/GB>] [--cli] [--single-run] [--silent] [--force-pull] [--remove-lock] [--hard-reset] [--confirm-reset] [--confirm-alert] [--sudo-su] [--debug-memory] [--dump-state] [--dump-large <n>] [--attach <name>] [--background <name>] [--reattach <name>] [--persist[=name]] [--help]`
 
 ### TLDR usage tips
 
@@ -162,6 +162,8 @@ Most options have single-letter shorthands. Run `autogitpull --help` for a compl
 - `--ignore-lock` – Don't create or check lock file.
 - `--hard-reset` – Delete all logs and configs.
 - `--confirm-reset` – Confirm `--hard-reset`.
+- `--confirm-alert` – Confirm unsafe interval or force pull.
+- `--sudo-su` – Suppress confirmation alerts.
 
 
 By default, repositories whose `origin` remote does not point to GitHub or require authentication are skipped during scanning. Use `--include-private` to include them. Skipped repositories are hidden from the TUI unless `--show-skipped` is also provided.

--- a/src/autogitpull.cpp
+++ b/src/autogitpull.cpp
@@ -178,6 +178,11 @@ int main(int argc, char* argv[]) {
                 std::cout << name << " " << pid << "\n";
             return 0;
         }
+        if (!alerts_allowed(opts)) {
+            std::cerr << "WARNING: --interval below 15s or --force-pull used" << std::endl;
+            std::cerr << "Re-run with --confirm-alert or --sudo-su to proceed" << std::endl;
+            return 1;
+        }
         return run_with_monitor(opts);
     } catch (const std::exception& e) {
         std::cerr << e.what() << "\n";

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -102,6 +102,8 @@ void print_help(const char* prog) {
         {"--ignore-lock", "", "", "Don't create or check lock file", "Actions"},
         {"--hard-reset", "", "", "Delete all logs and configs", "Actions"},
         {"--confirm-reset", "", "", "Confirm --hard-reset", "Actions"},
+        {"--confirm-alert", "", "", "Confirm unsafe options", "Actions"},
+        {"--sudo-su", "", "", "Suppress confirmation alerts", "Actions"},
         {"--log-dir", "-d", "<path>", "Directory for pull logs", "Logging"},
         {"--log-file", "-l", "<path>", "File for general logs", "Logging"},
         {"--max-log-size", "", "<bytes>", "Rotate --log-file when over this size", "Logging"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -206,7 +206,9 @@ Options parse_options(int argc, char* argv[]) {
                                       "--censor-char",
                                       "--keep-first",
                                       "--hard-reset",
-                                      "--confirm-reset"};
+                                      "--confirm-reset",
+                                      "--confirm-alert",
+                                      "--sudo-su"};
     const std::map<char, std::string> short_opts{{'p', "--include-private"},
                                                  {'k', "--show-skipped"},
                                                  {'v', "--show-version"},
@@ -464,6 +466,8 @@ Options parse_options(int argc, char* argv[]) {
     opts.print_version = parser.has_flag("--version");
     opts.hard_reset = parser.has_flag("--hard-reset") || cfg_flag("--hard-reset");
     opts.confirm_reset = parser.has_flag("--confirm-reset") || cfg_flag("--confirm-reset");
+    opts.confirm_alert = parser.has_flag("--confirm-alert") || cfg_flag("--confirm-alert");
+    opts.sudo_su = parser.has_flag("--sudo-su") || cfg_flag("--sudo-su");
     if (!parser.unknown_flags().empty()) {
         throw std::runtime_error("Unknown option: " + parser.unknown_flags().front());
     }
@@ -875,4 +879,12 @@ Options parse_options(int argc, char* argv[]) {
             opts.history_file = hist.string();
     }
     return opts;
+}
+
+bool alerts_allowed(const Options& opts) {
+    if (opts.confirm_alert || opts.sudo_su)
+        return true;
+    if (opts.interval < 15 || opts.force_pull)
+        return false;
+    return true;
 }

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -347,3 +347,10 @@ TEST_CASE("parse_options max log size") {
     Options opts = parse_options(4, const_cast<char**>(argv));
     REQUIRE(opts.max_log_size == 100 * 1024);
 }
+
+TEST_CASE("parse_options alert flags") {
+    const char* argv[] = {"prog", "path", "--confirm-alert", "--sudo-su"};
+    Options opts = parse_options(4, const_cast<char**>(argv));
+    REQUIRE(opts.confirm_alert);
+    REQUIRE(opts.sudo_su);
+}

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -76,6 +76,21 @@ TEST_CASE("find_running_instances lists instances") {
 #endif
 }
 
+TEST_CASE("alerts_allowed logic") {
+    Options opts;
+    opts.interval = 10;
+    REQUIRE_FALSE(alerts_allowed(opts));
+    opts.confirm_alert = true;
+    REQUIRE(alerts_allowed(opts));
+    opts.confirm_alert = false;
+    opts.sudo_su = true;
+    REQUIRE(alerts_allowed(opts));
+    opts.sudo_su = false;
+    opts.interval = 20;
+    opts.force_pull = true;
+    REQUIRE_FALSE(alerts_allowed(opts));
+}
+
 TEST_CASE("find_running_instances detects process name") {
 #if defined(__linux__) || defined(__APPLE__)
     pid_t pid = fork();


### PR DESCRIPTION
## Summary
- add `--confirm-alert` and `--sudo-su` global options
- warn if interval is below 15s or `--force-pull` used
- expose `alerts_allowed` helper and test alert logic
- document new options in help output and README

## Testing
- `make format`
- `make lint`
- `make test`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_688cedac485083259978f7e16f71bac8