### PR TITLE
Refactor config value conversion

### DIFF
--- a/tests/config_tests.cpp
+++ b/tests/config_tests.cpp
@@ -109,3 +109,43 @@ TEST_CASE("JSON repositories section") {
     fs::remove(cfg);
 }
 
+TEST_CASE("YAML value conversions") {
+    fs::path cfg = fs::temp_directory_path() / "cfg_values.yaml";
+    {
+        std::ofstream ofs(cfg);
+        ofs << "bool_true: true\n";
+        ofs << "bool_false: false\n";
+        ofs << "int_val: 7\n";
+        ofs << "float_val: 3.5\n";
+        ofs << "null_val: null\n";
+    }
+    std::map<std::string, std::string> opts;
+    std::map<std::string, std::map<std::string, std::string>> repo;
+    std::string err;
+    REQUIRE(load_yaml_config(cfg.string(), opts, repo, err));
+    REQUIRE(opts["--bool_true"] == "true");
+    REQUIRE(opts["--bool_false"] == "false");
+    REQUIRE(opts["--int_val"] == "7");
+    REQUIRE(opts["--float_val"] == "3.5");
+    REQUIRE(opts["--null_val"] == "");
+    fs::remove(cfg);
+}
+
+TEST_CASE("JSON value conversions") {
+    fs::path cfg = fs::temp_directory_path() / "cfg_values.json";
+    {
+        std::ofstream ofs(cfg);
+        ofs << "{\n  \"bool_true\": true,\n  \"bool_false\": false,\n  \"int_val\": 7,\n  \"float_val\": 3.5,\n  \"null_val\": null\n}";
+    }
+    std::map<std::string, std::string> opts;
+    std::map<std::string, std::map<std::string, std::string>> repo;
+    std::string err;
+    REQUIRE(load_json_config(cfg.string(), opts, repo, err));
+    REQUIRE(opts["--bool_true"] == "true");
+    REQUIRE(opts["--bool_false"] == "false");
+    REQUIRE(opts["--int_val"] == "7");
+    REQUIRE(opts["--float_val"] == "3.5");
+    REQUIRE(opts["--null_val"] == "");
+    fs::remove(cfg);
+}
+

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -1,4 +1,6 @@
 #include "test_common.hpp"
+#include <catch2/catch_approx.hpp>
+using Catch::Approx;
 
 TEST_CASE("Resource helpers") {
     procutil::set_thread_poll_interval(1);


### PR DESCRIPTION
## Summary
- add `to_string_value` helper for YAML/JSON scalar conversion
- use helper in `load_yaml_config` and `load_json_config`
- add regression tests for scalar value conversions and fix test utilities

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Disk usage reset starts from zero – 1 failed, 123 passed)*
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689bf9c98c18832594ddad570602da0b