### PR TITLE
refactor(cli): modularize command handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,14 @@ add_library(autogitpull_lib STATIC
     src/parse_utils.cpp
     src/history_utils.cpp
     src/lock_utils.cpp
-    src/process_monitor.cpp)
+    src/process_monitor.cpp
+    src/cli_commands.cpp)
 if(WIN32)
-    target_sources(autogitpull_lib PRIVATE src/windows_service.cpp)
+    target_sources(autogitpull_lib PRIVATE src/windows_service.cpp src/windows_commands.cpp)
 elseif(APPLE)
-    target_sources(autogitpull_lib PRIVATE src/macos_daemon.cpp)
+    target_sources(autogitpull_lib PRIVATE src/macos_daemon.cpp src/linux_commands.cpp)
 else()
-    target_sources(autogitpull_lib PRIVATE src/linux_daemon.cpp)
+    target_sources(autogitpull_lib PRIVATE src/linux_daemon.cpp src/linux_commands.cpp)
 endif()
 target_include_directories(autogitpull_lib PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(autogitpull_lib PRIVATE PkgConfig::LIBGIT2 yaml-cpp nlohmann_json::nlohmann_json pthread)
@@ -70,7 +71,7 @@ if(NOT Catch2_FOUND)
     FetchContent_MakeAvailable(Catch2)
 endif()
 add_executable(autogitpull_tests
-  tests/arg_parser_tests.cpp tests/utils_tests.cpp tests/options_tests.cpp tests/config_tests.cpp tests/repo_tests.cpp tests/process_tests.cpp tests/ui_output_tests.cpp tests/history_tests.cpp tests/ignore_utils_tests.cpp tests/timeout_tests.cpp tests/git_remote_tests.cpp tests/windows_attach_tests.cpp tests/macos_daemon_tests.cpp src/autogitpull.cpp src/tui.cpp src/ignore_utils.cpp)
+  tests/arg_parser_tests.cpp tests/utils_tests.cpp tests/options_tests.cpp tests/config_tests.cpp tests/repo_tests.cpp tests/process_tests.cpp tests/ui_output_tests.cpp tests/history_tests.cpp tests/ignore_utils_tests.cpp tests/timeout_tests.cpp tests/git_remote_tests.cpp tests/windows_attach_tests.cpp tests/macos_daemon_tests.cpp tests/cli_commands_tests.cpp src/autogitpull.cpp src/tui.cpp src/ignore_utils.cpp)
 target_include_directories(autogitpull_tests PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(autogitpull_tests PRIVATE AUTOGITPULL_NO_MAIN)
 target_link_libraries(autogitpull_tests PRIVATE Catch2::Catch2WithMain autogitpull_lib)
@@ -94,13 +95,14 @@ add_executable(memory_leak_test
     src/parse_utils.cpp
     src/history_utils.cpp
     src/lock_utils.cpp
-    src/tui.cpp)
+    src/tui.cpp
+    src/cli_commands.cpp)
 if(WIN32)
-    target_sources(memory_leak_test PRIVATE src/windows_service.cpp)
+    target_sources(memory_leak_test PRIVATE src/windows_service.cpp src/windows_commands.cpp)
 elseif(APPLE)
-    target_sources(memory_leak_test PRIVATE src/macos_daemon.cpp)
+    target_sources(memory_leak_test PRIVATE src/macos_daemon.cpp src/linux_commands.cpp)
 else()
-    target_sources(memory_leak_test PRIVATE src/linux_daemon.cpp)
+    target_sources(memory_leak_test PRIVATE src/linux_daemon.cpp src/linux_commands.cpp)
 endif()
 target_include_directories(memory_leak_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(memory_leak_test PRIVATE AUTOGITPULL_NO_MAIN)

--- a/include/cli_commands.hpp
+++ b/include/cli_commands.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "options.hpp"
+
+namespace cli {
+
+std::optional<int> handle_status_queries(const Options& opts);
+std::optional<int> handle_service_control(const Options& opts, const std::string& exec_path);
+std::optional<int> handle_daemon_control(const Options& opts, const std::string& exec_path);
+std::optional<int> handle_hard_reset(const Options& opts);
+int handle_monitoring_run(const Options& opts);
+
+namespace platform {
+struct ServiceStatus {
+    bool exists = false;
+    bool running = false;
+};
+
+std::string service_name(const Options& opts);
+std::string daemon_name(const Options& opts);
+
+bool service_exists(const std::string& name);
+std::vector<std::pair<std::string, ServiceStatus>> list_services();
+bool install_service(const std::string& name, const std::string& exec_path,
+                     const std::string& config_file, bool persist, const std::string& user);
+bool uninstall_service(const std::string& name);
+ServiceStatus service_status(const std::string& name);
+bool start_service(const std::string& name);
+bool stop_service(const std::string& name, bool force);
+bool restart_service(const std::string& name, bool force);
+bool start_daemon(const std::string& name);
+bool stop_daemon(const std::string& name, bool force);
+bool restart_daemon(const std::string& name, bool force);
+} // namespace platform
+
+} // namespace cli

--- a/src/autogitpull.cpp
+++ b/src/autogitpull.cpp
@@ -4,37 +4,12 @@
 #include "options.hpp"
 #include "help_text.hpp"
 #include "ui_loop.hpp"
-#include "process_monitor.hpp"
 #include "git_utils.hpp"
-#include "lock_utils.hpp"
 #include "history_utils.hpp"
 #include "version.hpp"
-#ifndef _WIN32
-#ifdef __APPLE__
-#include "macos_daemon.hpp"
-#else
-#include "linux_daemon.hpp"
-#endif
-#else
-#include "windows_service.hpp"
-#endif
+#include "cli_commands.hpp"
 
 namespace fs = std::filesystem;
-
-static void perform_hard_reset(const Options& opts) {
-    std::error_code ec;
-    if (!opts.log_file.empty())
-        fs::remove(opts.log_file, ec);
-    if (!opts.log_dir.empty())
-        fs::remove_all(opts.log_dir, ec);
-    if (!opts.root.empty()) {
-        fs::remove(opts.root / ".autogitpull.lock", ec);
-        fs::remove(opts.root / ".autogitpull.yaml", ec);
-        fs::remove(opts.root / ".autogitpull.json", ec);
-        fs::path hist = opts.root / opts.history_file;
-        fs::remove(hist, ec);
-    }
-}
 
 #ifndef AUTOGITPULL_NO_MAIN
 int main(int argc, char* argv[]) {
@@ -60,183 +35,16 @@ int main(int argc, char* argv[]) {
             std::cout << AUTOGITPULL_VERSION << "\n";
             return 0;
         }
-        if (opts.show_service) {
-#ifndef _WIN32
-            if (procutil::service_unit_exists(opts.daemon_name))
-                std::cout << opts.daemon_name << "\n";
-#else
-            if (winservice::service_exists(opts.service_name))
-                std::cout << opts.service_name << "\n";
-#endif
-            return 0;
-        }
-        if (opts.list_services) {
-#ifndef _WIN32
-            auto svcs = procutil::list_installed_services();
-#else
-            auto svcs = winservice::list_installed_services();
-#endif
-            for (const auto& [name, st] : svcs)
-                std::cout << name << " " << (st.running ? "running" : "stopped") << "\n";
-            return 0;
-        }
-        if (opts.install_service || opts.install_daemon) {
-#ifndef _WIN32
-            std::string exec = fs::absolute(argv[0]).string();
-            std::string cfg = opts.install_service ? opts.service_config : opts.daemon_config;
-            std::string name = opts.install_service ? opts.service_name : opts.daemon_name;
-            const char* user = std::getenv("USER");
-            std::string usr = user ? user : "root";
-            return procutil::create_service_unit(name, exec, cfg, usr, opts.persist) ? 0 : 1;
-#else
-            std::string exec = fs::absolute(argv[0]).string();
-            std::string cfg = opts.install_service ? opts.service_config : opts.daemon_config;
-            std::string name = opts.install_service ? opts.service_name : opts.daemon_name;
-            return winservice::install_service(name, exec, cfg, opts.persist) ? 0 : 1;
-#endif
-        }
-        if (opts.uninstall_service || opts.uninstall_daemon) {
-#ifndef _WIN32
-            std::string name = opts.uninstall_service ? opts.service_name : opts.daemon_name;
-            return procutil::remove_service_unit(name) ? 0 : 1;
-#else
-            std::string name = opts.uninstall_service ? opts.service_name : opts.daemon_name;
-            return winservice::uninstall_service(name) ? 0 : 1;
-#endif
-        }
-        if (opts.service_status) {
-#ifndef _WIN32
-            procutil::ServiceStatus st{};
-            procutil::service_unit_status(opts.daemon_name, st);
-#else
-            winservice::ServiceStatus st{};
-            winservice::service_status(opts.service_name, st);
-#endif
-            std::cout << (st.exists ? "exists" : "missing") << " "
-                      << (st.running ? "running" : "stopped") << "\n";
-            return 0;
-        }
-        if (opts.daemon_status) {
-#ifndef _WIN32
-            procutil::ServiceStatus st{};
-            procutil::service_unit_status(opts.daemon_name, st);
-            std::cout << (st.exists ? "exists" : "missing") << " "
-                      << (st.running ? "running" : "stopped") << "\n";
-            return 0;
-#else
-            winservice::ServiceStatus st{};
-            winservice::service_status(opts.service_name, st);
-            std::cout << (st.exists ? "exists" : "missing") << " "
-                      << (st.running ? "running" : "stopped") << "\n";
-            return 0;
-#endif
-        }
-#define SERVICE_NAME(name) ((name).empty() ? opts.service_name : (name))
-#define DAEMON_NAME(name) ((name).empty() ? opts.daemon_name : (name))
-        if (opts.start_service) {
-#ifndef _WIN32
-            return procutil::start_service_unit(DAEMON_NAME(opts.start_service_name)) ? 0 : 1;
-#else
-            return winservice::start_service(SERVICE_NAME(opts.start_service_name)) ? 0 : 1;
-#endif
-        }
-        if (opts.stop_service) {
-#ifndef _WIN32
-            return procutil::stop_service_unit(DAEMON_NAME(opts.stop_service_name),
-                                               opts.force_stop_service)
-                       ? 0
-                       : 1;
-#else
-            return winservice::stop_service(SERVICE_NAME(opts.stop_service_name),
-                                            opts.force_stop_service)
-                       ? 0
-                       : 1;
-#endif
-        }
-        if (opts.restart_service) {
-#ifndef _WIN32
-            return procutil::restart_service_unit(DAEMON_NAME(opts.restart_service_name),
-                                                  opts.force_restart_service)
-                       ? 0
-                       : 1;
-#else
-            return winservice::restart_service(SERVICE_NAME(opts.restart_service_name),
-                                               opts.force_restart_service)
-                       ? 0
-                       : 1;
-#endif
-        }
-#undef SERVICE_NAME
-#undef DAEMON_NAME
-#ifndef _WIN32
-        if (opts.start_daemon)
-            return procutil::start_service_unit(
-                       opts.start_daemon_name.empty() ? opts.daemon_name : opts.start_daemon_name)
-                       ? 0
-                       : 1;
-        if (opts.stop_daemon)
-            return procutil::stop_service_unit(
-                       opts.stop_daemon_name.empty() ? opts.daemon_name : opts.stop_daemon_name,
-                       opts.force_stop_daemon)
-                       ? 0
-                       : 1;
-        if (opts.restart_daemon)
-            return procutil::restart_service_unit(opts.restart_daemon_name.empty()
-                                                      ? opts.daemon_name
-                                                      : opts.restart_daemon_name,
-                                                  opts.force_restart_daemon)
-                       ? 0
-                       : 1;
-#endif
-        if (opts.remove_lock) {
-            if (!opts.root.empty()) {
-                fs::path lock = opts.root / ".autogitpull.lock";
-                procutil::release_lock_file(lock);
-            }
-            return 0;
-        }
-        if (opts.kill_all) {
-            if (opts.root.empty()) {
-                std::cerr << "--kill-all requires a root path" << std::endl;
-                return 1;
-            }
-            fs::path lock = opts.root / ".autogitpull.lock";
-            unsigned long pid = 0;
-            if (procutil::read_lock_pid(lock, pid) && procutil::process_running(pid)) {
-                if (procutil::terminate_process(pid)) {
-                    procutil::release_lock_file(lock);
-                    std::cout << "Terminated process " << pid << "\n";
-                } else {
-                    std::cerr << "Failed to terminate process " << pid << "\n";
-                    return 1;
-                }
-            } else {
-                std::cout << "No running instance" << std::endl;
-            }
-            return 0;
-        }
-        if (opts.hard_reset) {
-            std::cerr << "WARNING: --hard-reset will delete all application data" << std::endl;
-            if (!opts.confirm_reset) {
-                std::cerr << "Re-run with --confirm-reset to proceed" << std::endl;
-                return 1;
-            }
-            perform_hard_reset(opts);
-            std::cout << "Reset complete" << std::endl;
-            return 0;
-        }
-        if (opts.list_instances) {
-            auto insts = procutil::find_running_instances();
-            for (const auto& [name, pid] : insts)
-                std::cout << name << " " << pid << "\n";
-            return 0;
-        }
-        if (!alerts_allowed(opts)) {
-            std::cerr << "WARNING: --interval below 15s or --force-pull used" << std::endl;
-            std::cerr << "Re-run with --confirm-alert or --sudo-su to proceed" << std::endl;
-            return 1;
-        }
-        return run_with_monitor(opts);
+        std::string exec_path = argv[0];
+        if (auto rc = cli::handle_status_queries(opts); rc)
+            return *rc;
+        if (auto rc = cli::handle_service_control(opts, exec_path); rc)
+            return *rc;
+        if (auto rc = cli::handle_daemon_control(opts, exec_path); rc)
+            return *rc;
+        if (auto rc = cli::handle_hard_reset(opts); rc)
+            return *rc;
+        return cli::handle_monitoring_run(opts);
     } catch (const std::exception& e) {
         std::cerr << e.what() << "\n";
         return 1;

--- a/src/cli_commands.cpp
+++ b/src/cli_commands.cpp
@@ -1,0 +1,171 @@
+#include <filesystem>
+#include <iostream>
+#include <cstdlib>
+
+#include "cli_commands.hpp"
+#include "lock_utils.hpp"
+#include "process_monitor.hpp"
+
+namespace fs = std::filesystem;
+
+namespace cli {
+
+namespace {
+void perform_hard_reset(const Options& opts) {
+    std::error_code ec;
+    if (!opts.log_file.empty())
+        fs::remove(opts.log_file, ec);
+    if (!opts.log_dir.empty())
+        fs::remove_all(opts.log_dir, ec);
+    if (!opts.root.empty()) {
+        fs::remove(opts.root / ".autogitpull.lock", ec);
+        fs::remove(opts.root / ".autogitpull.yaml", ec);
+        fs::remove(opts.root / ".autogitpull.json", ec);
+        fs::path hist = opts.root / opts.history_file;
+        fs::remove(hist, ec);
+    }
+}
+} // namespace
+
+std::optional<int> handle_status_queries(const Options& opts) {
+    if (opts.show_service) {
+        std::string name = platform::service_name(opts);
+        if (platform::service_exists(name))
+            std::cout << name << "\n";
+        return 0;
+    }
+    if (opts.list_services) {
+        auto svcs = platform::list_services();
+        for (const auto& [name, st] : svcs)
+            std::cout << name << " " << (st.running ? "running" : "stopped") << "\n";
+        return 0;
+    }
+    if (opts.service_status) {
+        auto st = platform::service_status(platform::service_name(opts));
+        std::cout << (st.exists ? "exists" : "missing") << " "
+                  << (st.running ? "running" : "stopped") << "\n";
+        return 0;
+    }
+    if (opts.daemon_status) {
+        auto st = platform::service_status(platform::daemon_name(opts));
+        std::cout << (st.exists ? "exists" : "missing") << " "
+                  << (st.running ? "running" : "stopped") << "\n";
+        return 0;
+    }
+    if (opts.list_instances) {
+        auto insts = procutil::find_running_instances();
+        for (const auto& [name, pid] : insts)
+            std::cout << name << " " << pid << "\n";
+        return 0;
+    }
+    return std::nullopt;
+}
+
+std::optional<int> handle_service_control(const Options& opts, const std::string& exec_path) {
+    if (opts.install_service) {
+        std::string exec = fs::absolute(exec_path).string();
+        const char* user_env = std::getenv("USER");
+        std::string usr = user_env ? user_env : "root";
+        bool ok = platform::install_service(opts.service_name, exec, opts.service_config,
+                                            opts.persist, usr);
+        return ok ? std::optional<int>(0) : std::optional<int>(1);
+    }
+    if (opts.uninstall_service)
+        return platform::uninstall_service(opts.service_name) ? 0 : 1;
+    if (opts.start_service) {
+        std::string name =
+            opts.start_service_name.empty() ? opts.service_name : opts.start_service_name;
+        return platform::start_service(name) ? 0 : 1;
+    }
+    if (opts.stop_service) {
+        std::string name =
+            opts.stop_service_name.empty() ? opts.service_name : opts.stop_service_name;
+        return platform::stop_service(name, opts.force_stop_service) ? 0 : 1;
+    }
+    if (opts.restart_service) {
+        std::string name =
+            opts.restart_service_name.empty() ? opts.service_name : opts.restart_service_name;
+        return platform::restart_service(name, opts.force_restart_service) ? 0 : 1;
+    }
+    return std::nullopt;
+}
+
+std::optional<int> handle_daemon_control(const Options& opts, const std::string& exec_path) {
+    if (opts.install_daemon) {
+        std::string exec = fs::absolute(exec_path).string();
+        const char* user_env = std::getenv("USER");
+        std::string usr = user_env ? user_env : "root";
+        bool ok = platform::install_service(opts.daemon_name, exec, opts.daemon_config,
+                                            opts.persist, usr);
+        return ok ? std::optional<int>(0) : std::optional<int>(1);
+    }
+    if (opts.uninstall_daemon)
+        return platform::uninstall_service(opts.daemon_name) ? 0 : 1;
+    if (opts.start_daemon) {
+        std::string name =
+            opts.start_daemon_name.empty() ? opts.daemon_name : opts.start_daemon_name;
+        return platform::start_daemon(name) ? 0 : 1;
+    }
+    if (opts.stop_daemon) {
+        std::string name = opts.stop_daemon_name.empty() ? opts.daemon_name : opts.stop_daemon_name;
+        return platform::stop_daemon(name, opts.force_stop_daemon) ? 0 : 1;
+    }
+    if (opts.restart_daemon) {
+        std::string name =
+            opts.restart_daemon_name.empty() ? opts.daemon_name : opts.restart_daemon_name;
+        return platform::restart_daemon(name, opts.force_restart_daemon) ? 0 : 1;
+    }
+    return std::nullopt;
+}
+
+std::optional<int> handle_hard_reset(const Options& opts) {
+    if (opts.remove_lock) {
+        if (!opts.root.empty()) {
+            fs::path lock = opts.root / ".autogitpull.lock";
+            procutil::release_lock_file(lock);
+        }
+        return 0;
+    }
+    if (opts.kill_all) {
+        if (opts.root.empty()) {
+            std::cerr << "--kill-all requires a root path" << std::endl;
+            return 1;
+        }
+        fs::path lock = opts.root / ".autogitpull.lock";
+        unsigned long pid = 0;
+        if (procutil::read_lock_pid(lock, pid) && procutil::process_running(pid)) {
+            if (procutil::terminate_process(pid)) {
+                procutil::release_lock_file(lock);
+                std::cout << "Terminated process " << pid << "\n";
+            } else {
+                std::cerr << "Failed to terminate process " << pid << "\n";
+                return 1;
+            }
+        } else {
+            std::cout << "No running instance" << std::endl;
+        }
+        return 0;
+    }
+    if (opts.hard_reset) {
+        std::cerr << "WARNING: --hard-reset will delete all application data" << std::endl;
+        if (!opts.confirm_reset) {
+            std::cerr << "Re-run with --confirm-reset to proceed" << std::endl;
+            return 1;
+        }
+        perform_hard_reset(opts);
+        std::cout << "Reset complete" << std::endl;
+        return 0;
+    }
+    return std::nullopt;
+}
+
+int handle_monitoring_run(const Options& opts) {
+    if (!alerts_allowed(opts)) {
+        std::cerr << "WARNING: --interval below 15s or --force-pull used" << std::endl;
+        std::cerr << "Re-run with --confirm-alert or --sudo-su to proceed" << std::endl;
+        return 1;
+    }
+    return run_with_monitor(opts);
+}
+
+} // namespace cli

--- a/src/linux_commands.cpp
+++ b/src/linux_commands.cpp
@@ -1,0 +1,57 @@
+#include "cli_commands.hpp"
+
+#ifndef _WIN32
+#include "linux_daemon.hpp"
+#include <cstdlib>
+
+namespace cli::platform {
+
+std::string service_name(const Options& opts) { return opts.daemon_name; }
+std::string daemon_name(const Options& opts) { return opts.daemon_name; }
+
+bool service_exists(const std::string& name) { return procutil::service_unit_exists(name); }
+
+std::vector<std::pair<std::string, ServiceStatus>> list_services() {
+    std::vector<std::pair<std::string, ServiceStatus>> result;
+    for (const auto& [name, st] : procutil::list_installed_services())
+        result.push_back({name, {st.exists, st.running}});
+    return result;
+}
+
+bool install_service(const std::string& name, const std::string& exec_path,
+                     const std::string& config_file, bool persist, const std::string& user) {
+    std::string usr =
+        user.empty() ? std::string(std::getenv("USER") ? std::getenv("USER") : "root") : user;
+    return procutil::create_service_unit(name, exec_path, config_file, usr, persist);
+}
+
+bool uninstall_service(const std::string& name) { return procutil::remove_service_unit(name); }
+
+ServiceStatus service_status(const std::string& name) {
+    procutil::ServiceStatus st{};
+    procutil::service_unit_status(name, st);
+    return {st.exists, st.running};
+}
+
+bool start_service(const std::string& name) { return procutil::start_service_unit(name); }
+
+bool stop_service(const std::string& name, bool force) {
+    return procutil::stop_service_unit(name, force);
+}
+
+bool restart_service(const std::string& name, bool force) {
+    return procutil::restart_service_unit(name, force);
+}
+
+bool start_daemon(const std::string& name) { return procutil::start_service_unit(name); }
+
+bool stop_daemon(const std::string& name, bool force) {
+    return procutil::stop_service_unit(name, force);
+}
+
+bool restart_daemon(const std::string& name, bool force) {
+    return procutil::restart_service_unit(name, force);
+}
+
+} // namespace cli::platform
+#endif

--- a/src/windows_commands.cpp
+++ b/src/windows_commands.cpp
@@ -1,0 +1,54 @@
+#include "cli_commands.hpp"
+
+#ifdef _WIN32
+#include "windows_service.hpp"
+
+namespace cli::platform {
+
+std::string service_name(const Options& opts) { return opts.service_name; }
+std::string daemon_name(const Options& opts) { return opts.service_name; }
+
+bool service_exists(const std::string& name) { return winservice::service_exists(name); }
+
+std::vector<std::pair<std::string, ServiceStatus>> list_services() {
+    std::vector<std::pair<std::string, ServiceStatus>> result;
+    for (const auto& [name, st] : winservice::list_installed_services())
+        result.push_back({name, {st.exists, st.running}});
+    return result;
+}
+
+bool install_service(const std::string& name, const std::string& exec_path,
+                     const std::string& config_file, bool persist, const std::string&) {
+    return winservice::install_service(name, exec_path, config_file, persist);
+}
+
+bool uninstall_service(const std::string& name) { return winservice::uninstall_service(name); }
+
+ServiceStatus service_status(const std::string& name) {
+    winservice::ServiceStatus st{};
+    winservice::service_status(name, st);
+    return {st.exists, st.running};
+}
+
+bool start_service(const std::string& name) { return winservice::start_service(name); }
+
+bool stop_service(const std::string& name, bool force) {
+    return winservice::stop_service(name, force);
+}
+
+bool restart_service(const std::string& name, bool force) {
+    return winservice::restart_service(name, force);
+}
+
+bool start_daemon(const std::string& name) { return winservice::start_service(name); }
+
+bool stop_daemon(const std::string& name, bool force) {
+    return winservice::stop_service(name, force);
+}
+
+bool restart_daemon(const std::string& name, bool force) {
+    return winservice::restart_service(name, force);
+}
+
+} // namespace cli::platform
+#endif

--- a/tests/cli_commands_tests.cpp
+++ b/tests/cli_commands_tests.cpp
@@ -1,0 +1,27 @@
+#include "test_common.hpp"
+#include "cli_commands.hpp"
+
+TEST_CASE("handle_hard_reset requires confirmation") {
+    Options opts;
+    opts.hard_reset = true;
+    auto rc = cli::handle_hard_reset(opts);
+    REQUIRE(rc.has_value());
+    REQUIRE(*rc == 1);
+}
+
+TEST_CASE("handle_status_queries list instances") {
+    Options opts;
+    opts.list_instances = true;
+    auto rc = cli::handle_status_queries(opts);
+    REQUIRE(rc.has_value());
+    REQUIRE(*rc == 0);
+}
+
+TEST_CASE("handle_hard_reset executes when confirmed") {
+    Options opts;
+    opts.hard_reset = true;
+    opts.confirm_reset = true;
+    auto rc = cli::handle_hard_reset(opts);
+    REQUIRE(rc.has_value());
+    REQUIRE(*rc == 0);
+}


### PR DESCRIPTION
## Summary
- extract service and daemon command logic into dedicated handlers
- add platform-specific command implementations
- streamline main command dispatch and add basic dispatch tests

## Testing
- `make format`
- `make lint`
- `cpplint src/cli_commands.cpp src/linux_commands.cpp src/windows_commands.cpp tests/cli_commands_tests.cpp include/cli_commands.hpp`
- `make test` *(fails: Could not find yaml-cppConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689c9f37a10c83259420579da11be5b0