### PR TITLE
fix(build): include mutant mode in scripts

### DIFF
--- a/scripts/compile-cl.bat
+++ b/scripts/compile-cl.bat
@@ -21,10 +21,10 @@ cl /nologo /std:c++20 /EHsc /O2 /DNDEBUG /D YAML_CPP_STATIC_DEFINE ^
  src\autogitpull.cpp src\scanner.cpp src\ui_loop.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp ^
 src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\ignore_utils.cpp src\debug_utils.cpp ^
 src\options.cpp src\parse_utils.cpp src\history_utils.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^
-src\cli_commands.cpp src\linux_daemon.cpp src\windows_service.cpp ^
+src\cli_commands.cpp src\mutant_mode.cpp src\linux_daemon.cpp src\windows_service.cpp ^
 src\linux_commands.cpp src\windows_commands.cpp ^
- "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib ^
- /Fedist\autogitpull.exe
+"%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib ^
+/Fedist\autogitpull.exe
 
 if errorlevel 1 (
     echo Build failed.

--- a/scripts/compile-debug-cl.bat
+++ b/scripts/compile-debug-cl.bat
@@ -23,7 +23,7 @@ cl /nologo /std:c++20 /EHsc /Zi /D YAML_CPP_STATIC_DEFINE ^
  src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
  src\ignore_utils.cpp ^
  src\options.cpp src\parse_utils.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^
- src\cli_commands.cpp src\linux_daemon.cpp src\windows_service.cpp ^
+ src\cli_commands.cpp src\mutant_mode.cpp src\linux_daemon.cpp src\windows_service.cpp ^
  src\linux_commands.cpp src\windows_commands.cpp ^
  "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /fsanitize:address ^
  /Fedist\autogitpull_debug.exe

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -38,7 +38,7 @@ if exist "%LIBSSH2_LIB%\libssh2.a" (
     "%ROOT_DIR%\src\resource_utils.cpp" "%ROOT_DIR%\src\system_utils.cpp" "%ROOT_DIR%\src\time_utils.cpp" ^
     "%ROOT_DIR%\src\config_utils.cpp" "%ROOT_DIR%\src\ignore_utils.cpp" "%ROOT_DIR%\src\debug_utils.cpp" "%ROOT_DIR%\src\options.cpp" ^
     "%ROOT_DIR%\src\parse_utils.cpp" "%ROOT_DIR%\src\history_utils.cpp" "%ROOT_DIR%\src\lock_utils_windows.cpp" "%ROOT_DIR%\src\process_monitor.cpp" ^
-    "%ROOT_DIR%\src\help_text.cpp" "%ROOT_DIR%\src\cli_commands.cpp" "%ROOT_DIR%\src\linux_daemon.cpp" "%ROOT_DIR%\src\windows_service.cpp" ^
+    "%ROOT_DIR%\src\help_text.cpp" "%ROOT_DIR%\src\cli_commands.cpp" "%ROOT_DIR%\src\mutant_mode.cpp" "%ROOT_DIR%\src\linux_daemon.cpp" "%ROOT_DIR%\src\windows_service.cpp" ^
     "%ROOT_DIR%\src\linux_commands.cpp" "%ROOT_DIR%\src\windows_commands.cpp" ^
     "%LIBGIT2_LIB%\libgit2.a" "%YAMLCPP_LIB%\libyaml-cpp.a" %SSH2_LIB% -lz -lws2_32 -lwinhttp ^
     -lole32 -lrpcrt4 -lcrypt32 -lpsapi %LDFLAGS% -o "%ROOT_DIR%\dist\autogitpull_debug.exe"

--- a/scripts/compile-debug.sh
+++ b/scripts/compile-debug.sh
@@ -35,6 +35,7 @@ mkdir -p "${ROOT_DIR}/dist"
     ${ROOT_DIR}/src/process_monitor.cpp \
     ${ROOT_DIR}/src/help_text.cpp \
     ${ROOT_DIR}/src/cli_commands.cpp \
+    ${ROOT_DIR}/src/mutant_mode.cpp \
     ${ROOT_DIR}/src/linux_daemon.cpp \
     ${ROOT_DIR}/src/windows_service.cpp \
     ${ROOT_DIR}/src/linux_commands.cpp \

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -130,6 +130,7 @@ for %%F in (
     "%ROOT_DIR%\src\process_monitor.cpp"
     "%ROOT_DIR%\src\help_text.cpp"
     "%ROOT_DIR%\src\cli_commands.cpp"
+    "%ROOT_DIR%\src\mutant_mode.cpp"
     "%ROOT_DIR%\src\linux_daemon.cpp"
     "%ROOT_DIR%\src\windows_service.cpp"
     "%ROOT_DIR%\src\linux_commands.cpp"

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -67,6 +67,7 @@ SRCS=(
     "${ROOT_DIR}/src/process_monitor.cpp"
     "${ROOT_DIR}/src/help_text.cpp"
     "${ROOT_DIR}/src/cli_commands.cpp"
+    "${ROOT_DIR}/src/mutant_mode.cpp"
     "${ROOT_DIR}/src/linux_daemon.cpp"
     "${ROOT_DIR}/src/windows_service.cpp"
     "${ROOT_DIR}/src/linux_commands.cpp"


### PR DESCRIPTION
## Summary
- add mutant_mode.cpp to portable release/debug compile scripts
- ensure Windows build helpers also compile mutant mode

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6141845ec832599e81a2d9181c271