### PR TITLE
fix(build): include mutant mode in manual compile scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,29 @@ project(autogitpull)
 
 set(CMAKE_CXX_STANDARD 20)
 
+include(FetchContent)
+
 find_package(PkgConfig REQUIRED)
-find_package(yaml-cpp REQUIRED)
-find_package(nlohmann_json 3 REQUIRED)
+find_package(yaml-cpp CONFIG QUIET)
+if(NOT yaml-cpp_FOUND)
+    message(STATUS "yaml-cpp not found, fetching via FetchContent...")
+    FetchContent_Declare(
+        yaml-cpp
+        GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+        GIT_TAG 0.8.0
+    )
+    FetchContent_MakeAvailable(yaml-cpp)
+endif()
+find_package(nlohmann_json 3 CONFIG QUIET)
+if(NOT nlohmann_json_FOUND)
+    message(STATUS "nlohmann_json not found, fetching via FetchContent...")
+    FetchContent_Declare(
+        nlohmann_json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG v3.11.2
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
+endif()
 if(APPLE)
     set(PKG_CONFIG_USE_STATIC_LIBS OFF)
 else()
@@ -59,8 +79,6 @@ if(MINGW)
     target_link_libraries(autogitpull PRIVATE winhttp ole32 rpcrt4 crypt32)
 endif()
 
-include(FetchContent)
-
 enable_testing()
 find_package(Catch2 3 QUIET)
 if(NOT Catch2_FOUND)
@@ -108,5 +126,5 @@ target_include_directories(memory_leak_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(memory_leak_test PRIVATE AUTOGITPULL_NO_MAIN)
 target_compile_options(memory_leak_test PRIVATE -fsanitize=address)
 target_link_options(memory_leak_test PRIVATE -fsanitize=address)
-target_link_libraries(memory_leak_test PRIVATE Catch2::Catch2WithMain autogitpull_lib)
+target_link_libraries(memory_leak_test PRIVATE Catch2::Catch2WithMain autogitpull_lib yaml-cpp nlohmann_json::nlohmann_json)
 add_test(NAME memory_leak_test COMMAND memory_leak_test)

--- a/scripts/compile-cl.bat
+++ b/scripts/compile-cl.bat
@@ -21,7 +21,7 @@ cl /nologo /std:c++20 /EHsc /O2 /DNDEBUG /D YAML_CPP_STATIC_DEFINE ^
  src\autogitpull.cpp src\scanner.cpp src\ui_loop.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp ^
 src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\ignore_utils.cpp src\debug_utils.cpp ^
 src\options.cpp src\parse_utils.cpp src\history_utils.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^
-src\cli_commands.cpp src\linux_daemon.cpp src\windows_service.cpp ^
+src\cli_commands.cpp src\mutant_mode.cpp src\linux_daemon.cpp src\windows_service.cpp ^
 src\linux_commands.cpp src\windows_commands.cpp ^
  "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib ^
  /Fedist\autogitpull.exe

--- a/scripts/compile-debug-cl.bat
+++ b/scripts/compile-debug-cl.bat
@@ -22,7 +22,7 @@ cl /nologo /std:c++20 /EHsc /Zi /D YAML_CPP_STATIC_DEFINE ^
  src\autogitpull.cpp src\scanner.cpp src\ui_loop.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp ^
  src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
  src\ignore_utils.cpp ^
- src\options.cpp src\parse_utils.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^
+ src\options.cpp src\parse_utils.cpp src\mutant_mode.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^
  src\cli_commands.cpp src\linux_daemon.cpp src\windows_service.cpp ^
  src\linux_commands.cpp src\windows_commands.cpp ^
  "%LIB%\git2.lib" advapi32.lib Ws2_32.lib Shell32.lib Ole32.lib Rpcrt4.lib Crypt32.lib winhttp.lib Psapi.lib yaml-cpp.lib /fsanitize:address ^

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -37,7 +37,7 @@ if exist "%LIBSSH2_LIB%\libssh2.a" (
     "%ROOT_DIR%\src\git_utils.cpp" "%ROOT_DIR%\src\tui.cpp" "%ROOT_DIR%\src\logger.cpp" ^
     "%ROOT_DIR%\src\resource_utils.cpp" "%ROOT_DIR%\src\system_utils.cpp" "%ROOT_DIR%\src\time_utils.cpp" ^
     "%ROOT_DIR%\src\config_utils.cpp" "%ROOT_DIR%\src\ignore_utils.cpp" "%ROOT_DIR%\src\debug_utils.cpp" "%ROOT_DIR%\src\options.cpp" ^
-    "%ROOT_DIR%\src\parse_utils.cpp" "%ROOT_DIR%\src\history_utils.cpp" "%ROOT_DIR%\src\lock_utils_windows.cpp" "%ROOT_DIR%\src\process_monitor.cpp" ^
+    "%ROOT_DIR%\src\parse_utils.cpp" "%ROOT_DIR%\src\history_utils.cpp" "%ROOT_DIR%\src\mutant_mode.cpp" "%ROOT_DIR%\src\lock_utils_windows.cpp" "%ROOT_DIR%\src\process_monitor.cpp" ^
     "%ROOT_DIR%\src\help_text.cpp" "%ROOT_DIR%\src\cli_commands.cpp" "%ROOT_DIR%\src\linux_daemon.cpp" "%ROOT_DIR%\src\windows_service.cpp" ^
     "%ROOT_DIR%\src\linux_commands.cpp" "%ROOT_DIR%\src\windows_commands.cpp" ^
     "%LIBGIT2_LIB%\libgit2.a" "%YAMLCPP_LIB%\libyaml-cpp.a" %SSH2_LIB% -lz -lws2_32 -lwinhttp ^

--- a/scripts/compile-debug.sh
+++ b/scripts/compile-debug.sh
@@ -31,6 +31,7 @@ mkdir -p "${ROOT_DIR}/dist"
     ${ROOT_DIR}/src/options.cpp \
     ${ROOT_DIR}/src/parse_utils.cpp \
     ${ROOT_DIR}/src/history_utils.cpp \
+    ${ROOT_DIR}/src/mutant_mode.cpp \
     ${ROOT_DIR}/src/lock_utils_posix.cpp \
     ${ROOT_DIR}/src/process_monitor.cpp \
     ${ROOT_DIR}/src/help_text.cpp \

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -126,6 +126,7 @@ for %%F in (
     "%ROOT_DIR%\src\options.cpp"
     "%ROOT_DIR%\src\parse_utils.cpp"
     "%ROOT_DIR%\src\history_utils.cpp"
+    "%ROOT_DIR%\src\mutant_mode.cpp"
     "%ROOT_DIR%\src\lock_utils_windows.cpp"
     "%ROOT_DIR%\src\process_monitor.cpp"
     "%ROOT_DIR%\src\help_text.cpp"

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -63,6 +63,7 @@ SRCS=(
     "${ROOT_DIR}/src/options.cpp"
     "${ROOT_DIR}/src/parse_utils.cpp"
     "${ROOT_DIR}/src/history_utils.cpp"
+    "${ROOT_DIR}/src/mutant_mode.cpp"
     "${ROOT_DIR}/src/lock_utils_posix.cpp"
     "${ROOT_DIR}/src/process_monitor.cpp"
     "${ROOT_DIR}/src/help_text.cpp"


### PR DESCRIPTION
## Summary
- add mutant_mode.cpp to manual compile scripts so mac builds link
- update Windows scripts to build mutant mode as well
- fetch yaml-cpp and nlohmann_json at configure time when not present
- link memory leak test with yaml-cpp and nlohmann_json

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f92f67e48325ba83d9e62a77b276