### PR TITLE
fix(lock): include windows headers before toolhelp

### DIFF
--- a/src/lock_utils_windows.cpp
+++ b/src/lock_utils_windows.cpp
@@ -1,6 +1,6 @@
 #include "lock_utils.hpp"
-#include <tlhelp32.h>
 #include <windows.h>
+#include <tlhelp32.h>
 #include <algorithm>
 #include <cstring>
 #include <fstream>


### PR DESCRIPTION
## Summary
- include <windows.h> before <tlhelp32.h> in lock_utils_windows.cpp to resolve missing type definitions

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find a package configuration file provided by "yaml-cpp")*

------
https://chatgpt.com/codex/tasks/task_e_689ce6259fb8832591a8b89de0b47fd9