### PR TITLE
Add repo override controls

### DIFF
--- a/include/repo_options.hpp
+++ b/include/repo_options.hpp
@@ -7,6 +7,9 @@
 
 struct RepoOptions {
     std::optional<bool> force_pull;
+    std::optional<bool> exclude;
+    std::optional<bool> check_only;
+    std::optional<double> cpu_limit;
     std::optional<size_t> download_limit;
     std::optional<size_t> upload_limit;
     std::optional<size_t> disk_limit;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -127,6 +127,7 @@ Options parse_options(int argc, char* argv[]) {
                                       "--download-limit",
                                       "--upload-limit",
                                       "--disk-limit",
+                                      "--cpu-limit",
                                       "--total-traffic-limit",
                                       "--max-depth",
                                       "--cli",
@@ -138,6 +139,7 @@ Options parse_options(int argc, char* argv[]) {
                                       "--config-json",
                                       "--ignore",
                                       "--force-pull",
+                                      "--exclude",
                                       "--discard-dirty",
                                       "--debug-memory",
                                       "--dump-state",
@@ -914,6 +916,10 @@ Options parse_options(int argc, char* argv[]) {
         bool ok = false;
         if (rflag("--force-pull") || rflag("--discard-dirty"))
             ro.force_pull = true;
+        if (rflag("--exclude"))
+            ro.exclude = true;
+        if (rflag("--check-only"))
+            ro.check_only = true;
         if (values.count("--download-limit")) {
             size_t bytes = parse_bytes(ropt("--download-limit"), 0, SIZE_MAX, ok);
             if (!ok)
@@ -931,6 +937,12 @@ Options parse_options(int argc, char* argv[]) {
             if (!ok)
                 throw std::runtime_error("Invalid per-repo disk-limit");
             ro.disk_limit = bytes / 1024ull;
+        }
+        if (values.count("--cpu-limit")) {
+            double pct = parse_double(ropt("--cpu-limit"), 0.0, 100.0, ok);
+            if (!ok)
+                throw std::runtime_error("Invalid per-repo cpu-limit");
+            ro.cpu_limit = pct;
         }
         if (values.count("--max-runtime")) {
             int sec = parse_int(ropt("--max-runtime"), 1, INT_MAX, ok);

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -443,13 +443,24 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
                 auto it_ro = overrides.find(p);
                 if (it_ro != overrides.end())
                     ro = it_ro->second;
+                if (ro.exclude.value_or(false)) {
+                    std::lock_guard<std::mutex> lk(mtx);
+                    RepoInfo& info = repo_infos[p];
+                    if (info.path.empty())
+                        info.path = p;
+                    info.status = RS_SKIPPED;
+                    info.message = "Excluded";
+                    continue;
+                }
+                bool co = ro.check_only.value_or(check_only);
+                double cl = ro.cpu_limit.value_or(cpu_percent_limit);
                 size_t dl = ro.download_limit.value_or(down_limit);
                 size_t ul = ro.upload_limit.value_or(up_limit);
                 size_t disk = ro.disk_limit.value_or(disk_limit);
                 bool fp = ro.force_pull.value_or(force_pull);
                 std::chrono::seconds pt = ro.pull_timeout.value_or(pull_timeout);
                 process_repo(p, repo_infos, skip_repos, mtx, running, action, action_mtx,
-                             include_private, log_dir, check_only, hash_check, dl, ul, disk, silent,
+                             include_private, log_dir, co, hash_check, dl, ul, disk, silent,
                              cli_mode, fp, skip_timeout, skip_accessible_errors, updated_since,
                              show_pull_author, pt);
                 if (mem_limit > 0 && procutil::get_memory_usage_mb() > mem_limit) {
@@ -457,10 +468,10 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
                     running = false;
                     break;
                 }
-                if (cpu_percent_limit > 0.0) {
+                if (cl > 0.0) {
                     double cpu = procutil::get_cpu_percent();
-                    if (cpu > cpu_percent_limit) {
-                        double over = cpu / cpu_percent_limit - 1.0;
+                    if (cpu > cl) {
+                        double over = cpu / cl - 1.0;
                         std::this_thread::sleep_for(
                             std::chrono::milliseconds(static_cast<int>(over * 100)));
                     }

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -290,7 +290,7 @@ TEST_CASE("parse_options repo overrides") {
     fs::path cfg = fs::temp_directory_path() / "opts_repo.json";
     {
         std::ofstream ofs(cfg);
-        ofs << "{\n  \"root\": \"/tmp\",\n  \"/tmp/repo\": {\n    \"force-pull\": true\n  }\n}";
+        ofs << "{\n  \"root\": \"/tmp\",\n  \"/tmp/repo\": {\n    \"force-pull\": true,\n    \"exclude\": true,\n    \"check-only\": true,\n    \"cpu-limit\": 25.5\n  }\n}"; 
     }
     std::string p = cfg.string();
     char* path_c = strdup(p.c_str());
@@ -299,7 +299,11 @@ TEST_CASE("parse_options repo overrides") {
     free(path_c);
     REQUIRE(opts.root == fs::path("/tmp"));
     REQUIRE(opts.repo_overrides.count(fs::path("/tmp/repo")) == 1);
-    REQUIRE(opts.repo_overrides[fs::path("/tmp/repo")].force_pull.value_or(false));
+    const RepoOptions& ro = opts.repo_overrides[fs::path("/tmp/repo")];
+    REQUIRE(ro.force_pull.value_or(false));
+    REQUIRE(ro.exclude.value_or(false));
+    REQUIRE(ro.check_only.value_or(false));
+    REQUIRE(ro.cpu_limit.value_or(0.0) == 25.5);
     fs::remove(cfg);
 }
 


### PR DESCRIPTION
## Summary
- allow per-repo exclusion, check-only mode, and CPU limiting
- parse new repo fields from YAML/JSON configs
- honor per-repo overrides during scanning

## Testing
- `make format`
- `make lint`
- `make test`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689bdc83d864832585f1e284a5cb5176