### PR TITLE
Document CLI defaults and validate config options

### DIFF
--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -1,0 +1,197 @@
+# Command Line Options
+
+
+## Actions
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--add-ignore` | false (disabled) | Add path to .autogitpull.ignore |
+| `--check-only` | false (disabled) | Only check for updates |
+| `--clear-ignores` | false (disabled) | Delete all ignore entries |
+| `--confirm-alert` | false (disabled) | Confirm unsafe options |
+| `--confirm-reset` | false (disabled) | Confirm --hard-reset |
+| `--depth` | 2 | Depth for --find-ignores/--clear-ignores |
+| `--discard-dirty` | false (disabled) | Alias for --force-pull |
+| `--find-ignores` | false (disabled) | List ignore entries |
+| `--force-pull` | false (disabled) | Discard local changes when pulling |
+| `--hard-reset` | false (disabled) | Delete all logs and configs |
+| `--list-instances` | false (disabled) | List running instance names and PIDs |
+| `--no-hash-check` | false (feature enabled) | Always pull without hash check |
+| `--remove-ignore` | false (disabled) | Remove path from ignore file |
+| `--sudo-su` | false (disabled) | Suppress confirmation alerts |
+
+## Basics
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--dont-skip-timeouts` | false | Retry repositories that timeout |
+| `--help` | false (disabled) | Show this message |
+| `--ignore` |  | Directory to ignore (repeatable) |
+| `--include-private` | false (disabled) | Include private repositories |
+| `--interval` | 30 | Delay between scans |
+| `--keep-first-valid` | false (disabled) | Keep valid repos from first scan |
+| `--max-depth` | 0 | Limit recursive scan depth |
+| `--recursive` | false (disabled) | Scan subdirectories recursively |
+| `--refresh-rate` | 250 | TUI refresh rate |
+| `--rescan-new` | false (disabled) | Rescan for new repos every N minutes (default 5) |
+| `--root` |  | Root folder of repositories |
+| `--single-repo` | false (disabled) | Only monitor the specified root repo |
+| `--single-run` | false (disabled) | Run a single scan cycle and exit |
+| `--updated-since` | 0 | Only sync repos updated recently |
+| `--wait-empty` | false (disabled) | Keep retrying when no repos are found (optional limit) |
+
+## Concurrency
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--concurrency` | 1 | Number of worker threads |
+| `--max-threads` | 0 | Cap the scanning worker threads |
+| `--single-thread` | 1 | Run using a single worker thread |
+| `--threads` | 1 | Alias for --concurrency |
+
+## Config
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--auto-config` | false (disabled) | Auto detect YAML or JSON config |
+| `--auto-reload-config` | false (disabled) | Reload config when the file changes |
+| `--config-json` |  | Load options from JSON file |
+| `--config-yaml` |  | Load options from YAML file |
+| `--enable-history` | false (disabled) | Enable command history |
+| `--enable-hotkeys` | false (disabled) | Enable TUI hotkeys |
+| `--rerun-last` | false (disabled) | Reuse args from .autogitpull.config |
+| `--save-args` | false (disabled) | Save args to config file |
+
+## Daemon
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--daemon-config` |  | Config file for daemon install |
+| `--daemon-name` | autogitpull | Daemon unit name for install |
+| `--daemon-status` | false (disabled) | Check daemon existence and running state |
+| `--force-restart-daemon` | false (disabled) | Force restart daemon |
+| `--force-stop-daemon` | false (disabled) | Force stop daemon |
+| `--install-daemon` | false (disabled) | Install background daemon |
+| `--restart-daemon` | false (disabled) | Restart daemon service |
+| `--start-daemon` | false (disabled) | Start daemon service |
+| `--stop-daemon` | false (disabled) | Stop daemon service |
+| `--uninstall-daemon` | false (disabled) | Uninstall background daemon |
+
+## Display
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--censor-char` | '*' | Character for name masking |
+| `--censor-names` | false (disabled) | Mask repository names |
+| `--color` |  | Override status color |
+| `--color` |  | Override status color |
+| `--hide-date-time` | true (enabled) | Hide date/time line in TUI |
+| `--hide-date-time` | true (enabled) | Hide date/time line in TUI |
+| `--hide-header` | true (enabled) | Hide status header |
+| `--hide-header` | true (enabled) | Hide status header |
+| `--no-colors` | false | Disable ANSI colors |
+| `--no-colors` | false | Disable ANSI colors |
+| `--row-order` | DEFAULT | Row ordering (alpha/reverse) |
+| `--row-order` | DEFAULT | Row ordering (alpha/reverse) |
+| `--session-dates-only` | false (disabled) | Only show dates for repos pulled this session |
+| `--show-commit-author` | false (disabled) | Display last commit author |
+| `--show-commit-author` | false (disabled) | Display last commit author |
+| `--show-commit-date` | false (disabled) | Display last commit time |
+| `--show-commit-date` | false (disabled) | Display last commit time |
+| `--show-pull-author` | false (disabled) | Show author when pull succeeds |
+| `--show-repo-count` | false (disabled) | Display number of repositories |
+| `--show-runtime` | false (disabled) | Display elapsed runtime |
+| `--show-skipped` | false (disabled) | Show skipped repositories |
+| `--show-version` | false (disabled) | Display program version in TUI |
+| `--version` | false (disabled) | Print program version and exit |
+
+## Kill
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--kill-all` | false (disabled) | Terminate running instance and exit |
+| `--kill-on-sleep` | false (disabled) | Exit if a system sleep is detected |
+
+## Lock
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--ignore-lock` | false (disabled) | Don't create or check lock file |
+| `--remove-lock` | false (disabled) | Remove directory lock file and exit |
+
+## Logging
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--debug-memory` | false (disabled) | Log memory usage each scan |
+| `--dump-large` | 0 | Dump threshold for --dump-state |
+| `--dump-state` | false (disabled) | Dump container state when large |
+| `--log-dir` |  | Directory for pull logs |
+| `--log-file` |  | File for general logs |
+| `--log-level` | INFO | Set log verbosity |
+| `--max-log-size` | 0 | Rotate --log-file when over this size |
+| `--syslog` | false (disabled) | Log to syslog |
+| `--syslog-facility` | 0 | Syslog facility |
+| `--verbose` | INFO | Shorthand for --log-level DEBUG |
+
+## Process
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--attach` |  | Attach to daemon and show status |
+| `--background` | false (disabled) | Run in background with attach name |
+| `--cli` | false (disabled) | Use console output |
+| `--exit-on-timeout` | false (disabled) | Terminate worker on poll timeout |
+| `--exit-on-timeout` | false (disabled) | Terminate worker on poll timeout |
+| `--keep-first` | false (disabled) | Keep repos validated on first scan |
+| `--max-runtime` | 0 | Exit after given runtime |
+| `--persist` | false (disabled) | Keep running after exit (optional name) |
+| `--print-skipped` | false (disabled) | Print skipped repositories once |
+| `--pull-timeout` | 0 | Network operation timeout |
+| `--pull-timeout` | 0 | Network operation timeout |
+| `--reattach` | false (disabled) | Reattach to background process |
+| `--respawn-limit` | 0 | Respawn limit within minutes |
+| `--silent` | false (disabled) | Disable console output |
+
+## Resource limits
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--cpu-cores` | 0 | Set CPU affinity mask |
+| `--cpu-percent` | 0.0 | Approximate CPU usage limit |
+| `--disk-limit` | 0 | Limit disk throughput |
+| `--download-limit` | 0 | Limit total download rate |
+| `--mem-limit` | 0 | Abort if memory exceeds this amount |
+| `--total-traffic-limit` | 0 | Stop after this much traffic |
+| `--upload-limit` | 0 | Limit total upload rate |
+
+## Service
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--force-restart-service` | false (disabled) | Force restart service |
+| `--force-stop-service` | false (disabled) | Force stop service |
+| `--install-service` | false (disabled) | Install system service |
+| `--list-daemons` | false (disabled) | Alias for --list-services |
+| `--list-services` | false (disabled) | List installed service units |
+| `--restart-service` | false (disabled) | Restart service |
+| `--service-config` |  | Config file for service install |
+| `--service-name` | autogitpull | Service name for install |
+| `--service-status` | false (disabled) | Check service existence and running state |
+| `--show-service` | false (disabled) | Show installed service name |
+| `--start-service` | false (disabled) | Start installed service |
+| `--stop-service` | false (disabled) | Stop installed service |
+| `--uninstall-service` | false (disabled) | Uninstall system service |
+
+## Tracking
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--cpu-poll` | 5 | CPU usage polling interval |
+| `--mem-poll` | 5 | Memory usage polling interval |
+| `--net-tracker` | false (disabled) | Track network usage |
+| `--no-cpu-tracker` | false (feature enabled) | Disable CPU usage tracker |
+| `--no-mem-tracker` | false (feature enabled) | Disable memory usage tracker |
+| `--no-thread-tracker` | false (feature enabled) | Disable thread tracker |
+| `--thread-poll` | 5 | Thread count polling interval |
+| `--vmem` | false (disabled) | Show virtual memory usage |

--- a/examples/example-config.json
+++ b/examples/example-config.json
@@ -1,46 +1,131 @@
 {
-    "General": {
-        "root": "repos",
-        "include-private": true,
-        "show-skipped": false,
-        "show-version": false,
+    "Basics": {
+        "include-private": false,
+        "root": "",
         "interval": 30,
-        "refresh-rate": "250ms",
-        "cli": false,
-        "single-run": false,
-        "single-repo": false,
-        "silent": false,
+        "refresh-rate": 250,
         "recursive": false,
         "max-depth": 0,
-        "row-order": "default",
-        "color": "",
-        "no-colors": false,
-        "show-commit-date": false,
-        "show-commit-author": false,
-        "vmem": false,
-        "updated-since": "",
+        "ignore": "",
+        "single-run": false,
+        "single-repo": false,
+        "rescan-new": false,
+        "wait-empty": false,
+        "dont-skip-timeouts": false,
+        "keep-first-valid": false,
+        "updated-since": 0,
+        "help": false
+    },
+    "Process": {
+        "cli": false,
+        "silent": false,
+        "attach": "",
+        "background": false,
+        "reattach": false,
+        "persist": false,
+        "respawn-limit": 0,
+        "max-runtime": 0,
+        "pull-timeout": 0,
+        "exit-on-timeout": false,
+        "print-skipped": false,
+        "keep-first": false
+    },
+    "Config": {
         "auto-config": false,
         "auto-reload-config": false,
         "rerun-last": false,
         "save-args": false,
         "enable-history": false,
-        "session-dates-only": false
+        "enable-hotkeys": false,
+        "config-yaml": "",
+        "config-json": ""
+    },
+    "Display": {
+        "show-skipped": false,
+        "show-version": false,
+        "version": false,
+        "show-runtime": false,
+        "show-repo-count": false,
+        "show-commit-date": false,
+        "show-commit-author": false,
+        "show-pull-author": false,
+        "session-dates-only": false,
+        "hide-date-time": true,
+        "hide-header": true,
+        "row-order": "DEFAULT",
+        "color": "",
+        "no-colors": false,
+        "censor-names": false,
+        "censor-char": "'*'"
+    },
+    "Actions": {
+        "check-only": false,
+        "no-hash-check": false,
+        "force-pull": false,
+        "discard-dirty": false,
+        "list-instances": false,
+        "hard-reset": false,
+        "confirm-reset": false,
+        "confirm-alert": false,
+        "sudo-su": false,
+        "add-ignore": false,
+        "remove-ignore": false,
+        "clear-ignores": false,
+        "find-ignores": false,
+        "depth": 2
+    },
+    "Daemon": {
+        "install-daemon": false,
+        "uninstall-daemon": false,
+        "daemon-config": "",
+        "daemon-name": "autogitpull",
+        "start-daemon": false,
+        "stop-daemon": false,
+        "force-stop-daemon": false,
+        "restart-daemon": false,
+        "force-restart-daemon": false,
+        "daemon-status": false
+    },
+    "Service": {
+        "install-service": false,
+        "uninstall-service": false,
+        "start-service": false,
+        "stop-service": false,
+        "force-stop-service": false,
+        "restart-service": false,
+        "force-restart-service": false,
+        "service-config": "",
+        "service-name": "autogitpull",
+        "service-status": false,
+        "show-service": false,
+        "list-services": false,
+        "list-daemons": false
+    },
+    "Lock": {
+        "remove-lock": false,
+        "ignore-lock": false
+    },
+    "Kill": {
+        "kill-all": false,
+        "kill-on-sleep": false
     },
     "Logging": {
-        "log-dir": "logs",
-        "log-file": "autogitpull.log",
+        "log-dir": "",
+        "log-file": "",
+        "max-log-size": 0,
         "log-level": "INFO",
-        "verbose": false,
+        "verbose": "INFO",
         "debug-memory": false,
         "dump-state": false,
         "dump-large": 0,
         "syslog": false,
-        "syslog-facility": 1
+        "syslog-facility": 0
     },
     "Concurrency": {
-        "concurrency": 4,
-        "single-thread": false,
-        "max-threads": 8
+        "concurrency": 1,
+        "threads": 1,
+        "single-thread": 1,
+        "max-threads": 0
     },
     "Tracking": {
         "cpu-poll": 5,
@@ -49,25 +134,16 @@
         "no-cpu-tracker": false,
         "no-mem-tracker": false,
         "no-thread-tracker": false,
-        "net-tracker": false
+        "net-tracker": false,
+        "vmem": false
     },
     "Resource limits": {
-        "cpu-percent": 50.0,
-        "cpu-cores": "0xff",
+        "cpu-percent": 0.0,
+        "cpu-cores": 0,
         "mem-limit": 0,
         "download-limit": 0,
         "upload-limit": 0,
         "disk-limit": 0,
         "total-traffic-limit": 0
-    },
-    "Actions": {
-        "check-only": false,
-        "no-hash-check": false,
-        "force-pull": false,
-        "discard-dirty": false
-    },
-    "repos/example": {
-        "force-pull": true,
-        "pull-timeout": 30
     }
 }

--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -1,38 +1,134 @@
-#Example configuration for autogitpull
-General : root : repos include - private : true show - skipped : false show -
-                                                                 version
-    : false interval : 30 refresh -
-      rate : 250ms cli : false single - run : false single -
-                                            repo : false silent : false recursive
-    : false max -
-      depth : 0 row - order : default color : "" no - colors : false show - commit -
-                                                               date : false show - commit -
-                                                                      author : false vmem
-    : false updated -
-      since : "" auto - config : false auto - reload - config : false rerun - last : false save -
-                                                                                     args
-    : false enable -
-      history : false session - dates -
-                only : false Logging : log - dir : logs log - file : autogitpull.log log -
-                                                   level : INFO verbose
-    : false debug -
-      memory : false dump - state : false dump - large : 0 syslog : false syslog -
-                                                                    facility : 1 Concurrency
-    : concurrency : 4 single -
-      thread : false max -
-               threads : 8 Tracking : cpu - poll : 5 mem - poll : 5 thread - poll : 5 no - cpu -
-                                      tracker : false no - mem - tracker : false no - thread -
-                                                                           tracker
-    : false net -
-      tracker : false Resource limits : cpu - percent : 50 cpu - cores : 0xff mem -
-                                        limit : 0 download - limit : 0 upload - limit : 0 disk -
-                                        limit : 0 Actions : check - only : false no - hash -
-                                                                           check
-    : false force -
-      pull : false discard - dirty : false remove - lock : false kill -
-                                                           all : false
-
-#Per - repository overrides
-                                                                 repos /
-                                                                 example : force -
-                                                           pull : true pull - timeout : 30
+Basics:
+  include-private: False
+  root: 
+  interval: 30
+  refresh-rate: 250
+  recursive: False
+  max-depth: 0
+  ignore: 
+  single-run: False
+  single-repo: False
+  rescan-new: False
+  wait-empty: False
+  dont-skip-timeouts: False
+  keep-first-valid: False
+  updated-since: 0
+  help: False
+Process:
+  cli: False
+  silent: False
+  attach: 
+  background: False
+  reattach: False
+  persist: False
+  respawn-limit: 0
+  max-runtime: 0
+  pull-timeout: 0
+  exit-on-timeout: False
+  print-skipped: False
+  keep-first: False
+Config:
+  auto-config: False
+  auto-reload-config: False
+  rerun-last: False
+  save-args: False
+  enable-history: False
+  enable-hotkeys: False
+  config-yaml: 
+  config-json: 
+Display:
+  show-skipped: False
+  show-version: False
+  version: False
+  show-runtime: False
+  show-repo-count: False
+  show-commit-date: False
+  show-commit-author: False
+  show-pull-author: False
+  session-dates-only: False
+  hide-date-time: True
+  hide-header: True
+  row-order: DEFAULT
+  color: 
+  no-colors: False
+  censor-names: False
+  censor-char: '*'
+Actions:
+  check-only: False
+  no-hash-check: False
+  force-pull: False
+  discard-dirty: False
+  list-instances: False
+  hard-reset: False
+  confirm-reset: False
+  confirm-alert: False
+  sudo-su: False
+  add-ignore: False
+  remove-ignore: False
+  clear-ignores: False
+  find-ignores: False
+  depth: 2
+Daemon:
+  install-daemon: False
+  uninstall-daemon: False
+  daemon-config: 
+  daemon-name: autogitpull
+  start-daemon: False
+  stop-daemon: False
+  force-stop-daemon: False
+  restart-daemon: False
+  force-restart-daemon: False
+  daemon-status: False
+Service:
+  install-service: False
+  uninstall-service: False
+  start-service: False
+  stop-service: False
+  force-stop-service: False
+  restart-service: False
+  force-restart-service: False
+  service-config: 
+  service-name: autogitpull
+  service-status: False
+  show-service: False
+  list-services: False
+  list-daemons: False
+Lock:
+  remove-lock: False
+  ignore-lock: False
+Kill:
+  kill-all: False
+  kill-on-sleep: False
+Logging:
+  log-dir: 
+  log-file: 
+  max-log-size: 0
+  log-level: INFO
+  verbose: INFO
+  debug-memory: False
+  dump-state: False
+  dump-large: 0
+  syslog: False
+  syslog-facility: 0
+Concurrency:
+  concurrency: 1
+  threads: 1
+  single-thread: 1
+  max-threads: 0
+Tracking:
+  cpu-poll: 5
+  mem-poll: 5
+  thread-poll: 5
+  no-cpu-tracker: False
+  no-mem-tracker: False
+  no-thread-tracker: False
+  net-tracker: False
+  vmem: False
+Resource limits:
+  cpu-percent: 0.0
+  cpu-cores: 0
+  mem-limit: 0
+  download-limit: 0
+  upload-limit: 0
+  disk-limit: 0
+  total-traffic-limit: 0

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,8 @@ Repositories with uncommitted changes are skipped by default to avoid losing wor
 ### Usage options
 
 Most options have single-letter shorthands. Run `autogitpull --help` for a complete list.
+The full catalogue of flags with their default values is documented in
+[`docs/cli_options.md`](docs/cli_options.md).
 
 #### Basics
 - `--include-private` (`-p`) – Include private repositories.

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+import re, json, sys
+from pathlib import Path
+from collections import defaultdict
+
+# parse defaults from include/options.hpp
+def parse_defaults():
+    text = Path('include/options.hpp').read_text()
+    pattern_eq = re.compile(r'^\s*[\w:<>\s,{}]+\s+(\w+)\s*=\s*([^;]+);', re.MULTILINE)
+    pattern_br = re.compile(r'^\s*[\w:<>\s,{}]+\s+(\w+)\{([^}]+)\};', re.MULTILINE)
+    pattern_decl = re.compile(r'^\s*[\w:<>\s,{}]+\s+(\w+);', re.MULTILINE)
+    defaults = {}
+    for m in pattern_eq.finditer(text):
+        defaults[m.group(1)] = m.group(2).strip()
+    for m in pattern_br.finditer(text):
+        defaults[m.group(1)] = m.group(2).strip()
+    for m in pattern_decl.finditer(text):
+        if m.group(1) not in defaults:
+            defaults[m.group(1)] = ''
+    return defaults
+
+# mapping for flags whose field names differ
+FLAG_MAP = {
+    '--refresh-rate':'refresh_ms',
+    '--recursive':'recursive_scan',
+    '--ignore':'ignore_dirs',
+    '--attach':'attach_name',
+    '--background':'run_background',
+    '--respawn-limit':'respawn_max',
+    '--max-runtime':'runtime_limit',
+    '--print-skipped':'cli_print_skipped',
+    '--keep-first':'keep_first_valid',
+    '--cpu-poll':'cpu_poll_sec',
+    '--mem-poll':'mem_poll_sec',
+    '--thread-poll':'thread_poll_sec',
+    '--cpu-percent':'cpu_percent_limit',
+    '--cpu-cores':'cpu_core_mask',
+    '--dump-large':'dump_threshold',
+    '--help':'show_help',
+    '--hide-date-time':'show_datetime_line',
+    '--hide-header':'show_header',
+    '--row-order':'sort_mode',
+    '--color':'custom_color',
+    '--single-thread':'concurrency',
+    '--threads':'concurrency',
+    '--syslog':'use_syslog',
+    '--verbose':'log_level',
+    '--version':'print_version',
+    '--vmem':'show_vmem',
+    '--discard-dirty':'force_pull',
+    '--list-daemons':'list_services',
+}
+
+# parse options from help_text.cpp
+def parse_entries():
+    text = Path('src/help_text.cpp').read_text()
+    pattern_opt = re.compile(r'\{"([^"]+)",\s*"([^"]*)",\s*"([^"]*)",\s*"([^"]*)",\s*"([^"]*)"\}', re.MULTILINE)
+    return [m.groups() for m in pattern_opt.finditer(text)]
+
+# determine default string for a flag
+
+def get_default(flag, field, defaults):
+    if flag.startswith('--no-'):
+        base = field[3:] if field.startswith('no_') else flag[5:].replace('-', '_')
+        base_def = defaults.get(base, '')
+        if base_def.lower() == 'true':
+            return 'false (feature enabled)'
+        elif base_def:
+            return 'false'
+        else:
+            return 'false'
+    if flag.startswith('--dont-'):
+        base = field[5:] if field.startswith('dont_') else flag[7:].replace('-', '_')
+        base_def = defaults.get(base, '')
+        if base_def.lower() == 'true':
+            return 'false (feature enabled)'
+        else:
+            return 'false'
+    def_val = defaults.get(field, '')
+    if def_val == '':
+        return ''
+    val = def_val
+    if val.startswith('"') and val.endswith('"'):
+        val = val[1:-1]
+    if val.startswith('LogLevel::'):
+        val = val.split('::',1)[1]
+    if val.lower() == 'true':
+        return 'true (enabled)'
+    if val.lower() == 'false':
+        return 'false (disabled)'
+    return val
+
+# convert default to JSON/YAML value
+
+def to_value(default_str):
+    if default_str.lower() == 'true (enabled)':
+        return True
+    if default_str.lower() == 'false (disabled)':
+        return False
+    if default_str.lower() in ('true', 'false'):
+        return default_str.lower() == 'true'
+    # handle strings like 'false (feature enabled)' for negative flags
+    if default_str.startswith('false'):
+        return False
+    try:
+        if '.' in default_str:
+            return float(default_str)
+        return int(default_str)
+    except ValueError:
+        return default_str
+
+
+def main():
+    defaults = parse_defaults()
+    entries = parse_entries()
+    by_cat = defaultdict(list)
+    for long_flag, short_flag, arg, desc, cat in entries:
+        field = FLAG_MAP.get(long_flag, long_flag[2:].replace('-', '_'))
+        if field is None:
+            default_str = ''
+        else:
+            default_str = get_default(long_flag, field, defaults)
+        by_cat[cat].append((long_flag, default_str, desc))
+    # generate docs
+    lines = ['# Command Line Options\n']
+    for cat in sorted(by_cat):
+        lines.append(f'\n## {cat}\n')
+        lines.append('| Option | Default | Description |')
+        lines.append('|--------|---------|-------------|')
+        for long_flag, def_str, desc in sorted(by_cat[cat]):
+            lines.append(f'| `{long_flag}` | {def_str if def_str else ""} | {desc} |')
+    Path('docs/cli_options.md').write_text('\n'.join(lines))
+    # generate example configs
+    json_data = defaultdict(dict)
+    for cat, items in by_cat.items():
+        for long_flag, def_str, desc in items:
+            key = long_flag[2:]
+            json_data[cat][key] = to_value(def_str if def_str else '')
+    Path('examples/example-config.json').write_text(json.dumps(json_data, indent=4))
+    try:
+        import yaml
+        Path('examples/example-config.yaml').write_text(yaml.dump(json_data, sort_keys=False))
+    except Exception:
+        # simple manual YAML dump
+        def dump_yaml(d, indent=0):
+            lines=[]
+            for k,v in d.items():
+                if isinstance(v, dict):
+                    lines.append(' ' * indent + f'{k}:')
+                    lines.extend(dump_yaml(v, indent+2))
+                else:
+                    lines.append(' ' * indent + f'{k}: {v}')
+            return lines
+        Path('examples/example-config.yaml').write_text('\n'.join(dump_yaml(json_data)))
+
+if __name__ == '__main__':
+    main()

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -261,6 +261,16 @@ Options parse_options(int argc, char* argv[]) {
                                                  {'W', "--wait-empty"},
                                                  {'Z', "--show-repo-count"}};
     ArgParser parser(argc, argv, known, short_opts);
+    for (const auto& kv : cfg_opts) {
+        if (!known.count(kv.first))
+            throw std::runtime_error("Unknown option in config: " + kv.first);
+    }
+    for (const auto& repo : cfg_repo_opts) {
+        for (const auto& kv : repo.second) {
+            if (!known.count(kv.first))
+                throw std::runtime_error("Unknown option in config: " + kv.first);
+        }
+    }
 
     auto cfg_flag = [&](const std::string& k) {
         auto it = cfg_opts.find(k);


### PR DESCRIPTION
## Summary
- generate docs and example configs listing every CLI flag with its default value
- reject unknown keys when loading YAML/JSON configs
- link README to the new CLI reference

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find package configuration file provided by "yaml-cpp")*
- `make` *(fails: fatal error: git2.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e8dd78d0c8325a6c31dc0e25e5e4c