### PR TITLE
Add macOS resource tracking

### DIFF
--- a/tests/test_common.hpp
+++ b/tests/test_common.hpp
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <thread>
 #include <chrono>
+#include <vector>
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -31,12 +32,11 @@
 #include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#endif
-#ifdef __linux__
 #include <sys/socket.h>
 #include <netinet/in.h>
+#endif
+#ifdef __linux__
 #include <sys/un.h>
-#include <vector>
 #endif
 
 namespace fs = std::filesystem;

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -269,7 +269,7 @@ TEST_CASE("--log-file without value creates file") {
 }
 
 TEST_CASE("Network usage upload bytes") {
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     procutil::init_network_usage();
     int srv = socket(AF_INET, SOCK_STREAM, 0);
     REQUIRE(srv >= 0);


### PR DESCRIPTION
## Summary
- support macOS network I/O reporting and include required headers
- extend tests to cover macOS network usage paths

## Testing
- `make format`
- `make lint`
- `make test` *(fails: clone_repo failed: failed to connect to github.com)*
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689c8ad831408325bd8f0d4271301171