### PR TITLE
feat(git): support progress callback for clone_repo

### DIFF
--- a/include/git_utils.hpp
+++ b/include/git_utils.hpp
@@ -122,13 +122,19 @@ bool has_uncommitted_changes(const fs::path& repo);
  *
  * @param dest           Destination path for the new repository.
  * @param url            Remote repository URL.
+ * @param progress_cb    Optional callback reporting fetch progress in percent.
  * @param use_credentials Whether to attempt authentication using environment
  *                        variables.
  * @param auth_failed    Optional output flag set when authentication fails.
+ * @param down_limit_kbps Optional download rate limit in KiB/s.
+ * @param up_limit_kbps Optional upload rate limit in KiB/s.
+ * @param disk_limit_kbps Optional disk I/O rate limit in KiB/s.
  * @return `true` on success, `false` otherwise.
  */
-bool clone_repo(const fs::path& dest, const std::string& url, bool use_credentials = false,
-                bool* auth_failed = nullptr);
+bool clone_repo(const fs::path& dest, const std::string& url,
+                const std::function<void(int)>* progress_cb = nullptr, bool use_credentials = false,
+                bool* auth_failed = nullptr, size_t down_limit_kbps = 0, size_t up_limit_kbps = 0,
+                size_t disk_limit_kbps = 0);
 
 /**
  * @brief Perform a fast-forward pull from the specified remote.

--- a/src/git_utils.cpp
+++ b/src/git_utils.cpp
@@ -266,50 +266,59 @@ bool has_uncommitted_changes(const fs::path& repo) {
     return git_status_list_entrycount(list.get()) > 0;
 }
 
-bool clone_repo(const fs::path& dest, const std::string& url, bool use_credentials,
-                bool* auth_failed) {
+bool clone_repo(const fs::path& dest, const std::string& url,
+                const std::function<void(int)>* progress_cb, bool use_credentials,
+                bool* auth_failed, size_t down_limit_kbps, size_t up_limit_kbps,
+                size_t disk_limit_kbps) {
     git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
     git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
-    ProgressData progress{nullptr, std::chrono::steady_clock::now(), 0, 0, 0};
-    callbacks.payload = &progress;
-    callbacks.transfer_progress = [](const git_transfer_progress* stats, void* payload) -> int {
-        if (!payload)
+    ProgressData progress{progress_cb, std::chrono::steady_clock::now(), down_limit_kbps,
+                          up_limit_kbps, disk_limit_kbps};
+    if (up_limit_kbps > 0)
+        procutil::init_network_usage();
+    if (progress_cb || down_limit_kbps > 0 || up_limit_kbps > 0 || disk_limit_kbps > 0) {
+        if (disk_limit_kbps > 0)
+            procutil::init_disk_usage();
+        callbacks.payload = &progress;
+        callbacks.transfer_progress = [](const git_transfer_progress* stats, void* payload) -> int {
+            if (!payload)
+                return 0;
+            auto* pd = static_cast<ProgressData*>(payload);
+            if (pd->cb) {
+                int pct = 0;
+                if (stats->total_objects > 0)
+                    pct = static_cast<int>(100 * stats->received_objects / stats->total_objects);
+                (*pd->cb)(pct);
+            }
+            double expected_ms = 0.0;
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::steady_clock::now() - pd->start)
+                               .count();
+            if (pd->down_limit > 0) {
+                double ms = (double)stats->received_bytes / (pd->down_limit * 1024.0) * 1000.0;
+                if (ms > expected_ms)
+                    expected_ms = ms;
+            }
+            if (pd->up_limit > 0) {
+                auto net = procutil::get_network_usage();
+                double ms = (double)net.upload_bytes / (pd->up_limit * 1024.0) * 1000.0;
+                if (ms > expected_ms)
+                    expected_ms = ms;
+            }
+            if (pd->disk_limit > 0) {
+                auto du = procutil::get_disk_usage();
+                double ms =
+                    (double)(du.read_bytes + du.write_bytes) / (pd->disk_limit * 1024.0) * 1000.0;
+                if (ms > expected_ms)
+                    expected_ms = ms;
+            }
+            if (expected_ms > elapsed) {
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(static_cast<int>(expected_ms - elapsed)));
+            }
             return 0;
-        auto* pd = static_cast<ProgressData*>(payload);
-        if (pd->cb) {
-            int pct = 0;
-            if (stats->total_objects > 0)
-                pct = static_cast<int>(100 * stats->received_objects / stats->total_objects);
-            (*pd->cb)(pct);
-        }
-        double expected_ms = 0.0;
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                           std::chrono::steady_clock::now() - pd->start)
-                           .count();
-        if (pd->down_limit > 0) {
-            double ms = (double)stats->received_bytes / (pd->down_limit * 1024.0) * 1000.0;
-            if (ms > expected_ms)
-                expected_ms = ms;
-        }
-        if (pd->up_limit > 0) {
-            auto net = procutil::get_network_usage();
-            double ms = (double)net.upload_bytes / (pd->up_limit * 1024.0) * 1000.0;
-            if (ms > expected_ms)
-                expected_ms = ms;
-        }
-        if (pd->disk_limit > 0) {
-            auto du = procutil::get_disk_usage();
-            double ms =
-                (double)(du.read_bytes + du.write_bytes) / (pd->disk_limit * 1024.0) * 1000.0;
-            if (ms > expected_ms)
-                expected_ms = ms;
-        }
-        if (expected_ms > elapsed) {
-            std::this_thread::sleep_for(
-                std::chrono::milliseconds(static_cast<int>(expected_ms - elapsed)));
-        }
-        return 0;
-    };
+        };
+    }
     if (use_credentials)
         callbacks.credentials = credential_cb;
     opts.fetch_opts.callbacks = callbacks;


### PR DESCRIPTION
## Summary
- allow callers to provide progress callbacks and rate limits to `clone_repo`
- add repo test covering progress notifications and throttling behavior

## Testing
- `make format`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689cfbee8c008325a1a2d9187f45b4ef