### PR TITLE
fix(build): include windows header before tlhelp

### DIFF
--- a/src/lock_utils_windows.cpp
+++ b/src/lock_utils_windows.cpp
@@ -1,6 +1,6 @@
 #include "lock_utils.hpp"
-#include <tlhelp32.h>
 #include <windows.h>
+#include <tlhelp32.h>
 #include <algorithm>
 #include <cstring>
 #include <fstream>


### PR DESCRIPTION
## Summary
- ensure `windows.h` is included before `tlhelp32.h` so Windows builds resolve needed types

## Testing
- `make format`
- `make lint`
- `make deps`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ce0cae4dc8325aa16a796fdf493ca