### PR TITLE
feat(config): validate config keys

### DIFF
--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -1,6 +1,22 @@
 # Command Line Options
 
 
+## Configuration file schema
+
+Configuration files may be written in YAML or JSON. The top level accepts the
+following keys:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `interval` | number or string | Maps to `--interval` |
+| `cli` | boolean | Maps to `--cli` |
+| `root` | string | Maps to `--root` |
+| `credential-file` | string | Maps to `--credential-file` |
+| `repositories` | object | Map of repository paths to option maps |
+
+All other top-level mappings are treated as option categories or repository
+overrides. Scalar keys outside this list are rejected.
+
 ## Actions
 
 | Option | Default | Description |

--- a/tests/config_tests.cpp
+++ b/tests/config_tests.cpp
@@ -177,3 +177,59 @@ TEST_CASE("JSON value conversions") {
     fs::remove(cfg);
 }
 
+TEST_CASE("YAML invalid key is reported") {
+    fs::path cfg = fs::temp_directory_path() / "cfg_bad.yaml";
+    {
+        std::ofstream ofs(cfg);
+        ofs << "unknown: 1\n";
+    }
+    std::map<std::string, std::string> opts;
+    std::map<std::string, std::map<std::string, std::string>> repo;
+    std::string err;
+    REQUIRE_FALSE(load_yaml_config(cfg.string(), opts, repo, err));
+    REQUIRE(err.find("Unknown key") != std::string::npos);
+    fs::remove(cfg);
+}
+
+TEST_CASE("JSON invalid key is reported") {
+    fs::path cfg = fs::temp_directory_path() / "cfg_bad.json";
+    {
+        std::ofstream ofs(cfg);
+        ofs << "{\n  \"unknown\": 1\n}";
+    }
+    std::map<std::string, std::string> opts;
+    std::map<std::string, std::map<std::string, std::string>> repo;
+    std::string err;
+    REQUIRE_FALSE(load_json_config(cfg.string(), opts, repo, err));
+    REQUIRE(err.find("Unknown key") != std::string::npos);
+    fs::remove(cfg);
+}
+
+TEST_CASE("YAML type mismatch is reported") {
+    fs::path cfg = fs::temp_directory_path() / "cfg_type.yaml";
+    {
+        std::ofstream ofs(cfg);
+        ofs << "interval:\n  sub: 1\n";
+    }
+    std::map<std::string, std::string> opts;
+    std::map<std::string, std::map<std::string, std::string>> repo;
+    std::string err;
+    REQUIRE_FALSE(load_yaml_config(cfg.string(), opts, repo, err));
+    REQUIRE(err.find("interval") != std::string::npos);
+    fs::remove(cfg);
+}
+
+TEST_CASE("JSON type mismatch is reported") {
+    fs::path cfg = fs::temp_directory_path() / "cfg_type.json";
+    {
+        std::ofstream ofs(cfg);
+        ofs << "{\n  \"interval\": {\n    \"sub\": 1\n  }\n}";
+    }
+    std::map<std::string, std::string> opts;
+    std::map<std::string, std::map<std::string, std::string>> repo;
+    std::string err;
+    REQUIRE_FALSE(load_json_config(cfg.string(), opts, repo, err));
+    REQUIRE(err.find("interval") != std::string::npos);
+    fs::remove(cfg);
+}
+


### PR DESCRIPTION
## Summary
- add minimal schema for config loaders
- validate YAML/JSON nodes and surface unknown keys and type mismatches
- document config schema and add negative tests

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Could not find a package configuration file provided by "yaml-cpp")*


------
https://chatgpt.com/codex/tasks/task_e_68a3b678aee48325826b0bdae2db43c2