### PR TITLE
Support SSH key options and richer credential fallback

### DIFF
--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -37,6 +37,13 @@
 | `--updated-since` | 0 | Only sync repos updated recently (m, h, d, w, M, Y) |
 | `--wait-empty` | false (disabled) | Keep retrying when no repos are found (optional limit) |
 
+## Authentication
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--ssh-public-key` |  | Path to SSH public key |
+| `--ssh-private-key` |  | Path to SSH private key |
+
 ## Concurrency
 
 | Option | Default | Description |

--- a/include/options.hpp
+++ b/include/options.hpp
@@ -25,6 +25,8 @@ struct Options {
     LogLevel log_level = LogLevel::INFO;
     std::filesystem::path log_dir;
     std::string log_file;
+    std::filesystem::path ssh_public_key;
+    std::filesystem::path ssh_private_key;
     size_t max_log_size = 0;
     int interval = 30;
     std::chrono::milliseconds refresh_ms{250};

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -107,6 +107,8 @@ Options parse_options(int argc, char* argv[]) {
                                       "--thread-poll",
                                       "--log-dir",
                                       "--log-file",
+                                      "--ssh-public-key",
+                                      "--ssh-private-key",
                                       "--max-log-size",
                                       "--concurrency",
                                       "--check-only",
@@ -812,6 +814,22 @@ Options parse_options(int argc, char* argv[]) {
         if (val.empty())
             val = cfg_opt("--log-file");
         opts.log_file = val;
+    }
+    if (parser.has_flag("--ssh-public-key") || cfg_opts.count("--ssh-public-key")) {
+        std::string val = parser.get_option("--ssh-public-key");
+        if (val.empty())
+            val = cfg_opt("--ssh-public-key");
+        if (val.empty())
+            throw std::runtime_error("--ssh-public-key requires a path");
+        opts.ssh_public_key = val;
+    }
+    if (parser.has_flag("--ssh-private-key") || cfg_opts.count("--ssh-private-key")) {
+        std::string val = parser.get_option("--ssh-private-key");
+        if (val.empty())
+            val = cfg_opt("--ssh-private-key");
+        if (val.empty())
+            throw std::runtime_error("--ssh-private-key requires a path");
+        opts.ssh_private_key = val;
     }
     if (parser.has_flag("--max-log-size") || cfg_opts.count("--max-log-size")) {
         std::string val = parser.get_option("--max-log-size");


### PR DESCRIPTION
## Summary
- add `--ssh-public-key` and `--ssh-private-key` options
- try SSH agent and username before falling back to user/password
- document new SSH key options and test credential callback paths

## Testing
- `make format`
- `make lint`
- `make test` *(fails: clone_repo failed: Network is unreachable)*
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689bf6fcb1748325a6d3f23b2439b88c