### PR TITLE
docs: clarify history utilities comments

### DIFF
--- a/include/history_utils.hpp
+++ b/include/history_utils.hpp
@@ -4,7 +4,26 @@
 #include <string>
 #include <vector>
 
+/**
+ * @brief Read history entries from a newline-delimited text file.
+ *
+ * Each line in the file represents a single UTF-8 encoded entry.
+ *
+ * @param path Filesystem location of the history file.
+ * @return Vector of entries in the order they appear in the file.
+ */
 std::vector<std::string> read_history(const std::filesystem::path& path);
+
+/**
+ * @brief Append an entry to the history file, trimming old entries.
+ *
+ * The file is assumed to be newline-delimited UTF-8 text. The function appends
+ * @a entry as a new line and retains at most @a max_entries newest lines.
+ *
+ * @param path Filesystem location of the history file.
+ * @param entry Entry to append as a single line.
+ * @param max_entries Maximum number of entries to keep in the file.
+ */
 void append_history(const std::filesystem::path& path, const std::string& entry,
                     std::size_t max_entries = 100);
 


### PR DESCRIPTION
## Summary
- document read_history and append_history expectations and parameters

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find a package configuration file provided by "yaml-cpp" with any of the following names: yaml-cppConfig.cmake, yaml-cpp-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a256d18ec88325b763cbbe624d9bf8