### PR TITLE
build: include cli command sources in manual scripts

### DIFF
--- a/scripts/compile-cl.bat
+++ b/scripts/compile-cl.bat
@@ -21,7 +21,8 @@ cl /nologo /std:c++20 /EHsc /O2 /DNDEBUG /D YAML_CPP_STATIC_DEFINE ^
  src\autogitpull.cpp src\scanner.cpp src\ui_loop.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp ^
 src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\ignore_utils.cpp src\debug_utils.cpp ^
 src\options.cpp src\parse_utils.cpp src\history_utils.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^
- src\linux_daemon.cpp src\windows_service.cpp ^
+src\cli_commands.cpp src\linux_daemon.cpp src\windows_service.cpp ^
+src\linux_commands.cpp src\windows_commands.cpp ^
  "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib ^
  /Fedist\autogitpull.exe
 

--- a/scripts/compile-debug-cl.bat
+++ b/scripts/compile-debug-cl.bat
@@ -23,7 +23,8 @@ cl /nologo /std:c++20 /EHsc /Zi /D YAML_CPP_STATIC_DEFINE ^
  src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
  src\ignore_utils.cpp ^
  src\options.cpp src\parse_utils.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^
- src\linux_daemon.cpp src\windows_service.cpp ^
+ src\cli_commands.cpp src\linux_daemon.cpp src\windows_service.cpp ^
+ src\linux_commands.cpp src\windows_commands.cpp ^
  "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /fsanitize:address ^
  /Fedist\autogitpull_debug.exe
 

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -38,7 +38,8 @@ if exist "%LIBSSH2_LIB%\libssh2.a" (
     "%ROOT_DIR%\src\resource_utils.cpp" "%ROOT_DIR%\src\system_utils.cpp" "%ROOT_DIR%\src\time_utils.cpp" ^
     "%ROOT_DIR%\src\config_utils.cpp" "%ROOT_DIR%\src\ignore_utils.cpp" "%ROOT_DIR%\src\debug_utils.cpp" "%ROOT_DIR%\src\options.cpp" ^
     "%ROOT_DIR%\src\parse_utils.cpp" "%ROOT_DIR%\src\history_utils.cpp" "%ROOT_DIR%\src\lock_utils_windows.cpp" "%ROOT_DIR%\src\process_monitor.cpp" ^
-    "%ROOT_DIR%\src\help_text.cpp" "%ROOT_DIR%\src\linux_daemon.cpp" "%ROOT_DIR%\src\windows_service.cpp" ^
+    "%ROOT_DIR%\src\help_text.cpp" "%ROOT_DIR%\src\cli_commands.cpp" "%ROOT_DIR%\src\linux_daemon.cpp" "%ROOT_DIR%\src\windows_service.cpp" ^
+    "%ROOT_DIR%\src\linux_commands.cpp" "%ROOT_DIR%\src\windows_commands.cpp" ^
     "%LIBGIT2_LIB%\libgit2.a" "%YAMLCPP_LIB%\libyaml-cpp.a" %SSH2_LIB% -lz -lws2_32 -lwinhttp ^
     -lole32 -lrpcrt4 -lcrypt32 -lpsapi %LDFLAGS% -o "%ROOT_DIR%\dist\autogitpull_debug.exe"
 

--- a/scripts/compile-debug.sh
+++ b/scripts/compile-debug.sh
@@ -34,8 +34,11 @@ mkdir -p "${ROOT_DIR}/dist"
     ${ROOT_DIR}/src/lock_utils_posix.cpp \
     ${ROOT_DIR}/src/process_monitor.cpp \
     ${ROOT_DIR}/src/help_text.cpp \
+    ${ROOT_DIR}/src/cli_commands.cpp \
     ${ROOT_DIR}/src/linux_daemon.cpp \
     ${ROOT_DIR}/src/windows_service.cpp \
+    ${ROOT_DIR}/src/linux_commands.cpp \
+    ${ROOT_DIR}/src/windows_commands.cpp \
     ${PKG_LIBS} -fsanitize=address -o "${ROOT_DIR}/dist/autogitpull_debug"
 
 echo "Build complete: ${ROOT_DIR}/dist/autogitpull_debug"

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -129,8 +129,11 @@ for %%F in (
     "%ROOT_DIR%\src\lock_utils_windows.cpp"
     "%ROOT_DIR%\src\process_monitor.cpp"
     "%ROOT_DIR%\src\help_text.cpp"
+    "%ROOT_DIR%\src\cli_commands.cpp"
     "%ROOT_DIR%\src\linux_daemon.cpp"
     "%ROOT_DIR%\src\windows_service.cpp"
+    "%ROOT_DIR%\src\linux_commands.cpp"
+    "%ROOT_DIR%\src\windows_commands.cpp"
 ) do set "SRCS=!SRCS! %%~F"
 
 rem --------------------------------------------------------------------

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -66,8 +66,11 @@ SRCS=(
     "${ROOT_DIR}/src/lock_utils_posix.cpp"
     "${ROOT_DIR}/src/process_monitor.cpp"
     "${ROOT_DIR}/src/help_text.cpp"
+    "${ROOT_DIR}/src/cli_commands.cpp"
     "${ROOT_DIR}/src/linux_daemon.cpp"
     "${ROOT_DIR}/src/windows_service.cpp"
+    "${ROOT_DIR}/src/linux_commands.cpp"
+    "${ROOT_DIR}/src/windows_commands.cpp"
 )
 
 mkdir -p "${ROOT_DIR}/dist"


### PR DESCRIPTION
## Summary
- include cli and platform command sources in legacy compile scripts
- keep debug and release scripts in sync to avoid undefined reference errors

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find a package configuration file provided by "yaml-cpp")*

------
https://chatgpt.com/codex/tasks/task_e_689cf83cde748325a0e433f55a5f4bb7