### PR TITLE
fix(build): update lock utils references in build scripts

### DIFF
--- a/scripts/compile-cl.bat
+++ b/scripts/compile-cl.bat
@@ -20,7 +20,7 @@ cl /nologo /std:c++20 /EHsc /O2 /DNDEBUG /D YAML_CPP_STATIC_DEFINE ^
  /I "%INC%" /I include ^
  src\autogitpull.cpp src\scanner.cpp src\ui_loop.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp ^
 src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\ignore_utils.cpp src\debug_utils.cpp ^
-src\options.cpp src\parse_utils.cpp src\history_utils.cpp src\lock_utils.cpp src\process_monitor.cpp src\help_text.cpp ^
+src\options.cpp src\parse_utils.cpp src\history_utils.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^
  src\linux_daemon.cpp src\windows_service.cpp ^
  "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib ^
  /Fedist\autogitpull.exe

--- a/scripts/compile-debug-cl.bat
+++ b/scripts/compile-debug-cl.bat
@@ -22,7 +22,7 @@ cl /nologo /std:c++20 /EHsc /Zi /D YAML_CPP_STATIC_DEFINE ^
  src\autogitpull.cpp src\scanner.cpp src\ui_loop.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp ^
  src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
  src\ignore_utils.cpp ^
- src\options.cpp src\parse_utils.cpp src\lock_utils.cpp src\process_monitor.cpp src\help_text.cpp ^
+ src\options.cpp src\parse_utils.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^
  src\linux_daemon.cpp src\windows_service.cpp ^
  "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /fsanitize:address ^
  /Fedist\autogitpull_debug.exe

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -37,7 +37,7 @@ if exist "%LIBSSH2_LIB%\libssh2.a" (
     "%ROOT_DIR%\src\git_utils.cpp" "%ROOT_DIR%\src\tui.cpp" "%ROOT_DIR%\src\logger.cpp" ^
     "%ROOT_DIR%\src\resource_utils.cpp" "%ROOT_DIR%\src\system_utils.cpp" "%ROOT_DIR%\src\time_utils.cpp" ^
     "%ROOT_DIR%\src\config_utils.cpp" "%ROOT_DIR%\src\ignore_utils.cpp" "%ROOT_DIR%\src\debug_utils.cpp" "%ROOT_DIR%\src\options.cpp" ^
-    "%ROOT_DIR%\src\parse_utils.cpp" "%ROOT_DIR%\src\history_utils.cpp" "%ROOT_DIR%\src\lock_utils.cpp" "%ROOT_DIR%\src\process_monitor.cpp" ^
+    "%ROOT_DIR%\src\parse_utils.cpp" "%ROOT_DIR%\src\history_utils.cpp" "%ROOT_DIR%\src\lock_utils_windows.cpp" "%ROOT_DIR%\src\process_monitor.cpp" ^
     "%ROOT_DIR%\src\help_text.cpp" "%ROOT_DIR%\src\linux_daemon.cpp" "%ROOT_DIR%\src\windows_service.cpp" ^
     "%LIBGIT2_LIB%\libgit2.a" "%YAMLCPP_LIB%\libyaml-cpp.a" %SSH2_LIB% -lz -lws2_32 -lwinhttp ^
     -lole32 -lrpcrt4 -lcrypt32 -lpsapi %LDFLAGS% -o "%ROOT_DIR%\dist\autogitpull_debug.exe"

--- a/scripts/compile-debug.sh
+++ b/scripts/compile-debug.sh
@@ -31,7 +31,7 @@ mkdir -p "${ROOT_DIR}/dist"
     ${ROOT_DIR}/src/options.cpp \
     ${ROOT_DIR}/src/parse_utils.cpp \
     ${ROOT_DIR}/src/history_utils.cpp \
-    ${ROOT_DIR}/src/lock_utils.cpp \
+    ${ROOT_DIR}/src/lock_utils_posix.cpp \
     ${ROOT_DIR}/src/process_monitor.cpp \
     ${ROOT_DIR}/src/help_text.cpp \
     ${ROOT_DIR}/src/linux_daemon.cpp \

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -126,7 +126,7 @@ for %%F in (
     "%ROOT_DIR%\src\options.cpp"
     "%ROOT_DIR%\src\parse_utils.cpp"
     "%ROOT_DIR%\src\history_utils.cpp"
-    "%ROOT_DIR%\src\lock_utils.cpp"
+    "%ROOT_DIR%\src\lock_utils_windows.cpp"
     "%ROOT_DIR%\src\process_monitor.cpp"
     "%ROOT_DIR%\src\help_text.cpp"
     "%ROOT_DIR%\src\linux_daemon.cpp"

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -63,7 +63,7 @@ SRCS=(
     "${ROOT_DIR}/src/options.cpp"
     "${ROOT_DIR}/src/parse_utils.cpp"
     "${ROOT_DIR}/src/history_utils.cpp"
-    "${ROOT_DIR}/src/lock_utils.cpp"
+    "${ROOT_DIR}/src/lock_utils_posix.cpp"
     "${ROOT_DIR}/src/process_monitor.cpp"
     "${ROOT_DIR}/src/help_text.cpp"
     "${ROOT_DIR}/src/linux_daemon.cpp"


### PR DESCRIPTION
## Summary
- reference `lock_utils_posix.cpp` in Unix build scripts
- reference `lock_utils_windows.cpp` in Windows build scripts

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find package configuration file provided by "yaml-cpp")*
- `./scripts/compile.sh` *(fails: fatal error: git2.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb9d72b48325869b15e591ae9d8b