### PR TITLE
refactor: split lock utils by platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,15 +31,14 @@ add_library(autogitpull_lib STATIC
     src/options.cpp
     src/parse_utils.cpp
     src/history_utils.cpp
-    src/lock_utils.cpp
     src/process_monitor.cpp
     src/cli_commands.cpp)
 if(WIN32)
-    target_sources(autogitpull_lib PRIVATE src/windows_service.cpp src/windows_commands.cpp)
+    target_sources(autogitpull_lib PRIVATE src/windows_service.cpp src/windows_commands.cpp src/lock_utils_windows.cpp)
 elseif(APPLE)
-    target_sources(autogitpull_lib PRIVATE src/macos_daemon.cpp src/linux_commands.cpp)
+    target_sources(autogitpull_lib PRIVATE src/macos_daemon.cpp src/linux_commands.cpp src/lock_utils_posix.cpp)
 else()
-    target_sources(autogitpull_lib PRIVATE src/linux_daemon.cpp src/linux_commands.cpp)
+    target_sources(autogitpull_lib PRIVATE src/linux_daemon.cpp src/linux_commands.cpp src/lock_utils_posix.cpp)
 endif()
 target_include_directories(autogitpull_lib PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(autogitpull_lib PRIVATE PkgConfig::LIBGIT2 yaml-cpp nlohmann_json::nlohmann_json pthread)
@@ -94,15 +93,14 @@ add_executable(memory_leak_test
     src/ignore_utils.cpp
     src/parse_utils.cpp
     src/history_utils.cpp
-    src/lock_utils.cpp
     src/tui.cpp
     src/cli_commands.cpp)
 if(WIN32)
-    target_sources(memory_leak_test PRIVATE src/windows_service.cpp src/windows_commands.cpp)
+    target_sources(memory_leak_test PRIVATE src/windows_service.cpp src/windows_commands.cpp src/lock_utils_windows.cpp)
 elseif(APPLE)
-    target_sources(memory_leak_test PRIVATE src/macos_daemon.cpp src/linux_commands.cpp)
+    target_sources(memory_leak_test PRIVATE src/macos_daemon.cpp src/linux_commands.cpp src/lock_utils_posix.cpp)
 else()
-    target_sources(memory_leak_test PRIVATE src/linux_daemon.cpp src/linux_commands.cpp)
+    target_sources(memory_leak_test PRIVATE src/linux_daemon.cpp src/linux_commands.cpp src/lock_utils_posix.cpp)
 endif()
 target_include_directories(memory_leak_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(memory_leak_test PRIVATE AUTOGITPULL_NO_MAIN)

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,19 @@ SRC = \
     src/options.cpp \
     src/parse_utils.cpp \
     src/history_utils.cpp \
-    src/lock_utils.cpp \
     src/process_monitor.cpp \
     src/help_text.cpp \
     src/linux_daemon.cpp \
     src/windows_service.cpp
 
+ifeq ($(OS),Windows_NT)
+SRC += src/lock_utils_windows.cpp
+else
+SRC += src/lock_utils_posix.cpp
+endif
+
 OBJ = $(SRC:.cpp=.o)
-FORMAT_FILES = $(SRC) include/*.hpp
+FORMAT_FILES = $(SRC) src/lock_utils_posix.cpp src/lock_utils_windows.cpp include/*.hpp
 
 all: autogitpull
 

--- a/src/lock_utils_posix.cpp
+++ b/src/lock_utils_posix.cpp
@@ -1,0 +1,136 @@
+#include "lock_utils.hpp"
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <unistd.h>
+#ifdef __linux__
+#include <sys/socket.h>
+#include <sys/un.h>
+#endif
+#ifdef __APPLE__
+#include <libproc.h>
+#endif
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <set>
+#include <system_error>
+
+namespace procutil {
+
+bool acquire_lock_file(const std::filesystem::path& path) {
+    int fd = open(path.c_str(), O_RDWR | O_CREAT | O_EXCL, 0644);
+    if (fd == -1)
+        return false;
+    char buf[32];
+    int len = snprintf(buf, sizeof(buf), "%ld\n", static_cast<long>(getpid()));
+    write(fd, buf, len);
+    close(fd);
+    return true;
+}
+
+void release_lock_file(const std::filesystem::path& path) {
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+    (void)ec;
+}
+
+bool read_lock_pid(const std::filesystem::path& path, unsigned long& pid) {
+    std::ifstream f(path);
+    if (!f.is_open())
+        return false;
+    f >> pid;
+    return true;
+}
+
+bool process_running(unsigned long pid) {
+    if (kill(static_cast<pid_t>(pid), 0) == 0)
+        return true;
+    return errno != ESRCH;
+}
+
+bool terminate_process(unsigned long pid) { return kill(static_cast<pid_t>(pid), SIGTERM) == 0; }
+
+LockFileGuard::LockFileGuard(const std::filesystem::path& p) : path(p) {
+    locked = acquire_lock_file(path);
+}
+
+LockFileGuard::~LockFileGuard() {
+    if (locked)
+        release_lock_file(path);
+}
+
+std::vector<std::pair<std::string, unsigned long>> find_running_instances() {
+    namespace fs = std::filesystem;
+    std::vector<std::pair<std::string, unsigned long>> out;
+    auto add_inst = [&](const std::string& n, unsigned long p) { out.emplace_back(n, p); };
+
+    fs::path tmp = fs::temp_directory_path();
+    for (const auto& entry : fs::directory_iterator(tmp)) {
+        if (entry.is_directory()) {
+            fs::path lock = entry.path() / ".autogitpull.lock";
+            unsigned long pid = 0;
+            if (fs::exists(lock) && read_lock_pid(lock, pid) && process_running(pid))
+                add_inst(entry.path().filename().string(), pid);
+        }
+#ifdef __linux__
+        if (entry.path().extension() == ".sock") {
+            int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+            if (fd >= 0) {
+                sockaddr_un addr{};
+                addr.sun_family = AF_UNIX;
+                std::strncpy(addr.sun_path, entry.path().c_str(), sizeof(addr.sun_path) - 1);
+                if (connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+                    ucred cred{};
+                    socklen_t len = sizeof(cred);
+                    if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) == 0)
+                        add_inst(entry.path().stem().string(), cred.pid);
+                }
+                close(fd);
+            }
+        }
+#endif
+    }
+
+#ifdef __linux__
+    fs::path proc_dir("/proc");
+    for (const auto& entry : fs::directory_iterator(proc_dir)) {
+        if (!entry.is_directory())
+            continue;
+        std::string pidstr = entry.path().filename().string();
+        if (!std::all_of(pidstr.begin(), pidstr.end(), ::isdigit))
+            continue;
+        unsigned long pid = 0;
+        try {
+            pid = std::stoul(pidstr);
+        } catch (...) {
+            continue;
+        }
+        std::ifstream f(entry.path() / "cmdline");
+        if (!f.is_open())
+            continue;
+        std::string arg0;
+        std::getline(f, arg0, '\0');
+        if (fs::path(arg0).filename() == "autogitpull")
+            add_inst("autogitpull", pid);
+    }
+#elif defined(__APPLE__)
+    int count = proc_listallpids(nullptr, 0);
+    if (count > 0) {
+        std::vector<pid_t> pids(static_cast<std::size_t>(count));
+        count = proc_listallpids(pids.data(), static_cast<int>(pids.size() * sizeof(pid_t)));
+        count /= static_cast<int>(sizeof(pid_t));
+        char namebuf[PROC_PIDPATHINFO_MAXSIZE];
+        for (int i = 0; i < count; ++i) {
+            if (proc_name(pids[i], namebuf, sizeof(namebuf)) > 0) {
+                if (std::string(namebuf) == "autogitpull")
+                    add_inst("autogitpull", static_cast<unsigned long>(pids[i]));
+            }
+        }
+    }
+#endif
+
+    return out;
+}
+
+} // namespace procutil

--- a/tests/process_tests.cpp
+++ b/tests/process_tests.cpp
@@ -1,5 +1,11 @@
 #include "test_common.hpp"
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
 static int g_monitor_count = 0;
 
 TEST_CASE("run_event_loop runtime limit") {

--- a/tests/windows_attach_tests.cpp
+++ b/tests/windows_attach_tests.cpp
@@ -1,8 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
-#include "windows_service.hpp"
-#include "lock_utils.hpp"
 
 #ifdef _WIN32
+#include "windows_service.hpp"
+#include "lock_utils.hpp"
 #include <windows.h>
 #include <io.h>
 #include <thread>


### PR DESCRIPTION
## Summary
- split lock utility implementation into POSIX and Windows files
- adjust build and tests to use platform-specific lock utils

## Testing
- `make lint`
- `make test` *(fails: Could not find a package configuration file provided by "yaml-cpp")*


------
https://chatgpt.com/codex/tasks/task_e_689cabf240108325ba65d359f35d5670