### PR TITLE
docs(thread): document fallback jthread semantics

### DIFF
--- a/include/thread_compat.hpp
+++ b/include/thread_compat.hpp
@@ -1,6 +1,9 @@
 #pragma once
 #include <thread>
 
+// Provides a compatibility alias for `std::jthread`.
+// When `std::jthread` is unavailable, a minimal wrapper around `std::thread`
+// is supplied that joins on destruction but lacks stop token support.
 #if defined(__cpp_lib_jthread)
 #include <stop_token>
 namespace th_compat {


### PR DESCRIPTION
## Summary
- clarify the purpose of `th_compat::jthread`
- explain that the fallback wrapper joins on destruction and lacks stop token support

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find package configuration file provided by "yaml-cpp")*

------
https://chatgpt.com/codex/tasks/task_e_68a257cc881c8325989bd703b371f46c