### PR TITLE
Implement Windows named pipe status sockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(NOT Catch2_FOUND)
     FetchContent_MakeAvailable(Catch2)
 endif()
 add_executable(autogitpull_tests
-  tests/arg_parser_tests.cpp tests/utils_tests.cpp tests/options_tests.cpp tests/config_tests.cpp tests/repo_tests.cpp tests/process_tests.cpp tests/ui_output_tests.cpp tests/history_tests.cpp tests/ignore_utils_tests.cpp tests/timeout_tests.cpp tests/git_remote_tests.cpp src/autogitpull.cpp src/tui.cpp src/ignore_utils.cpp)
+  tests/arg_parser_tests.cpp tests/utils_tests.cpp tests/options_tests.cpp tests/config_tests.cpp tests/repo_tests.cpp tests/process_tests.cpp tests/ui_output_tests.cpp tests/history_tests.cpp tests/ignore_utils_tests.cpp tests/timeout_tests.cpp tests/git_remote_tests.cpp tests/windows_attach_tests.cpp src/autogitpull.cpp src/tui.cpp src/ignore_utils.cpp)
 target_include_directories(autogitpull_tests PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(autogitpull_tests PRIVATE AUTOGITPULL_NO_MAIN)
 target_link_libraries(autogitpull_tests PRIVATE Catch2::Catch2WithMain autogitpull_lib)

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -1,4 +1,7 @@
 #include "test_common.hpp"
+#include <catch2/catch_approx.hpp>
+
+using Catch::Approx;
 
 TEST_CASE("Resource helpers") {
     procutil::set_thread_poll_interval(1);

--- a/tests/windows_attach_tests.cpp
+++ b/tests/windows_attach_tests.cpp
@@ -1,0 +1,54 @@
+#include <catch2/catch_test_macros.hpp>
+#include "windows_service.hpp"
+#include "lock_utils.hpp"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <io.h>
+#include <thread>
+#include <chrono>
+
+TEST_CASE("windows named pipe attach", "[windows]") {
+    std::string name = "pipe-test";
+    int srv_fd = winservice::create_status_socket(name);
+    REQUIRE(srv_fd >= 0);
+    HANDLE srv_h = reinterpret_cast<HANDLE>(_get_osfhandle(srv_fd));
+    std::thread server([&]() {
+        ConnectNamedPipe(srv_h, nullptr);
+        const char msg[] = "hello";
+        DWORD written = 0;
+        WriteFile(srv_h, msg, sizeof(msg) - 1, &written, nullptr);
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    int cli_fd = winservice::connect_status_socket(name);
+    REQUIRE(cli_fd >= 0);
+    HANDLE cli_h = reinterpret_cast<HANDLE>(_get_osfhandle(cli_fd));
+    char buf[16] = {};
+    DWORD read = 0;
+    ReadFile(cli_h, buf, sizeof(buf), &read, nullptr);
+    REQUIRE(std::string(buf, read) == "hello");
+    server.join();
+    winservice::remove_status_socket(name, srv_fd);
+    _close(cli_fd);
+}
+
+TEST_CASE("find_running_instances detects pipe", "[windows]") {
+    std::string name = "detect-test";
+    int srv_fd = winservice::create_status_socket(name);
+    REQUIRE(srv_fd >= 0);
+    HANDLE srv_h = reinterpret_cast<HANDLE>(_get_osfhandle(srv_fd));
+    std::thread server([&]() { ConnectNamedPipe(srv_h, nullptr); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    auto instances = procutil::find_running_instances();
+    bool found = false;
+    for (const auto& inst : instances) {
+        if (inst.first == name) {
+            found = true;
+            REQUIRE(inst.second == static_cast<unsigned long>(GetCurrentProcessId()));
+        }
+    }
+    REQUIRE(found);
+    server.join();
+    winservice::remove_status_socket(name, srv_fd);
+}
+#endif


### PR DESCRIPTION
## Summary
- implement Windows named pipe create/connect/remove status socket functions
- detect Windows named pipe instances in `find_running_instances`
- add Windows tests for attach and instance discovery

## Testing
- `make format`
- `make lint`
- `make test` *(fails: failed to connect to github.com: Network is unreachable)*
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689bf9d415648325b8932861b661642d