### PR TITLE
fix(build): include mutant mode sources in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ SRC = \
     src/history_utils.cpp \
     src/process_monitor.cpp \
     src/help_text.cpp \
-    src/cli_commands.cpp
+    src/cli_commands.cpp \
+    src/mutant_mode.cpp
 
 # Platform-specific sources
 ifeq ($(OS),Windows_NT)

--- a/src/mutant_mode.cpp
+++ b/src/mutant_mode.cpp
@@ -1,8 +1,10 @@
 #include "mutant_mode.hpp"
-#include "git_utils.hpp"
+
 #include <fstream>
-#include <sstream>
 #include <map>
+#include <sstream>
+
+#include "git_utils.hpp"
 
 namespace fs = std::filesystem;
 
@@ -95,8 +97,7 @@ bool mutant_should_pull(const fs::path& repo, RepoInfo& ri, const std::string& r
     return true;
 }
 
-void mutant_record_result(const fs::path& repo, RepoStatus status,
-                          std::chrono::seconds duration) {
+void mutant_record_result(const fs::path& repo, RepoStatus status, std::chrono::seconds duration) {
     (void)repo;
     if (!current_opts)
         return;


### PR DESCRIPTION
## Summary
- add mutant_mode.cpp to Makefile to resolve missing symbols on macOS builds
- tidy mutant_mode.cpp include order

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6141845ec832599e81a2d9181c271