### PR TITLE
Fix MinGW build when libssh2 missing

### DIFF
--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -17,12 +17,20 @@ set "LIBGIT2_LIB=%ROOT_DIR%\libs\libgit2\libgit2_install\lib"
 set "YAMLCPP_INC=%ROOT_DIR%\libs\yaml-cpp\yaml-cpp_install\include"
 set "YAMLCPP_LIB=%ROOT_DIR%\libs\yaml-cpp\yaml-cpp_install\lib"
 set "JSON_INC=%ROOT_DIR%\libs\nlohmann-json\single_include"
-
+set "LIBSSH2_LIB=%ROOT_DIR%\libs\libssh2\libssh2_install\lib"
+if not exist "%LIBSSH2_LIB%\libssh2.a" call "%SCRIPT_DIR%install_libssh2_mingw.bat" || exit /b 1
 if not exist "%LIBGIT2_LIB%\libgit2.a" call "%SCRIPT_DIR%install_libgit2_mingw.bat" || exit /b 1
 if not exist "%YAMLCPP_LIB%\libyaml-cpp.a" call "%SCRIPT_DIR%install_yamlcpp_mingw.bat" || exit /b 1
 if not exist "%JSON_INC%\nlohmann\json.hpp" call "%SCRIPT_DIR%install_nlohmann_json.bat" || exit /b 1
 
 if not exist "%ROOT_DIR%\dist" mkdir "%ROOT_DIR%\dist"
+
+set "SSH2_LIB="
+if exist "%LIBSSH2_LIB%\libssh2.a" (
+    set "SSH2_LIB=%LIBSSH2_LIB%\libssh2.a"
+) else (
+    echo libssh2 not found, skipping SSH support.
+)
 
 %CXX% %CXXFLAGS% -I"%INC%" -I"%LIBGIT2_INC%" -I"%YAMLCPP_INC%" -I"%JSON_INC%" ^
     "%ROOT_DIR%\src\autogitpull.cpp" "%ROOT_DIR%\src\scanner.cpp" "%ROOT_DIR%\src\ui_loop.cpp" ^
@@ -31,7 +39,7 @@ if not exist "%ROOT_DIR%\dist" mkdir "%ROOT_DIR%\dist"
     "%ROOT_DIR%\src\config_utils.cpp" "%ROOT_DIR%\src\ignore_utils.cpp" "%ROOT_DIR%\src\debug_utils.cpp" "%ROOT_DIR%\src\options.cpp" ^
     "%ROOT_DIR%\src\parse_utils.cpp" "%ROOT_DIR%\src\history_utils.cpp" "%ROOT_DIR%\src\lock_utils.cpp" "%ROOT_DIR%\src\process_monitor.cpp" ^
     "%ROOT_DIR%\src\help_text.cpp" "%ROOT_DIR%\src\linux_daemon.cpp" "%ROOT_DIR%\src\windows_service.cpp" ^
-    "%LIBGIT2_LIB%\libgit2.a" "%YAMLCPP_LIB%\libyaml-cpp.a" -lz -lssh2 -lws2_32 -lwinhttp ^
+    "%LIBGIT2_LIB%\libgit2.a" "%YAMLCPP_LIB%\libyaml-cpp.a" %SSH2_LIB% -lz -lws2_32 -lwinhttp ^
     -lole32 -lrpcrt4 -lcrypt32 -lpsapi %LDFLAGS% -o "%ROOT_DIR%\dist\autogitpull_debug.exe"
 
 if errorlevel 1 (

--- a/scripts/install_libgit2_mingw.bat
+++ b/scripts/install_libgit2_mingw.bat
@@ -19,6 +19,12 @@ if errorlevel 1 (
     exit /b 1
 )
 
+REM Ensure libssh2 is available for SSH support
+if not exist libs\libssh2\libssh2_install\lib\libssh2.a (
+    echo libssh2 not found, building...
+    call "%~dp0install_libssh2_mingw.bat" || exit /b 1
+)
+
 REM Download libgit2 if not present
 if not exist libs mkdir ..\libs
 REM Clone libgit2 into libs\libgit2 if missing
@@ -36,7 +42,7 @@ mkdir build
 cd build
 
 REM Configure for static build with MinGW
-cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=..\libgit2_install ..
+cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=OFF -DCMAKE_PREFIX_PATH=..\libssh2\libssh2_install -DCMAKE_INSTALL_PREFIX=..\libgit2_install ..
 if errorlevel 1 (
     echo CMake configuration failed!
     exit /b 1

--- a/scripts/install_libssh2_mingw.bat
+++ b/scripts/install_libssh2_mingw.bat
@@ -1,0 +1,42 @@
+@echo off
+setlocal
+
+where cmake >nul 2>nul
+if errorlevel 1 (
+    echo CMake is required! Please install cmake and ensure it is in PATH.
+    exit /b 1
+)
+
+if not exist libs mkdir libs
+if not exist libs\libssh2 (
+    echo Cloning libssh2...
+    git clone --depth 1 https://github.com/libssh2/libssh2 libs\libssh2 || exit /b 1
+)
+
+cd libs\libssh2
+if exist build rmdir /s /q build
+mkdir build
+cd build
+
+cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=OFF -DCRYPTO_BACKEND=WinCNG -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=..\libssh2_install ..
+if errorlevel 1 (
+    echo libssh2 CMake configuration failed!
+    exit /b 1
+)
+
+mingw32-make
+if errorlevel 1 (
+    echo libssh2 build failed!
+    exit /b 1
+)
+
+mingw32-make install
+if errorlevel 1 (
+    echo libssh2 install failed!
+    exit /b 1
+)
+
+cd ..\..
+
+echo libssh2 built and installed to libs\libssh2\libssh2_install
+endlocal


### PR DESCRIPTION
## Summary
- add script to build libssh2 on MinGW
- rebuild libgit2 and link with libssh2 when available

## Testing
- `make format`
- `make lint`
- `make test` *(fails: yaml-cpp CMake package not found)*
- `make` *(fails: fatal error: git2.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689c84ec32088325811e18ae4b2f05e3