### PR TITLE
ci: simplify workflow to ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,7 @@ on:
 
 jobs:
   format:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -20,37 +17,17 @@ jobs:
         uses: aminya/setup-cpp@v1
 
       - name: Install dependencies
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            scripts\install_deps.bat
-          else
-            ./scripts/install_deps.sh
-          fi
-
-      - name: Install lint tools
-        run: pip install cpplint
+        run: ./scripts/install_deps.sh
 
       - name: Install clang-format
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update && sudo apt-get install -y clang-format
-          elif [ "$RUNNER_OS" = "macOS" ]; then
-            brew install clang-format
-          elif [ "$RUNNER_OS" = "Windows" ]; then
-            choco install -y llvm
-          fi
+        run: sudo apt-get update && sudo apt-get install -y clang-format
 
       - name: Auto Format
         run: make format && git diff --exit-code
 
   lint:
     needs: format
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,37 +36,17 @@ jobs:
         uses: aminya/setup-cpp@v1
 
       - name: Install dependencies
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            scripts\install_deps.bat
-          else
-            ./scripts/install_deps.sh
-          fi
-
-      - name: Install lint tools
-        run: pip install cpplint
+        run: ./scripts/install_deps.sh
 
       - name: Install clang-format
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update && sudo apt-get install -y clang-format
-          elif [ "$RUNNER_OS" = "macOS" ]; then
-            brew install clang-format
-          elif [ "$RUNNER_OS" = "Windows" ]; then
-            choco install -y llvm
-          fi
+        run: sudo apt-get update && sudo apt-get install -y clang-format
 
       - name: Auto Lint
         run: make lint
 
   test:
     needs: lint
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -98,23 +55,14 @@ jobs:
         uses: aminya/setup-cpp@v1
 
       - name: Install dependencies
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            scripts\install_deps.bat
-          else
-            ./scripts/install_deps.sh
-          fi
+        run: ./scripts/install_deps.sh
 
       - name: Auto Test
         run: make test
 
   build:
     needs: test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -123,13 +71,7 @@ jobs:
         uses: aminya/setup-cpp@v1
 
       - name: Install dependencies
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            scripts\install_deps.bat
-          else
-            ./scripts/install_deps.sh
-          fi
+        run: ./scripts/install_deps.sh
 
       - name: Auto Build
         run: make


### PR DESCRIPTION
## Summary
- streamline CI to run format, lint, test and build sequentially on ubuntu-latest
- drop macOS/Windows matrix and redundant lint tool installation

## Testing
- `make format`
- `make lint`
- `make test` (fails: clone_repo failed: failed to connect to github.com: Network is unreachable)
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689c8cf1370c832588fb447fcb95de0c