### PR TITLE
refactor: modularize TUI rendering helpers

### DIFF
--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -2,9 +2,9 @@
 #define TUI_HPP
 
 #include <filesystem>
-#include <vector>
 #include <map>
 #include <string>
+#include <vector>
 #include "repo.hpp"
 
 /**
@@ -13,6 +13,39 @@
  * Has no effect on other platforms.
  */
 void enable_win_ansi();
+
+/**
+ * @brief Resolved color codes for the TUI.
+ */
+struct TuiColors {
+    std::string reset;
+    std::string green;
+    std::string yellow;
+    std::string red;
+    std::string cyan;
+    std::string gray;
+    std::string bold;
+    std::string magenta;
+};
+
+/**
+ * @brief Create a color palette honoring user preferences.
+ */
+TuiColors make_tui_colors(bool no_colors, const std::string& custom_color);
+
+std::string render_header(const std::vector<std::filesystem::path>& all_repos,
+                          const std::map<std::filesystem::path, RepoInfo>& repo_infos, int interval,
+                          int seconds_left, bool scanning, const std::string& action,
+                          bool show_version, bool show_repo_count, const std::string& status_msg,
+                          int runtime_sec, bool show_datetime_line, const TuiColors& colors);
+
+std::string render_stats(bool track_cpu, bool track_mem, bool track_threads, bool track_net,
+                         bool show_affinity, bool track_vmem, const TuiColors& colors);
+
+std::string render_repo_entry(const std::filesystem::path& p, const RepoInfo& ri, bool show_skipped,
+                              bool show_notgit, bool show_commit_date, bool show_commit_author,
+                              bool session_dates_only, bool censor_names, char censor_char,
+                              const TuiColors& colors);
 
 /**
  * @brief Render the text user interface.

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -40,35 +40,40 @@ void enable_win_ansi() {
 void enable_win_ansi() {}
 #endif
 
-void draw_tui(const std::vector<fs::path>& all_repos,
-              const std::map<fs::path, RepoInfo>& repo_infos, int interval, int seconds_left,
-              bool scanning, const std::string& action, bool show_skipped, bool show_notgit,
-              bool show_version, bool track_cpu, bool track_mem, bool track_threads, bool track_net,
-              bool show_affinity, bool track_vmem, bool show_commit_date, bool show_commit_author,
-              bool session_dates_only, bool no_colors, const std::string& custom_color,
-              const std::string& status_msg, int runtime_sec, bool show_datetime_line,
-              bool show_header, bool show_repo_count, bool censor_names, char censor_char) {
-    std::ostringstream out;
+static std::string format_bytes(std::size_t b) {
+    std::ostringstream ss;
+    if (b >= 1024 * 1024)
+        ss << b / (1024 * 1024) << " MB";
+    else
+        ss << b / 1024 << " KB";
+    return ss.str();
+}
+
+TuiColors make_tui_colors(bool no_colors, const std::string& custom_color) {
     auto choose = [&](const char* def) {
         return no_colors ? "" : (custom_color.empty() ? def : custom_color.c_str());
     };
-    std::string reset = no_colors ? "" : COLOR_RESET;
-    std::string green = choose(COLOR_GREEN);
-    std::string yellow = choose(COLOR_YELLOW);
-    std::string red = choose(COLOR_RED);
-    std::string cyan = choose(COLOR_CYAN);
-    std::string gray = choose(COLOR_GRAY);
-    std::string bold = choose(COLOR_BOLD);
-    std::string magenta = choose(COLOR_MAGENTA);
+    return {no_colors ? "" : COLOR_RESET, choose(COLOR_GREEN),
+            choose(COLOR_YELLOW),         choose(COLOR_RED),
+            choose(COLOR_CYAN),           choose(COLOR_GRAY),
+            choose(COLOR_BOLD),           choose(COLOR_MAGENTA)};
+}
+
+std::string render_header(const std::vector<fs::path>& all_repos,
+                          const std::map<fs::path, RepoInfo>& repo_infos, int interval,
+                          int seconds_left, bool scanning, const std::string& action,
+                          bool show_version, bool show_repo_count, const std::string& status_msg,
+                          int runtime_sec, bool show_datetime_line, const TuiColors& c) {
+    std::ostringstream out;
     out << "\033[2J\033[H";
-    out << bold << "AutoGitPull TUI";
+    out << c.bold << "AutoGitPull TUI";
     if (show_version)
         out << " v" << AUTOGITPULL_VERSION;
-    out << reset << "\n";
+    out << c.reset << "\n";
     if (show_datetime_line)
-        out << "Date: " << cyan << timestamp() << reset << "\n";
-    out << "Monitoring: " << yellow
-        << (all_repos.empty() ? "" : all_repos[0].parent_path().string()) << reset << "\n";
+        out << "Date: " << c.cyan << timestamp() << c.reset << "\n";
+    out << "Monitoring: " << c.yellow
+        << (all_repos.empty() ? "" : all_repos[0].parent_path().string()) << c.reset << "\n";
     if (show_repo_count) {
         size_t active = 0;
         for (const auto& p : all_repos) {
@@ -82,15 +87,21 @@ void draw_tui(const std::vector<fs::path>& all_repos,
     out << "Interval: " << interval << "s    (Ctrl+C to exit)\n";
     out << "Status: ";
     if (scanning || action != "Idle")
-        out << COLOR_YELLOW << action << COLOR_RESET;
+        out << c.yellow << action << c.reset;
     else
-        out << green << "Idle" << reset;
+        out << c.green << "Idle" << c.reset;
     out << " - Next scan in " << seconds_left << "s";
     if (runtime_sec >= 0)
         out << " - Runtime " << format_duration_short(std::chrono::seconds(runtime_sec));
     out << "\n";
     if (!status_msg.empty())
         out << status_msg << "\n";
+    return out.str();
+}
+
+std::string render_stats(bool track_cpu, bool track_mem, bool track_threads, bool track_net,
+                         bool show_affinity, bool track_vmem, const TuiColors& c) {
+    std::ostringstream out;
     if (track_cpu || track_mem || track_threads || show_affinity || track_vmem) {
         out << "CPU: ";
         if (track_cpu)
@@ -118,20 +129,136 @@ void draw_tui(const std::vector<fs::path>& all_repos,
     }
     if (track_net) {
         auto usage = procutil::get_network_usage();
-        auto fmt = [](std::size_t b) {
-            std::ostringstream ss;
-            if (b >= 1024 * 1024)
-                ss << b / (1024 * 1024) << " MB";
-            else
-                ss << b / 1024 << " KB";
-            return ss.str();
-        };
-        out << "Net: D " << fmt(usage.download_bytes) << "  U " << fmt(usage.upload_bytes) << "\n";
+        out << "Net: D " << format_bytes(usage.download_bytes) << "  U "
+            << format_bytes(usage.upload_bytes) << "\n";
     }
+    return out.str();
+}
+
+std::string render_repo_entry(const fs::path& p, const RepoInfo& ri, bool show_skipped,
+                              bool show_notgit, bool show_commit_date, bool show_commit_author,
+                              bool session_dates_only, bool censor_names, char censor_char,
+                              const TuiColors& c) {
+    if ((ri.status == RS_SKIPPED && !show_skipped) || (ri.status == RS_NOT_GIT && !show_notgit))
+        return "";
+    std::string color = c.gray, status_s = "Pending ";
+    switch (ri.status) {
+    case RS_PENDING:
+        color = c.gray;
+        status_s = "Pending ";
+        break;
+    case RS_CHECKING:
+        color = c.cyan;
+        status_s = "Checking ";
+        break;
+    case RS_UP_TO_DATE:
+        color = c.green;
+        status_s = "UpToDate ";
+        break;
+    case RS_PULLING:
+        color = c.yellow;
+        status_s = "Pulling  ";
+        break;
+    case RS_PULL_OK:
+        color = c.green;
+        status_s = "Pulled   ";
+        break;
+    case RS_PKGLOCK_FIXED:
+        color = c.yellow;
+        status_s = "PkgLockOk";
+        break;
+    case RS_ERROR:
+        color = c.red;
+        status_s = "Error    ";
+        break;
+    case RS_SKIPPED:
+        color = c.gray;
+        status_s = "Skipped  ";
+        break;
+    case RS_NOT_GIT:
+        color = c.gray;
+        status_s = "NotGit  ";
+        break;
+    case RS_HEAD_PROBLEM:
+        color = c.red;
+        status_s = "HEAD/BR  ";
+        break;
+    case RS_DIRTY:
+        color = c.red;
+        status_s = "Dirty    ";
+        break;
+    case RS_TIMEOUT:
+        color = c.red;
+        status_s = "TimedOut ";
+        break;
+    case RS_RATE_LIMIT:
+        color = c.red;
+        status_s = "RateLimit";
+        break;
+    case RS_REMOTE_AHEAD:
+        color = c.magenta;
+        status_s = "RemoteUp";
+        break;
+    case RS_TEMPFAIL:
+        color = c.red;
+        status_s = "TempFail";
+        break;
+    }
+    std::ostringstream out;
+    std::string name = p.filename().string();
+    if (censor_names)
+        name.assign(name.size(), censor_char);
+    out << color << " [" << std::left << std::setw(9) << status_s << "]  " << name << c.reset;
+    if (!ri.branch.empty()) {
+        out << "  (" << ri.branch;
+        if (!ri.commit.empty())
+            out << "@" << ri.commit;
+        out << ")";
+    }
+    if ((!session_dates_only || ri.pulled) && (show_commit_author || show_commit_date)) {
+        out << " {";
+        bool first = true;
+        if (show_commit_author && !ri.commit_author.empty()) {
+            out << ri.commit_author;
+            first = false;
+        }
+        if (show_commit_date && !ri.commit_date.empty()) {
+            if (!first)
+                out << ' ';
+            out << ri.commit_date;
+        }
+        out << "}";
+    }
+    if (!ri.message.empty())
+        out << " - " << ri.message;
+    if (ri.auth_failed)
+        out << c.red << " [AUTH]" << c.reset;
+    if (ri.status == RS_PULLING)
+        out << " (" << ri.progress << "%)";
+    out << "\n";
+    return out.str();
+}
+
+void draw_tui(const std::vector<fs::path>& all_repos,
+              const std::map<fs::path, RepoInfo>& repo_infos, int interval, int seconds_left,
+              bool scanning, const std::string& action, bool show_skipped, bool show_notgit,
+              bool show_version, bool track_cpu, bool track_mem, bool track_threads, bool track_net,
+              bool show_affinity, bool track_vmem, bool show_commit_date, bool show_commit_author,
+              bool session_dates_only, bool no_colors, const std::string& custom_color,
+              const std::string& status_msg, int runtime_sec, bool show_datetime_line,
+              bool show_header, bool show_repo_count, bool censor_names, char censor_char) {
+    TuiColors colors = make_tui_colors(no_colors, custom_color);
+    std::ostringstream out;
+    out << render_header(all_repos, repo_infos, interval, seconds_left, scanning, action,
+                         show_version, show_repo_count, status_msg, runtime_sec, show_datetime_line,
+                         colors);
+    out << render_stats(track_cpu, track_mem, track_threads, track_net, show_affinity, track_vmem,
+                        colors);
     if (show_header) {
         out << "--------------------------------------------------------------";
         out << "-------------------\n";
-        out << bold << " [" << std::left << std::setw(9) << "Status" << "]  Repo" << reset << "\n";
+        out << colors.bold << " [" << std::left << std::setw(9) << "Status" << "]  Repo"
+            << colors.reset << "\n";
         out << "--------------------------------------------------------------";
         out << "-------------------\n";
     }
@@ -146,109 +273,15 @@ void draw_tui(const std::vector<fs::path>& all_repos,
             ri.path = p;
             ri.auth_failed = false;
         }
-        if ((ri.status == RS_SKIPPED && !show_skipped) || (ri.status == RS_NOT_GIT && !show_notgit))
-            continue;
-        std::string color = gray, status_s = "Pending ";
-        switch (ri.status) {
-        case RS_PENDING:
-            color = COLOR_GRAY;
-            status_s = "Pending ";
-            break;
-        case RS_CHECKING:
-            color = cyan;
-            status_s = "Checking ";
-            break;
-        case RS_UP_TO_DATE:
-            color = green;
-            status_s = "UpToDate ";
-            break;
-        case RS_PULLING:
-            color = yellow;
-            status_s = "Pulling  ";
-            break;
-        case RS_PULL_OK:
-            color = green;
-            status_s = "Pulled   ";
-            break;
-        case RS_PKGLOCK_FIXED:
-            color = yellow;
-            status_s = "PkgLockOk";
-            break;
-        case RS_ERROR:
-            color = red;
-            status_s = "Error    ";
-            break;
-        case RS_SKIPPED:
-            color = gray;
-            status_s = "Skipped  ";
-            break;
-        case RS_NOT_GIT:
-            color = gray;
-            status_s = "NotGit  ";
-            break;
-        case RS_HEAD_PROBLEM:
-            color = red;
-            status_s = "HEAD/BR  ";
-            break;
-        case RS_DIRTY:
-            color = red;
-            status_s = "Dirty    ";
-            break;
-        case RS_TIMEOUT:
-            color = red;
-            status_s = "TimedOut ";
-            break;
-        case RS_RATE_LIMIT:
-            color = red;
-            status_s = "RateLimit";
-            break;
-        case RS_REMOTE_AHEAD:
-            color = magenta;
-            status_s = "RemoteUp";
-            break;
-        case RS_TEMPFAIL:
-            color = red;
-            status_s = "TempFail";
-            break;
-        }
-        std::string name = p.filename().string();
-        if (censor_names)
-            name.assign(name.size(), censor_char);
-        out << color << " [" << std::left << std::setw(9) << status_s << "]  " << name << reset;
-        if (!ri.branch.empty()) {
-            out << "  (" << ri.branch;
-            if (!ri.commit.empty())
-                out << "@" << ri.commit;
-            out << ")";
-        }
-        if ((!session_dates_only || ri.pulled) && (show_commit_author || show_commit_date)) {
-            out << " {";
-            bool first = true;
-            if (show_commit_author && !ri.commit_author.empty()) {
-                out << ri.commit_author;
-                first = false;
-            }
-            if (show_commit_date && !ri.commit_date.empty()) {
-                if (!first)
-                    out << ' ';
-                out << ri.commit_date;
-            }
-            out << "}";
-        }
-        if (!ri.message.empty())
-            out << " - " << ri.message;
-        if (ri.auth_failed)
-            out << red << " [AUTH]" << reset;
-        if (ri.status == RS_PULLING)
-            out << " (" << ri.progress << "%)";
-        out << "\n";
+        out << render_repo_entry(p, ri, show_skipped, show_notgit, show_commit_date,
+                                 show_commit_author, session_dates_only, censor_names, censor_char,
+                                 colors);
     }
     if (show_header) {
         out << "--------------------------------------------------------------";
         out << "-------------------\n";
     }
     std::cout << out.str() << std::flush;
-    // Explicitly clear the string buffer to avoid stale allocations
     out.str("");
     out.clear();
     std::ostringstream().swap(out);

--- a/tests/ui_output_tests.cpp
+++ b/tests/ui_output_tests.cpp
@@ -1,6 +1,7 @@
 #include <sstream>
 #include <iostream>
 #include "test_common.hpp"
+#include "tui.hpp"
 #include "ui_loop.hpp"
 // Forward declaration of draw_cli from ui_loop.cpp
 void draw_cli(const std::vector<fs::path>& all_repos,
@@ -22,4 +23,25 @@ TEST_CASE("draw_cli shows active repo count") {
     std::cout.rdbuf(old);
     std::string out = oss.str();
     REQUIRE(out.rfind("Repos: 2/4\n", 0) == 0);
+}
+
+TEST_CASE("render_header reports repo count") {
+    std::vector<fs::path> repos = {"/a", "/b", "/c", "/d"};
+    std::map<fs::path, RepoInfo> infos;
+    infos[repos[0]] = RepoInfo{repos[0], RS_UP_TO_DATE, "", "", "", "", "", "", 0, false};
+    infos[repos[1]] = RepoInfo{repos[1], RS_SKIPPED, "", "", "", "", "", "", 0, false};
+    infos[repos[2]] = RepoInfo{repos[2], RS_NOT_GIT, "", "", "", "", "", "", 0, false};
+    infos[repos[3]] = RepoInfo{repos[3], RS_PENDING, "", "", "", "", "", "", 0, false};
+    TuiColors colors = make_tui_colors(true, "");
+    std::string out = render_header(repos, infos, 5, 1, false, "Idle", false, true, "", -1, false, colors);
+    REQUIRE(out.find("Repos: 2/4\n") != std::string::npos);
+}
+
+TEST_CASE("render_repo_entry censors names") {
+    fs::path repo = "/foo/bar";
+    RepoInfo ri{repo, RS_UP_TO_DATE, "", "", "", "", "", "", 0, false};
+    TuiColors colors = make_tui_colors(true, "");
+    std::string out = render_repo_entry(repo, ri, true, true, false, false, false, true, '#', colors);
+    REQUIRE(out.find("bar") == std::string::npos);
+    REQUIRE(out.find("###") != std::string::npos);
 }


### PR DESCRIPTION
## Summary
- split draw_tui into reusable render_header, render_stats, and render_repo_entry helpers
- centralize ANSI color handling via TuiColors
- add tests for new rendering helpers

## Testing
- `make format`
- `make lint`
- `make test` *(fails: 50% tests passed, 1 tests failed)*


------
https://chatgpt.com/codex/tasks/task_e_689c8fa54bd88325b304d14935ec462a