### PR TITLE
fix(build): add missing CLI commands source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ SRC = \
     src/lock_utils.cpp \
     src/process_monitor.cpp \
     src/help_text.cpp \
+    src/cli_commands.cpp \
     src/linux_daemon.cpp \
     src/windows_service.cpp
 


### PR DESCRIPTION
## Summary
- include `src/cli_commands.cpp` in Makefile's source list so CLI handlers link correctly

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find a package configuration file provided by "yaml-cpp")*

------
https://chatgpt.com/codex/tasks/task_e_689cd171691c8325a209c3dd93014d47