### PR TITLE
Organize .gitignore patterns by category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,19 @@
+# Build artifacts
 build/
+
+# Distribution files
 dist/
+
+# External libraries
 libs/
 
 # Log files
-*.log
-logs/
 log/
+logs/
+*.log
+
+# Ignores
+.autogitpull.ignore
 
 # Generated icon files
 */.bld

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -22,7 +22,7 @@ void print_help(const char* prog) {
         {"--refresh-rate", "-r", "<ms|s|m>", "TUI refresh rate", "Basics"},
         {"--recursive", "-e", "", "Scan subdirectories recursively", "Basics"},
         {"--max-depth", "-D", "<n>", "Limit recursive scan depth", "Basics"},
-        {"--ignore", "-I", "<dir>", "Directory to ignore (repeatable)", "Basics"},
+        {"--ignore", "-I", "<dir>", "Directory to ignore (repeatable)", "Ignores"},
         {"--single-run", "-u", "", "Run a single scan cycle and exit", "Basics"},
         {"--single-repo", "-S", "", "Only monitor the specified root repo", "Basics"},
         {"--rescan-new", "-w", "<min>", "Rescan for new repos every N minutes (default 5)",
@@ -104,11 +104,11 @@ void print_help(const char* prog) {
         {"--confirm-reset", "", "", "Confirm --hard-reset", "Actions"},
         {"--confirm-alert", "", "", "Confirm unsafe options", "Actions"},
         {"--sudo-su", "", "", "Suppress confirmation alerts", "Actions"},
-        {"--add-ignore", "", "<repo>", "Add path to .autogitpull.ignore", "Actions"},
-        {"--remove-ignore", "", "<repo>", "Remove path from ignore file", "Actions"},
-        {"--clear-ignores", "", "", "Delete all ignore entries", "Actions"},
-        {"--find-ignores", "", "", "List ignore entries", "Actions"},
-        {"--depth", "", "<n>", "Depth for --find-ignores/--clear-ignores", "Actions"},
+        {"--add-ignore", "", "<repo>", "Add path to .autogitpull.ignore", "Ignores"},
+        {"--remove-ignore", "", "<repo>", "Remove path from ignore file", "Ignores"},
+        {"--clear-ignores", "", "", "Delete all ignore entries", "Ignores"},
+        {"--find-ignores", "", "", "List ignore entries", "Ignores"},
+        {"--depth", "", "<n>", "Depth for --find-ignores/--clear-ignores", "Ignores"},
         {"--log-dir", "-d", "<path>", "Directory for pull logs", "Logging"},
         {"--log-file", "-l", "<path>", "File for general logs", "Logging"},
         {"--max-log-size", "", "<bytes>", "Rotate --log-file when over this size", "Logging"},
@@ -171,7 +171,7 @@ void print_help(const char* prog) {
     std::cout << "       " << prog << " --root <path> [options]\n\n";
     const std::vector<std::string> order{
         "Basics",   "Display", "Config",  "Process", "Logging", "Concurrency", "Resource limits",
-        "Tracking", "Actions", "Service", "Daemon",  "Lock",    "Kill"};
+        "Tracking", "Ignores", "Actions", "Service", "Daemon",  "Lock",        "Kill"};
     for (const auto& cat : order) {
         if (!groups.count(cat))
             continue;


### PR DESCRIPTION
## Summary
- group ignore entries into sections for build artifacts, distribution files, libraries, logs, ignores and generated icons
- group ignore CLI arguments under a dedicated "Ignores" help category

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find a package configuration file provided by "yaml-cpp")*
- `make` *(fails: fatal error: git2.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_688e18a4905483259bcb2dead6189a2f