### PR TITLE
feat(options): add dry-run mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if(NOT Catch2_FOUND)
     FetchContent_MakeAvailable(Catch2)
 endif()
 add_executable(autogitpull_tests
-  tests/arg_parser_tests.cpp tests/utils_tests.cpp tests/options_tests.cpp tests/config_tests.cpp tests/repo_tests.cpp tests/process_tests.cpp tests/ui_output_tests.cpp tests/history_tests.cpp tests/ignore_utils_tests.cpp tests/timeout_tests.cpp tests/git_remote_tests.cpp tests/mutant_timeout_tests.cpp tests/windows_attach_tests.cpp tests/macos_daemon_tests.cpp tests/cli_commands_tests.cpp tests/resource_limit_tests.cpp src/autogitpull.cpp src/tui.cpp src/ignore_utils.cpp)
+  tests/arg_parser_tests.cpp tests/utils_tests.cpp tests/options_tests.cpp tests/config_tests.cpp tests/repo_tests.cpp tests/process_tests.cpp tests/ui_output_tests.cpp tests/history_tests.cpp tests/ignore_utils_tests.cpp tests/timeout_tests.cpp tests/git_remote_tests.cpp tests/mutant_timeout_tests.cpp tests/windows_attach_tests.cpp tests/macos_daemon_tests.cpp tests/cli_commands_tests.cpp tests/resource_limit_tests.cpp tests/dry_run_tests.cpp src/autogitpull.cpp src/tui.cpp src/ignore_utils.cpp)
 target_include_directories(autogitpull_tests PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(autogitpull_tests PRIVATE AUTOGITPULL_NO_MAIN)
 target_link_libraries(autogitpull_tests PRIVATE Catch2::Catch2WithMain autogitpull_lib)

--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -26,6 +26,7 @@ overrides. Scalar keys outside this list are rejected.
 | `--confirm-reset` | false (disabled) | Confirm --hard-reset |
 | `--discard-dirty` | false (disabled) | Alias for --force-pull; resets repo to remote state |
 | `--force-pull` | false (disabled) | Reset repos to remote state, losing uncommitted work |
+| `--dry-run` | false (disabled) | Scan without contacting remotes or performing pulls |
 | `--hard-reset` | false (disabled) | Remove logs, configs, and lock files |
 | `--list-instances` | false (disabled) | List running instance names and PIDs |
 | `--no-hash-check` | false (feature enabled) | Always pull without hash check |

--- a/include/options.hpp
+++ b/include/options.hpp
@@ -94,6 +94,7 @@ struct Options {
     bool check_only = false;
     bool hash_check = true;
     bool force_pull = false;
+    bool dry_run = false;
     LoggingOptions logging;
     std::filesystem::path ssh_public_key;
     std::filesystem::path ssh_private_key;

--- a/include/scanner.hpp
+++ b/include/scanner.hpp
@@ -27,7 +27,8 @@ void process_repo(const std::filesystem::path& p,
                   size_t down_limit, size_t up_limit, size_t disk_limit, bool silent, bool cli_mode,
                   bool force_pull, bool skip_timeout, bool skip_unavailable,
                   bool skip_accessible_errors, std::chrono::seconds updated_since,
-                  bool show_pull_author, std::chrono::seconds pull_timeout, bool mutant_mode);
+                  bool show_pull_author, std::chrono::seconds pull_timeout, bool dry_run,
+                  bool mutant_mode);
 
 void scan_repos(const std::vector<std::filesystem::path>& all_repos,
                 std::map<std::filesystem::path, RepoInfo>& repo_infos,
@@ -39,7 +40,8 @@ void scan_repos(const std::vector<std::filesystem::path>& all_repos,
                 size_t up_limit, size_t disk_limit, bool silent, bool cli_mode, bool force_pull,
                 bool skip_timeout, bool skip_unavailable, bool skip_accessible_errors,
                 std::chrono::seconds updated_since, bool show_pull_author,
-                std::chrono::seconds pull_timeout, bool retry_skipped, bool reset_skipped,
+                std::chrono::seconds pull_timeout, bool dry_run, bool retry_skipped,
+                bool reset_skipped,
                 const std::map<std::filesystem::path, RepoOptions>& repo_settings,
                 bool mutant_mode);
 

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -83,6 +83,7 @@ void print_help(const char* prog) {
         {"--censor-names", "", "", "Mask repository names", "Display"},
         {"--censor-char", "", "<ch>", "Character for name masking", "Display"},
         {"--check-only", "-x", "", "Only check for updates", "Actions"},
+        {"--dry-run", "", "", "Skip network operations and pulls", "Actions"},
         {"--no-hash-check", "-N", "", "Always pull without hash check", "Actions"},
         {"--force-pull", "-f", "", "Reset repos to remote, losing uncommitted work", "Actions"},
         {"--discard-dirty", "", "", "Alias for --force-pull; same data loss", "Actions"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -747,6 +747,7 @@ Options parse_options(int argc, char* argv[]) {
     opts.hash_check = !(parser.has_flag("--no-hash-check") || cfg_flag("--no-hash-check"));
     opts.force_pull = parser.has_flag("--force-pull") || parser.has_flag("--discard-dirty") ||
                       cfg_flag("--force-pull") || cfg_flag("--discard-dirty");
+    opts.dry_run = parser.has_flag("--dry-run") || cfg_flag("--dry-run");
     if (parser.has_flag("--verbose") || cfg_flag("--verbose"))
         opts.logging.log_level = LogLevel::DEBUG;
     if (parser.has_flag("--log-level") || cfg_opts.count("--log-level")) {

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -612,7 +612,7 @@ int run_event_loop(Options opts) {
                 opts.limits.upload_limit, opts.limits.disk_limit, opts.silent, opts.cli,
                 opts.force_pull, opts.limits.skip_timeout, opts.skip_unavailable,
                 opts.skip_accessible_errors, opts.updated_since, opts.show_pull_author,
-                opts.limits.pull_timeout, opts.retry_skipped, opts.reset_skipped,
+                opts.limits.pull_timeout, opts.dry_run, opts.retry_skipped, opts.reset_skipped,
                 opts.repo_settings, opts.mutant_mode);
             countdown_ms = std::chrono::seconds(interval);
         }

--- a/tests/dry_run_tests.cpp
+++ b/tests/dry_run_tests.cpp
@@ -1,0 +1,31 @@
+#include "test_common.hpp"
+
+TEST_CASE("dry-run skips pulls") {
+    git::GitInitGuard guard;
+    fs::path repo = fs::temp_directory_path() / "dry_run_repo";
+    fs::remove_all(repo);
+    fs::create_directory(repo);
+    REQUIRE(std::system(("git init " + repo.string() + " > /dev/null 2>&1").c_str()) == 0);
+    std::system(("git -C " + repo.string() + " config user.email you@example.com").c_str());
+    std::system(("git -C " + repo.string() + " config user.name tester").c_str());
+    std::ofstream(repo / "file.txt") << "hello";
+    std::system(("git -C " + repo.string() + " add file.txt").c_str());
+    std::system(("git -C " + repo.string() + " commit -m init > /dev/null 2>&1").c_str());
+    std::system(("git -C " + repo.string() + " remote add origin https://github.com/octocat/Hello-World.git").c_str());
+
+    std::vector<fs::path> repos{repo};
+    std::map<fs::path, RepoInfo> infos;
+    std::set<fs::path> skip;
+    std::mutex mtx;
+    std::atomic<bool> scanning(false);
+    std::atomic<bool> running(true);
+    std::string action;
+    std::mutex action_mtx;
+    scan_repos(repos, infos, skip, mtx, scanning, running, action, action_mtx, false,
+               "origin", fs::path(), false, false, 1, 0, 0, 0, 0, 0, false, false, false,
+               std::chrono::seconds(0), false, std::chrono::seconds(0), true, false, false,
+               {}, false);
+    REQUIRE(infos[repo].status == RS_SKIPPED);
+    REQUIRE(infos[repo].message == "Dry run");
+    fs::remove_all(repo);
+}

--- a/tests/memory_leak.cpp
+++ b/tests/memory_leak.cpp
@@ -42,7 +42,7 @@ TEST_CASE("scan_repos memory stability") {
         scan_repos(repos, infos, skip, mtx, scanning, running, action, action_mtx, false,
                    "origin", fs::path(), true, true, 1, 0, 0, 0, 0, 0, false, false, false,
                    true, true, false, std::chrono::seconds(0), false,
-                   std::chrono::seconds(0), false, false, {}, false);
+                   std::chrono::seconds(0), false, false, false, {}, false);
         size_t mem = procutil::get_memory_usage_mb();
         if (i == 0)
             baseline = mem;

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -237,6 +237,12 @@ TEST_CASE("parse_options kill-on-sleep option") {
     REQUIRE(opts.service.kill_on_sleep);
 }
 
+TEST_CASE("parse_options dry-run option") {
+    const char* argv[] = {"prog", "path", "--dry-run"};
+    Options opts = parse_options(3, const_cast<char**>(argv));
+    REQUIRE(opts.dry_run);
+}
+
 TEST_CASE("parse_options rescan-new option default") {
     const char* argv[] = {"prog", "path", "--rescan-new"};
     Options opts = parse_options(3, const_cast<char**>(argv));

--- a/tests/repo_tests.cpp
+++ b/tests/repo_tests.cpp
@@ -272,7 +272,7 @@ TEST_CASE("scan_repos respects concurrency limit") {
         scan_repos(repos, infos, skip, mtx, scanning, running, act, act_mtx, false,
                    "origin", fs::path(), true, true, concurrency, 0, 0, 0, 0, 0, true,
                    false, false, true, true, false, std::chrono::seconds(0), false,
-                   std::chrono::seconds(0), false, false, {}, false);
+                   std::chrono::seconds(0), false, false, false, {}, false);
     });
     while (scanning) {
         max_seen = std::max(max_seen, read_thread_count());
@@ -354,7 +354,8 @@ TEST_CASE("scan_repos resets statuses to pending") {
 
     scan_repos({}, infos, skip, mtx, scanning, running, act, act_mtx, false, "origin",
                fs::path(), true, true, 1, 0, 0, 0, 0, 0, true, false, false, true, true, false,
-               std::chrono::seconds(0), false, std::chrono::seconds(0), false, false, {}, false);
+               std::chrono::seconds(0), false, std::chrono::seconds(0), false, false, false,
+               {}, false);
 
     REQUIRE(infos[p].status == RS_PENDING);
     REQUIRE(infos[p].progress == 0);


### PR DESCRIPTION
## Summary
- add `--dry-run` flag to skip network operations
- update scanner to bypass pulls and mark repos as dry-run
- document flag and cover with tests

## Testing
- `make format`
- `make lint`
- `make test` *(fails: libgit2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74f012b508325bf3abf373cb35d99