### PR TITLE
feat(logger): add JSON log output

### DIFF
--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -6,11 +6,18 @@ enum class LogLevel { DEBUG = 0, INFO, WARNING, ERR };
 
 void init_logger(const std::string& path, LogLevel level = LogLevel::INFO, size_t max_size = 0);
 void set_log_level(LogLevel level);
+void set_json_logging(bool enable);
 bool logger_initialized();
+void log_event(LogLevel level, const std::string& message);
+void log_event(LogLevel level, const std::string& message, const std::string& data);
 void log_debug(const std::string& msg);
+void log_debug(const std::string& msg, const std::string& data);
 void log_info(const std::string& msg);
+void log_info(const std::string& msg, const std::string& data);
 void log_warning(const std::string& msg);
+void log_warning(const std::string& msg, const std::string& data);
 void log_error(const std::string& msg);
+void log_error(const std::string& msg, const std::string& data);
 void init_syslog(int facility = 0);
 void shutdown_logger();
 

--- a/include/options.hpp
+++ b/include/options.hpp
@@ -30,6 +30,7 @@ struct Options {
     std::filesystem::path ssh_private_key;
     std::filesystem::path credential_file;
     size_t max_log_size = 0;
+    bool json_log = false;
     int interval = 30;
     std::chrono::milliseconds refresh_ms{250};
     unsigned int cpu_poll_sec = 5;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -430,6 +430,7 @@ Options parse_options(int argc, char* argv[]) {
                                       "--row-order",
                                       "--syslog",
                                       "--syslog-facility",
+                                      "--json-log",
                                       "--pull-timeout",
                                       "--exit-on-timeout",
                                       "--dont-skip-timeouts",
@@ -894,6 +895,7 @@ Options parse_options(int argc, char* argv[]) {
         else
             throw std::runtime_error("Invalid value for --row-order");
     }
+    opts.json_log = parser.has_flag("--json-log") || cfg_flag("--json-log");
     opts.use_syslog = parser.has_flag("--syslog") || cfg_flag("--syslog");
     if (parser.has_flag("--syslog-facility") || cfg_opts.count("--syslog-facility")) {
         std::string val = parser.get_option("--syslog-facility");

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -189,6 +189,7 @@ static void setup_environment(const Options& opts) {
 
 // Initialize logging if requested
 static void setup_logging(const Options& opts) {
+    set_json_logging(opts.json_log);
     if (!opts.log_file.empty()) {
         init_logger(opts.log_file, opts.log_level, opts.max_log_size);
         if (logger_initialized())

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -245,6 +245,25 @@ TEST_CASE("Logger rotates when exceeding max size") {
     fs::remove(log);
 }
 
+TEST_CASE("Logger outputs JSON when enabled") {
+    fs::path log = fs::temp_directory_path() / "autogitpull_json.log";
+    fs::remove(log);
+    init_logger(log.string());
+    set_json_logging(true);
+    log_info("json entry", "{\"k\":\"v\"}");
+    shutdown_logger();
+    set_json_logging(false);
+    std::ifstream ifs(log);
+    REQUIRE(ifs.good());
+    std::string line;
+    std::getline(ifs, line);
+    REQUIRE(line.find("\"timestamp\"") != std::string::npos);
+    REQUIRE(line.find("\"level\":\"INFO\"") != std::string::npos);
+    REQUIRE(line.find("\"msg\":\"json entry\"") != std::string::npos);
+    REQUIRE(line.find("\"data\":{\"k\":\"v\"}") != std::string::npos);
+    fs::remove(log);
+}
+
 TEST_CASE("--log-file without value creates file") {
     const char* argv[] = {"prog", "--log-file"};
     ArgParser parser(2, const_cast<char**>(argv), {"--log-file"});


### PR DESCRIPTION
## Summary
- allow logging structured events and JSON formatted records
- expose `--json-log` option and propagate to logger
- test JSON log formatting

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Disk usage reset starts from zero; credential callback selection; credential callback file)*
- `ctest --output-on-failure` *(fails: Disk usage reset starts from zero; credential callback selection; credential callback file)*

------
https://chatgpt.com/codex/tasks/task_e_689c8ecb72e883258437821f4b169d8f