### PR TITLE
Handle rate limit and timeout statuses

### DIFF
--- a/include/git_utils.hpp
+++ b/include/git_utils.hpp
@@ -130,6 +130,7 @@ int try_pull(const fs::path& repo, std::string& out_pull_log,
              size_t disk_limit_kbps = 0, bool force_pull = false);
 
 constexpr int TRY_PULL_TIMEOUT = 4;
+constexpr int TRY_PULL_RATE_LIMIT = 5;
 
 std::string get_last_commit_date(const fs::path& repo);
 std::string get_last_commit_author(const fs::path& repo);


### PR DESCRIPTION
## Summary
- ensure timed out connections remain visible instead of being skipped
- detect rate limiting, retry once after a short delay, and surface a rate-limited status

## Testing
- `make format`
- `make lint`
- `make test`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689bc3cd13d083258a69e93030e9e6dd