### PR TITLE
fix(build): auto-detect cmake and make paths

### DIFF
--- a/scripts/install_deps.bat
+++ b/scripts/install_deps.bat
@@ -1,5 +1,22 @@
 @echo off
 echo Installing dependencies...
+rem Auto-detect cmake and make if they are not in PATH
+where cmake >nul 2>nul
+if errorlevel 1 (
+    if exist "C:\Program Files\CMake\bin\cmake.exe" (
+        set "PATH=C:\Program Files\CMake\bin;%PATH%"
+    ) else if exist "C:\Program Files (x86)\CMake\bin\cmake.exe" (
+        set "PATH=C:\Program Files (x86)\CMake\bin;%PATH%"
+    )
+)
+where make >nul 2>nul
+if errorlevel 1 (
+    if exist "%ProgramFiles%\Git\usr\bin\make.exe" (
+        set "PATH=%ProgramFiles%\Git\usr\bin;%PATH%"
+    ) else if exist "%ProgramFiles(x86)%\GnuWin32\bin\make.exe" (
+        set "PATH=%ProgramFiles(x86)%\GnuWin32\bin;%PATH%"
+    )
+)
 rem Install cpplint if missing
 where cpplint >nul 2>nul
 if errorlevel 1 (

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -3,6 +3,22 @@ set -e
 echo "Installing dependencies..."
 
 
+# Auto-detect make and cmake if missing from PATH
+for tool in make cmake; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        for dir in /usr/local/opt/cmake/bin /usr/local/bin /opt/homebrew/bin /usr/bin; do
+            if [ -x "$dir/$tool" ]; then
+                export PATH="$dir:$PATH"
+                break
+            fi
+        done
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            echo "$tool not found. Please install $tool or add it to PATH." >&2
+        fi
+    fi
+done
+
+
 # Install cpplint if missing
 if ! command -v cpplint >/dev/null; then
     if command -v pip3 >/dev/null; then


### PR DESCRIPTION
## Summary
- auto-detect cmake and make if not found in PATH for Linux/macOS setup script
- auto-detect cmake and make if not found in PATH for Windows dependency script

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find a package configuration file provided by "yaml-cpp"...)*

------
https://chatgpt.com/codex/tasks/task_e_689c8e1a962483259680ff2795db77e5