### PR TITLE
fix(linux): quote service paths

### DIFF
--- a/src/linux_daemon.cpp
+++ b/src/linux_daemon.cpp
@@ -12,6 +12,7 @@
 #include <filesystem>
 #include <vector>
 #include <cstdlib>
+#include <iomanip>
 
 namespace fs = std::filesystem;
 
@@ -67,9 +68,9 @@ bool create_service_unit(const std::string& name, const std::string& exec_path,
     if (!out.is_open())
         return false;
     out << "[Unit]\nDescription=autogitpull daemon\nAfter=network.target\n\n";
-    out << "[Service]\nType=simple\nUser=" << user << "\nExecStart=" << exec_path;
+    out << "[Service]\nType=simple\nUser=" << user << "\nExecStart=" << std::quoted(exec_path);
     if (!config_file.empty())
-        out << " --daemon-config " << config_file;
+        out << " --daemon-config " << std::quoted(config_file);
     if (persist)
         out << " --persist";
     out << "\nRestart=on-failure\n\n";


### PR DESCRIPTION
## Summary
- preserve spaces in Linux service exec and config paths

## Testing
- `make format`
- `make lint` (fails: code should be clang-formatted in src/git_utils.cpp)
- `make test` (build interrupted: environment timeout)

------
https://chatgpt.com/codex/tasks/task_e_689c91af24fc8325b2421ff82382f10f