### PR TITLE
feat: add macOS CPU affinity helpers

### DIFF
--- a/tests/system_utils_tests.cpp
+++ b/tests/system_utils_tests.cpp
@@ -1,0 +1,15 @@
+#include "test_common.hpp"
+#include "system_utils.hpp"
+
+TEST_CASE("macOS CPU affinity helpers") {
+#ifdef __APPLE__
+    REQUIRE_FALSE(procutil::set_cpu_affinity(0));
+    REQUIRE(procutil::set_cpu_affinity(1ULL << 1));
+    auto affinity = procutil::get_cpu_affinity();
+    REQUIRE_FALSE(affinity.empty());
+    REQUIRE(affinity.find("1") != std::string::npos);
+#else
+    SUCCEED();
+#endif
+}
+


### PR DESCRIPTION
## Summary
- support CPU affinity on macOS using `thread_policy_set`
- expose macOS affinity info via `task_info`
- add unit test for macOS CPU affinity helpers

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find a package configuration file provided by "yaml-cpp" with any of the following names: yaml-cppConfig.cmake, yaml-cpp-config.cmake)*


------
https://chatgpt.com/codex/tasks/task_e_689c8fa22f6c832588fd5984bebe1089