### PR TITLE
fix(build): include platform command sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,16 @@ SRC = \
     src/lock_utils.cpp \
     src/process_monitor.cpp \
     src/help_text.cpp \
-    src/cli_commands.cpp \
-    src/linux_daemon.cpp \
-    src/windows_service.cpp
+    src/cli_commands.cpp
+
+# Platform-specific sources
+ifeq ($(OS),Windows_NT)
+SRC += src/windows_service.cpp src/windows_commands.cpp
+else ifeq ($(UNAME_S),Darwin)
+SRC += src/macos_daemon.cpp src/linux_commands.cpp
+else
+SRC += src/linux_daemon.cpp src/linux_commands.cpp
+endif
 
 OBJ = $(SRC:.cpp=.o)
 FORMAT_FILES = $(SRC) include/*.hpp


### PR DESCRIPTION
## Summary
- ensure Makefile compiles platform-specific command sources

## Testing
- `make format`
- `make lint`
- `make test`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689cd5a4a1748325aab22b8a64971c05