### PR TITLE
perf(scanner): speed up ignore checks

### DIFF
--- a/include/scanner.hpp
+++ b/include/scanner.hpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <mutex>
 #include <set>
+#include <unordered_set>
 #include <string>
 #include <vector>
 #include <chrono>
@@ -13,10 +14,9 @@
 #include "repo.hpp"
 #include "repo_options.hpp"
 
-std::vector<std::filesystem::path> build_repo_list(const std::vector<std::filesystem::path>& roots,
-                                                   bool recursive,
-                                                   const std::vector<std::filesystem::path>& ignore,
-                                                   size_t max_depth);
+std::vector<std::filesystem::path>
+build_repo_list(const std::vector<std::filesystem::path>& roots, bool recursive,
+                const std::unordered_set<std::filesystem::path>& ignore, size_t max_depth);
 
 void process_repo(const std::filesystem::path& p,
                   std::map<std::filesystem::path, RepoInfo>& repo_infos,

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <iostream>
 #include <ctime>
+#include <unordered_set>
 
 #include "git_utils.hpp"
 #include "logger.hpp"
@@ -20,7 +21,8 @@
 namespace fs = std::filesystem;
 
 std::vector<fs::path> build_repo_list(const std::vector<fs::path>& roots, bool recursive,
-                                      const std::vector<fs::path>& ignore, size_t max_depth) {
+                                      const std::unordered_set<fs::path>& ignore,
+                                      size_t max_depth) {
     std::vector<fs::path> result;
     for (const auto& root : roots) {
         if (root.empty())
@@ -70,7 +72,7 @@ std::vector<fs::path> build_repo_list(const std::vector<fs::path>& roots, bool r
                         ec.clear();
                     continue;
                 }
-                if (std::find(ignore.begin(), ignore.end(), p) != ignore.end()) {
+                if (ignore.count(p)) {
                     it.disable_recursion_pending();
                     continue;
                 }
@@ -99,7 +101,7 @@ std::vector<fs::path> build_repo_list(const std::vector<fs::path>& roots, bool r
                         ec.clear();
                     continue;
                 }
-                if (std::find(ignore.begin(), ignore.end(), p) != ignore.end())
+                if (ignore.count(p))
                     continue;
                 result.push_back(p);
             }

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <string>
 #include <set>
+#include <unordered_set>
 #include <map>
 #include <algorithm>
 #include <mutex>
@@ -207,7 +208,8 @@ static void prepare_repos(const Options& opts, std::vector<fs::path>& all_repos,
     } else {
         std::vector<fs::path> roots{opts.root};
         roots.insert(roots.end(), opts.include_dirs.begin(), opts.include_dirs.end());
-        all_repos = build_repo_list(roots, opts.recursive_scan, opts.ignore_dirs, opts.max_depth);
+        std::unordered_set<fs::path> ignore(opts.ignore_dirs.begin(), opts.ignore_dirs.end());
+        all_repos = build_repo_list(roots, opts.recursive_scan, ignore, opts.max_depth);
         if (opts.sort_mode == Options::ALPHA)
             std::sort(all_repos.begin(), all_repos.end());
         else if (opts.sort_mode == Options::REVERSE)
@@ -527,8 +529,10 @@ int run_event_loop(Options opts) {
             if (opts.rescan_new && rescan_countdown_ms <= std::chrono::milliseconds(0)) {
                 std::vector<fs::path> roots{opts.root};
                 roots.insert(roots.end(), opts.include_dirs.begin(), opts.include_dirs.end());
+                std::unordered_set<fs::path> ignore(opts.ignore_dirs.begin(),
+                                                    opts.ignore_dirs.end());
                 auto new_repos =
-                    build_repo_list(roots, opts.recursive_scan, opts.ignore_dirs, opts.max_depth);
+                    build_repo_list(roots, opts.recursive_scan, ignore, opts.max_depth);
                 if (opts.keep_first_valid) {
                     for (const auto& p : first_validated) {
                         if (std::find(new_repos.begin(), new_repos.end(), p) == new_repos.end())

--- a/tests/repo_tests.cpp
+++ b/tests/repo_tests.cpp
@@ -1,4 +1,5 @@
 #include "test_common.hpp"
+#include <unordered_set>
 
 TEST_CASE("get_local_hash surfaces error for missing repo") {
     git::GitInitGuard guard;
@@ -87,7 +88,7 @@ TEST_CASE("build_repo_list ignores directories") {
     fs::create_directories(root / "b");
     fs::create_directories(root / "c");
 
-    std::vector<fs::path> ignore{root / "b", root / "c"};
+    std::unordered_set<fs::path> ignore{root / "b", root / "c"};
     std::vector<fs::path> repos = build_repo_list({root}, false, ignore, 0);
     REQUIRE(std::find(repos.begin(), repos.end(), root / "a") != repos.end());
     REQUIRE(std::find(repos.begin(), repos.end(), root / "b") == repos.end());
@@ -102,7 +103,8 @@ TEST_CASE("build_repo_list skips files") {
     fs::create_directories(root / "repo");
     std::ofstream(root / "file.txt") << "ignore";
 
-    std::vector<fs::path> repos = build_repo_list({root}, false, {}, 0);
+    std::unordered_set<fs::path> ignore;
+    std::vector<fs::path> repos = build_repo_list({root}, false, ignore, 0);
     REQUIRE(std::find(repos.begin(), repos.end(), root / "repo") != repos.end());
     REQUIRE(std::find(repos.begin(), repos.end(), root / "file.txt") == repos.end());
 
@@ -120,7 +122,8 @@ TEST_CASE("build_repo_list ignores symlinks outside root") {
     fs::path link = root / "outside_link";
     fs::create_directory_symlink(outside, link);
 
-    std::vector<fs::path> repos = build_repo_list({root}, false, {}, 0);
+    std::unordered_set<fs::path> ignore;
+    std::vector<fs::path> repos = build_repo_list({root}, false, ignore, 0);
     REQUIRE(std::find(repos.begin(), repos.end(), root / "repo") != repos.end());
     REQUIRE(std::find(repos.begin(), repos.end(), link) == repos.end());
     REQUIRE(std::find(repos.begin(), repos.end(), outside) == repos.end());
@@ -161,7 +164,8 @@ TEST_CASE("build_repo_list respects max depth") {
     fs::remove_all(root);
     fs::create_directories(root / "a/b/c");
 
-    std::vector<fs::path> repos = build_repo_list({root}, true, {}, 2);
+    std::unordered_set<fs::path> ignore;
+    std::vector<fs::path> repos = build_repo_list({root}, true, ignore, 2);
     REQUIRE(std::find(repos.begin(), repos.end(), root / "a") != repos.end());
     REQUIRE(std::find(repos.begin(), repos.end(), root / "a/b") != repos.end());
     REQUIRE(std::find(repos.begin(), repos.end(), root / "a/b/c") == repos.end());
@@ -177,12 +181,35 @@ TEST_CASE("build_repo_list scans multiple roots") {
     fs::create_directories(r1 / "a");
     fs::create_directories(r2 / "b");
 
-    std::vector<fs::path> repos = build_repo_list({r1, r2}, false, {}, 0);
+    std::unordered_set<fs::path> ignore;
+    std::vector<fs::path> repos = build_repo_list({r1, r2}, false, ignore, 0);
     REQUIRE(std::find(repos.begin(), repos.end(), r1 / "a") != repos.end());
     REQUIRE(std::find(repos.begin(), repos.end(), r2 / "b") != repos.end());
 
     fs::remove_all(r1);
     fs::remove_all(r2);
+}
+
+TEST_CASE("build_repo_list handles large ignore set") {
+    fs::path root = fs::temp_directory_path() / "large_ignore_test";
+    fs::remove_all(root);
+    fs::create_directory(root);
+    constexpr int N = 1000;
+    std::vector<fs::path> dirs;
+    dirs.reserve(N);
+    for (int i = 0; i < N; ++i) {
+        fs::path d = root / ("dir" + std::to_string(i));
+        fs::create_directory(d);
+        dirs.push_back(d);
+    }
+    std::unordered_set<fs::path> ignore(dirs.begin(), dirs.end());
+    ignore.erase(dirs.back());
+    auto start = std::chrono::steady_clock::now();
+    std::vector<fs::path> repos = build_repo_list({root}, false, ignore, 0);
+    auto dur = std::chrono::steady_clock::now() - start;
+    REQUIRE(std::find(repos.begin(), repos.end(), dirs.back()) != repos.end());
+    REQUIRE(dur < std::chrono::seconds(2));
+    fs::remove_all(root);
 }
 
 TEST_CASE("scan_repos respects concurrency limit") {


### PR DESCRIPTION
## Summary
- switch `build_repo_list` ignore parameter to `std::unordered_set`
- use constant-time `ignore.count` checks in scanner
- update call sites and add unit test for large ignore sets

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cedfed4548325948ae4086553d6b8