### PR TITLE
feat(tui): add configurable color themes

### DIFF
--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -89,7 +89,9 @@
 | `--censor-char` | '*' | Character for name masking |
 | `--censor-names` | false (disabled) | Mask repository names |
 | `--color` |  | Override status color |
+| `--theme` |  | Load colors from theme file |
 | `--color` |  | Override status color |
+| `--theme` |  | Load colors from theme file |
 | `--hide-date-time` | true (enabled) | Hide date/time line in TUI |
 | `--hide-date-time` | true (enabled) | Hide date/time line in TUI |
 | `--hide-header` | true (enabled) | Hide status header |

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,24 @@
+# Themes
+
+Color themes for the TUI can be supplied as JSON or YAML files containing ANSI escape codes for each color field:
+
+```
+{
+  "reset": "\u001b[0m",
+  "green": "\u001b[32m",
+  "yellow": "\u001b[33m",
+  "red": "\u001b[31m",
+  "cyan": "\u001b[36m",
+  "gray": "\u001b[90m",
+  "bold": "\u001b[1m",
+  "magenta": "\u001b[35m"
+}
+```
+
+Use the `--theme` option to select a theme file:
+
+```
+autogitpull --root <path> --theme examples/themes/light.json
+```
+
+Sample themes are available under `examples/themes/`. Create your own by copying one of these files and adjusting the ANSI codes.

--- a/examples/themes/dark.json
+++ b/examples/themes/dark.json
@@ -1,0 +1,10 @@
+{
+  "reset": "\u001b[0m",
+  "green": "\u001b[32m",
+  "yellow": "\u001b[33m",
+  "red": "\u001b[31m",
+  "cyan": "\u001b[36m",
+  "gray": "\u001b[90m",
+  "bold": "\u001b[1m",
+  "magenta": "\u001b[35m"
+}

--- a/examples/themes/light.json
+++ b/examples/themes/light.json
@@ -1,0 +1,10 @@
+{
+  "reset": "\u001b[0m",
+  "green": "\u001b[92m",
+  "yellow": "\u001b[93m",
+  "red": "\u001b[31m",
+  "cyan": "\u001b[36m",
+  "gray": "\u001b[90m",
+  "bold": "\u001b[1m",
+  "magenta": "\u001b[35m"
+}

--- a/include/config_utils.hpp
+++ b/include/config_utils.hpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <string>
 #include "repo_options.hpp"
+#include "tui.hpp"
 
 bool load_yaml_config(const std::string& path, std::map<std::string, std::string>& opts,
                       std::map<std::string, std::map<std::string, std::string>>& repo_opts,
@@ -11,5 +12,7 @@ bool load_yaml_config(const std::string& path, std::map<std::string, std::string
 bool load_json_config(const std::string& path, std::map<std::string, std::string>& opts,
                       std::map<std::string, std::map<std::string, std::string>>& repo_opts,
                       std::string& error);
+
+bool load_theme(const std::string& path, TuiTheme& theme, std::string& error);
 
 #endif // CONFIG_UTILS_HPP

--- a/include/options.hpp
+++ b/include/options.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include "logger.hpp"
 #include "repo_options.hpp"
+#include "tui.hpp"
 
 struct Options {
     std::filesystem::path root;
@@ -63,6 +64,8 @@ struct Options {
     bool show_header = true;
     bool no_colors = false;
     std::string custom_color;
+    std::string theme_file;
+    TuiTheme theme;
     std::vector<std::filesystem::path> include_dirs;
     std::vector<std::filesystem::path> ignore_dirs;
     bool enable_history = false;

--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -15,6 +15,22 @@
 void enable_win_ansi();
 
 /**
+ * @brief Theme definition for TUI colors.
+ *
+ * Contains raw ANSI sequences for each color used by the interface.
+ */
+struct TuiTheme {
+    std::string reset = "\033[0m";
+    std::string green = "\033[32m";
+    std::string yellow = "\033[33m";
+    std::string red = "\033[31m";
+    std::string cyan = "\033[36m";
+    std::string gray = "\033[90m";
+    std::string bold = "\033[1m";
+    std::string magenta = "\033[35m";
+};
+
+/**
  * @brief Resolved color codes for the TUI.
  */
 struct TuiColors {
@@ -31,7 +47,7 @@ struct TuiColors {
 /**
  * @brief Create a color palette honoring user preferences.
  */
-TuiColors make_tui_colors(bool no_colors, const std::string& custom_color);
+TuiColors make_tui_colors(bool no_colors, const std::string& custom_color, const TuiTheme& theme);
 
 std::string render_header(const std::vector<std::filesystem::path>& all_repos,
                           const std::map<std::filesystem::path, RepoInfo>& repo_infos, int interval,
@@ -65,8 +81,8 @@ void draw_tui(const std::vector<std::filesystem::path>& all_repos,
               bool show_notgit, bool show_version, bool track_cpu, bool track_mem,
               bool track_threads, bool track_net, bool show_affinity, bool track_vmem,
               bool show_commit_date, bool show_commit_author, bool session_dates_only,
-              bool no_colors, const std::string& custom_color, const std::string& status_msg,
-              int runtime_sec, bool show_datetime_line, bool show_header, bool show_repo_count,
-              bool censor_names, char censor_char);
+              bool no_colors, const std::string& custom_color, const TuiTheme& theme,
+              const std::string& status_msg, int runtime_sec, bool show_datetime_line,
+              bool show_header, bool show_repo_count, bool censor_names, char censor_char);
 
 #endif // TUI_HPP

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -42,6 +42,7 @@ FLAG_MAP = {
     '--hide-header':'show_header',
     '--row-order':'sort_mode',
     '--color':'custom_color',
+    '--theme':'theme_file',
     '--single-thread':'concurrency',
     '--threads':'concurrency',
     '--syslog':'use_syslog',

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -72,6 +72,7 @@ void print_help(const char* prog) {
         {"--hide-header", "-H", "", "Hide status header", "Display"},
         {"--row-order", "", "<mode>", "Row ordering (alpha/reverse)", "Display"},
         {"--color", "", "<ansi>", "Override status color", "Display"},
+        {"--theme", "", "<file>", "Load colors from theme file", "Display"},
         {"--no-colors", "-C", "", "Disable ANSI colors", "Display"},
         {"--censor-names", "", "", "Mask repository names", "Display"},
         {"--censor-char", "", "<ch>", "Character for name masking", "Display"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -906,6 +906,17 @@ Options parse_options(int argc, char* argv[]) {
             val = cfg_opt("--color");
         opts.custom_color = val;
     }
+    if (parser.has_flag("--theme") || cfg_opts.count("--theme")) {
+        std::string val = parser.get_option("--theme");
+        if (val.empty())
+            val = cfg_opt("--theme");
+        opts.theme_file = val;
+        if (!val.empty()) {
+            std::string err;
+            if (!load_theme(val, opts.theme, err))
+                throw std::runtime_error("Failed to load theme: " + err);
+        }
+    }
     if (parser.has_flag("--row-order") || cfg_opts.count("--row-order")) {
         std::string val = parser.get_option("--row-order");
         if (val.empty())

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -16,15 +16,6 @@
 
 namespace fs = std::filesystem;
 
-const char* COLOR_RESET = "\033[0m";
-const char* COLOR_GREEN = "\033[32m";
-const char* COLOR_YELLOW = "\033[33m";
-const char* COLOR_RED = "\033[31m";
-const char* COLOR_CYAN = "\033[36m";
-const char* COLOR_GRAY = "\033[90m";
-const char* COLOR_BOLD = "\033[1m";
-const char* COLOR_MAGENTA = "\033[35m";
-
 #ifdef _WIN32
 void enable_win_ansi() {
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -49,14 +40,18 @@ static std::string format_bytes(std::size_t b) {
     return ss.str();
 }
 
-TuiColors make_tui_colors(bool no_colors, const std::string& custom_color) {
-    auto choose = [&](const char* def) {
-        return no_colors ? "" : (custom_color.empty() ? def : custom_color.c_str());
+TuiColors make_tui_colors(bool no_colors, const std::string& custom_color, const TuiTheme& theme) {
+    auto choose = [&](const std::string& def) {
+        return no_colors ? std::string() : (custom_color.empty() ? def : custom_color);
     };
-    return {no_colors ? "" : COLOR_RESET, choose(COLOR_GREEN),
-            choose(COLOR_YELLOW),         choose(COLOR_RED),
-            choose(COLOR_CYAN),           choose(COLOR_GRAY),
-            choose(COLOR_BOLD),           choose(COLOR_MAGENTA)};
+    return {no_colors ? std::string() : theme.reset,
+            choose(theme.green),
+            choose(theme.yellow),
+            choose(theme.red),
+            choose(theme.cyan),
+            choose(theme.gray),
+            choose(theme.bold),
+            choose(theme.magenta)};
 }
 
 std::string render_header(const std::vector<fs::path>& all_repos,
@@ -245,9 +240,10 @@ void draw_tui(const std::vector<fs::path>& all_repos,
               bool show_version, bool track_cpu, bool track_mem, bool track_threads, bool track_net,
               bool show_affinity, bool track_vmem, bool show_commit_date, bool show_commit_author,
               bool session_dates_only, bool no_colors, const std::string& custom_color,
-              const std::string& status_msg, int runtime_sec, bool show_datetime_line,
-              bool show_header, bool show_repo_count, bool censor_names, char censor_char) {
-    TuiColors colors = make_tui_colors(no_colors, custom_color);
+              const TuiTheme& theme, const std::string& status_msg, int runtime_sec,
+              bool show_datetime_line, bool show_header, bool show_repo_count, bool censor_names,
+              char censor_char) {
+    TuiColors colors = make_tui_colors(no_colors, custom_color, theme);
     std::ostringstream out;
     out << render_header(all_repos, repo_infos, interval, seconds_left, scanning, action,
                          show_version, show_repo_count, status_msg, runtime_sec, show_datetime_line,

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -230,8 +230,9 @@ static void update_ui(const Options& opts, const std::vector<fs::path>& all_repo
                  opts.show_notgit, opts.show_version, opts.cpu_tracker, opts.mem_tracker,
                  opts.thread_tracker, opts.net_tracker, opts.cpu_core_mask != 0, opts.show_vmem,
                  opts.show_commit_date, opts.show_commit_author, opts.session_dates_only,
-                 opts.no_colors, opts.custom_color, message, runtime_sec, opts.show_datetime_line,
-                 opts.show_header, opts.show_repo_count, opts.censor_names, opts.censor_char);
+                 opts.no_colors, opts.custom_color, opts.theme, message, runtime_sec,
+                 opts.show_datetime_line, opts.show_header, opts.show_repo_count, opts.censor_names,
+                 opts.censor_char);
     }
 }
 int run_event_loop(Options opts) {

--- a/tests/ui_output_tests.cpp
+++ b/tests/ui_output_tests.cpp
@@ -32,7 +32,7 @@ TEST_CASE("render_header reports repo count") {
     infos[repos[1]] = RepoInfo{repos[1], RS_SKIPPED, "", "", "", "", "", "", 0, false};
     infos[repos[2]] = RepoInfo{repos[2], RS_NOT_GIT, "", "", "", "", "", "", 0, false};
     infos[repos[3]] = RepoInfo{repos[3], RS_PENDING, "", "", "", "", "", "", 0, false};
-    TuiColors colors = make_tui_colors(true, "");
+    TuiColors colors = make_tui_colors(true, "", TuiTheme{});
     std::string out = render_header(repos, infos, 5, 1, false, "Idle", false, true, "", -1, false, colors);
     REQUIRE(out.find("Repos: 2/4\n") != std::string::npos);
 }
@@ -40,8 +40,24 @@ TEST_CASE("render_header reports repo count") {
 TEST_CASE("render_repo_entry censors names") {
     fs::path repo = "/foo/bar";
     RepoInfo ri{repo, RS_UP_TO_DATE, "", "", "", "", "", "", 0, false};
-    TuiColors colors = make_tui_colors(true, "");
+    TuiColors colors = make_tui_colors(true, "", TuiTheme{});
     std::string out = render_repo_entry(repo, ri, true, true, false, false, false, true, '#', colors);
     REQUIRE(out.find("bar") == std::string::npos);
     REQUIRE(out.find("###") != std::string::npos);
+}
+
+TEST_CASE("theme file overrides colors") {
+    fs::path theme_path = fs::path(__FILE__).parent_path() / ".." / "examples" / "themes" /
+                          "light.json";
+    TuiTheme theme;
+    std::string err;
+    REQUIRE(load_theme(theme_path.string(), theme, err));
+    TuiColors colors = make_tui_colors(false, "", theme);
+    REQUIRE(colors.green == "\033[92m");
+}
+
+TEST_CASE("no color option clears codes") {
+    TuiColors colors = make_tui_colors(true, "", TuiTheme{});
+    REQUIRE(colors.green.empty());
+    REQUIRE(colors.reset.empty());
 }


### PR DESCRIPTION
## Summary
- add `TuiTheme` to configure TUI colors and support `--theme`
- parse theme files and generate palettes with `TuiColors`
- document and test theme selection with example theme files

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cf7c51a94832588a05194ee898ffe