### PR TITLE
Support automatic config reload

### DIFF
--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -51,7 +51,7 @@
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--auto-config` | false (disabled) | Auto detect YAML or JSON config |
-| `--auto-reload-config` | false (disabled) | Reload config when the file changes |
+| `--auto-reload-config` | false (disabled) | Reload config when the file changes (CLI only) |
 | `--config-json` |  | Load options from JSON file |
 | `--config-yaml` |  | Load options from YAML file |
 | `--enable-history` | false (disabled) | Enable command history |

--- a/examples/example-config.json
+++ b/examples/example-config.json
@@ -42,7 +42,6 @@
     },
     "Config": {
         "auto-config": false,
-        "auto-reload-config": false,
         "rerun-last": false,
         "save-args": false,
         "enable-history": false,

--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -38,7 +38,6 @@ Process:
   keep-first: False
 Config:
   auto-config: False
-  auto-reload-config: False
   rerun-last: False
   save-args: False
   enable-history: False

--- a/include/options.hpp
+++ b/include/options.hpp
@@ -64,6 +64,8 @@ struct Options {
     bool enable_hotkeys = false;
     bool auto_config = false;
     bool auto_reload_config = false;
+    std::filesystem::path config_file;
+    std::vector<std::string> original_args;
     bool rerun_last = false;
     bool save_args = false;
     bool debug_memory = false;
@@ -143,6 +145,6 @@ struct Options {
 
 Options parse_options(int argc, char* argv[]);
 bool alerts_allowed(const Options& opts);
-int run_event_loop(const Options& opts);
+int run_event_loop(Options opts);
 
 #endif // OPTIONS_HPP

--- a/include/process_monitor.hpp
+++ b/include/process_monitor.hpp
@@ -4,6 +4,6 @@
 #include "options.hpp"
 
 int run_with_monitor(const Options& opts);
-void set_monitor_worker(int (*func)(const Options&));
+void set_monitor_worker(int (*func)(Options));
 
 #endif // PROCESS_MONITOR_HPP

--- a/include/ui_loop.hpp
+++ b/include/ui_loop.hpp
@@ -7,7 +7,7 @@
 /** Print the command line help text. */
 void print_help(const char* prog);
 
-int run_event_loop(const Options& opts);
+int run_event_loop(Options opts);
 
 bool poll_timed_out(const Options& opts, std::chrono::steady_clock::time_point start,
                     std::chrono::steady_clock::time_point now);

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ The full catalogue of flags with their default values is documented in
 
 #### Config
 - `--auto-config` – Auto detect YAML or JSON config.
-- `--auto-reload-config` – Reload config when the file changes.
+- `--auto-reload-config` – Reload config when the file changes (disabled by default).
 - `--rerun-last` – Reuse args from `.autogitpull.config`.
 - `--save-args` – Save args to config file.
 - `--enable-history[=<file>]` – Enable command history (default `.autogitpull.config`).

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -16,6 +16,7 @@
 namespace fs = std::filesystem;
 
 Options parse_options(int argc, char* argv[]) {
+    fs::path config_file;
     // Parse config file option first
     const std::set<std::string> pre_known{"--config-yaml", "--config-json"};
     const std::map<char, std::string> pre_short{{'y', "--config-yaml"}, {'j', "--config-json"}};
@@ -29,6 +30,7 @@ Options parse_options(int argc, char* argv[]) {
         std::string err;
         if (!load_yaml_config(cfg, cfg_opts, cfg_repo_opts, err))
             throw std::runtime_error("Failed to load config: " + err);
+        config_file = cfg;
     }
     if (pre_parser.has_flag("--config-json")) {
         std::string cfg = pre_parser.get_option("--config-json");
@@ -37,6 +39,7 @@ Options parse_options(int argc, char* argv[]) {
         std::string err;
         if (!load_json_config(cfg, cfg_opts, cfg_repo_opts, err))
             throw std::runtime_error("Failed to load config: " + err);
+        config_file = cfg;
     }
 
     // Look for automatic config files if requested
@@ -91,6 +94,7 @@ Options parse_options(int argc, char* argv[]) {
                 if (!load_json_config(cfg_path.string(), cfg_opts, cfg_repo_opts, err))
                     throw std::runtime_error("Failed to load config: " + err);
             }
+            config_file = cfg_path;
         }
     }
 
@@ -485,8 +489,7 @@ Options parse_options(int argc, char* argv[]) {
                             cfg_flag("--keep-first-valid") || parser.has_flag("--keep-first") ||
                             cfg_flag("--keep-first");
     opts.auto_config = parser.has_flag("--auto-config") || cfg_flag("--auto-config");
-    opts.auto_reload_config =
-        parser.has_flag("--auto-reload-config") || cfg_flag("--auto-reload-config");
+    opts.auto_reload_config = parser.has_flag("--auto-reload-config");
     opts.rerun_last = parser.has_flag("--rerun-last") || cfg_flag("--rerun-last");
     opts.save_args = parser.has_flag("--save-args") || cfg_flag("--save-args");
     opts.enable_history = parser.has_flag("--enable-history") || cfg_flag("--enable-history");
@@ -984,6 +987,12 @@ Options parse_options(int argc, char* argv[]) {
             hist = find_hist(exe_dir);
         if (!hist.empty())
             opts.history_file = hist.string();
+    }
+    opts.config_file = config_file;
+    opts.original_args.clear();
+    for (int i = 0; i < argc; ++i) {
+        if (argv[i])
+            opts.original_args.emplace_back(argv[i]);
     }
     return opts;
 }

--- a/src/process_monitor.cpp
+++ b/src/process_monitor.cpp
@@ -7,9 +7,9 @@
 #include "logger.hpp"
 #include "ui_loop.hpp"
 
-static int (*g_worker)(const Options&) = run_event_loop;
+static int (*g_worker)(Options) = run_event_loop;
 
-void set_monitor_worker(int (*func)(const Options&)) {
+void set_monitor_worker(int (*func)(Options)) {
     if (func)
         g_worker = func;
     else

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -451,9 +451,12 @@ void scan_repos(const std::vector<fs::path>& all_repos, std::map<fs::path, RepoI
                     break;
                 const auto& p = all_repos[idx];
                 RepoOptions ro;
-                auto it_ro = repo_settings.find(p);
-                if (it_ro != repo_settings.end())
-                    ro = it_ro->second;
+                {
+                    std::lock_guard<std::mutex> lk(mtx);
+                    auto it_ro = repo_settings.find(p);
+                    if (it_ro != repo_settings.end())
+                        ro = it_ro->second;
+                }
                 if (ro.exclude.value_or(false)) {
                     std::lock_guard<std::mutex> lk(mtx);
                     RepoInfo& info = repo_infos[p];

--- a/tests/process_tests.cpp
+++ b/tests/process_tests.cpp
@@ -25,7 +25,7 @@ TEST_CASE("run_event_loop runtime limit") {
 
 TEST_CASE("process monitor single run when disabled") {
     g_monitor_count = 0;
-    auto worker_fn = [](const Options&) {
+    auto worker_fn = [](Options) {
         ++g_monitor_count;
         return 0;
     };
@@ -39,7 +39,7 @@ TEST_CASE("process monitor single run when disabled") {
 
 TEST_CASE("process monitor respawns up to limit") {
     g_monitor_count = 0;
-    auto worker_fn = [](const Options&) {
+    auto worker_fn = [](Options) {
         ++g_monitor_count;
         return 0;
     };

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -1,5 +1,6 @@
 #include "test_common.hpp"
-
+#include <catch2/catch_approx.hpp>
+using Catch::Approx;
 TEST_CASE("Resource helpers") {
     procutil::set_thread_poll_interval(1);
     procutil::get_thread_count();


### PR DESCRIPTION
## Summary
- gate config reload behind explicit `--auto-reload-config` flag
- drop `auto-reload-config` entries from example configs and clarify docs

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find a package configuration file provided by "yaml-cpp")*
- `make` *(fails: fatal error: git2.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689bf9e7c5e08325a62687dd15d468e0