### PR TITLE
Refactor option parsing into helpers

### DIFF
--- a/include/options.hpp
+++ b/include/options.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <chrono>
 #include <map>
+#include <functional>
 #include "logger.hpp"
 #include "repo_options.hpp"
 
@@ -144,5 +145,16 @@ struct Options {
 Options parse_options(int argc, char* argv[]);
 bool alerts_allowed(const Options& opts);
 int run_event_loop(const Options& opts);
+
+class ArgParser;
+void parse_service_options(Options& opts, ArgParser& parser,
+                           const std::function<bool(const std::string&)>& cfg_flag,
+                           const std::function<std::string(const std::string&)>& cfg_opt,
+                           const std::map<std::string, std::string>& cfg_opts);
+void parse_tracker_options(Options& opts, ArgParser& parser,
+                           const std::function<bool(const std::string&)>& cfg_flag);
+void parse_limits(Options& opts, ArgParser& parser,
+                  const std::function<std::string(const std::string&)>& cfg_opt,
+                  const std::map<std::string, std::string>& cfg_opts);
 
 #endif // OPTIONS_HPP

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -240,6 +240,20 @@ TEST_CASE("parse_options short flags") {
     REQUIRE(opts.rescan_interval == std::chrono::minutes(5));
 }
 
+TEST_CASE("parse_options tracker flags") {
+    const char* argv[] = {"prog", "path", "--no-mem-tracker", "--net-tracker"};
+    Options opts = parse_options(4, const_cast<char**>(argv));
+    REQUIRE_FALSE(opts.mem_tracker);
+    REQUIRE(opts.net_tracker);
+}
+
+TEST_CASE("parse_options limit flags") {
+    const char* argv[] = {"prog", "path", "--mem-limit", "100MB", "--upload-limit", "1MB"};
+    Options opts = parse_options(6, const_cast<char**>(argv));
+    REQUIRE(opts.mem_limit == 100);
+    REQUIRE(opts.upload_limit == 1024);
+}
+
 TEST_CASE("parse_options dont skip timeouts") {
     const char* argv[] = {"prog", "path", "--dont-skip-timeouts"};
     Options opts = parse_options(3, const_cast<char**>(argv));


### PR DESCRIPTION
## Summary
- Modularize option parsing with `parse_service_options`, `parse_tracker_options`, and `parse_limits`
- Consolidate flag handling with lookup tables and loops
- Extend option tests to cover tracker and bandwidth limits

## Testing
- `make format`
- `make lint`
- `make test` *(fails: 'Approx' was not declared in this scope)*
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689bf9ce29fc8325b02c0598316f1d67