### PR TITLE
fix: handle ignore file whitespace and comments

### DIFF
--- a/include/ignore_utils.hpp
+++ b/include/ignore_utils.hpp
@@ -8,10 +8,11 @@ namespace ignore {
 /**
  * Read a list of ignore entries from a file.
  *
- * Each non-empty line in the file is treated as a distinct path entry. If a
- * line ends with a carriage return (`\r`), it is stripped before storing the
- * path. Paths are not normalised, so they may be relative or absolute and are
- * stored exactly as provided.
+ * Each non-empty, non-comment line in the file is trimmed of leading and
+ * trailing whitespace and treated as a distinct path entry. Lines beginning
+ * with '#' are considered comments and skipped. If a line ends with a carriage
+ * return (`\r`), it is stripped before processing. Paths are not normalised, so
+ * they may be relative or absolute and are stored exactly as provided.
  *
  * Missing or unreadable files result in an empty list of entries.
  */
@@ -20,8 +21,10 @@ std::vector<std::filesystem::path> read_ignore_file(const std::filesystem::path&
 /**
  * Write ignore entries to a file.
  *
- * Each path is written on its own line using its string representation. The
- * target file is truncated if it exists or created if missing.
+ * Blank or whitespace-only entries are skipped. Each path is written on its
+ * own line using its string representation and the file is always terminated
+ * with a trailing newline. The target file is truncated if it exists or
+ * created if missing.
  */
 void write_ignore_file(const std::filesystem::path& file,
                        const std::vector<std::filesystem::path>& entries);

--- a/src/ignore_utils.cpp
+++ b/src/ignore_utils.cpp
@@ -1,6 +1,19 @@
 #include "ignore_utils.hpp"
 #include <fstream>
 #include <algorithm>
+#include <cctype>
+
+namespace {
+
+void trim(std::string& s) {
+    s.erase(s.begin(),
+            std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); })
+                .base(),
+            s.end());
+}
+
+} // namespace
 
 namespace ignore {
 
@@ -13,8 +26,10 @@ std::vector<std::filesystem::path> read_ignore_file(const std::filesystem::path&
     while (std::getline(ifs, line)) {
         if (!line.empty() && line.back() == '\r')
             line.pop_back();
-        if (!line.empty())
-            entries.push_back(line);
+        trim(line);
+        if (line.empty() || line[0] == '#')
+            continue;
+        entries.emplace_back(line);
     }
     return entries;
 }
@@ -22,8 +37,13 @@ std::vector<std::filesystem::path> read_ignore_file(const std::filesystem::path&
 void write_ignore_file(const std::filesystem::path& file,
                        const std::vector<std::filesystem::path>& entries) {
     std::ofstream ofs(file, std::ios::trunc);
-    for (const auto& e : entries)
-        ofs << e.string() << '\n';
+    for (auto e : entries) {
+        std::string s = e.string();
+        trim(s);
+        if (s.empty())
+            continue;
+        ofs << s << '\n';
+    }
 }
 
 } // namespace ignore

--- a/tests/ignore_utils_tests.cpp
+++ b/tests/ignore_utils_tests.cpp
@@ -1,13 +1,30 @@
 #include "test_common.hpp"
 #include "ignore_utils.hpp"
 
-TEST_CASE("ignore file read write") {
-    fs::path dir = fs::temp_directory_path() / "ign_test";
+TEST_CASE("read_ignore_file trims whitespace and skips comments") {
+    fs::path dir = fs::temp_directory_path() / "ign_test_parse";
     fs::create_directories(dir);
     fs::path file = dir / ".autogitpull.ignore";
-    std::vector<fs::path> entries{dir / "a", dir / "b"};
+    std::ofstream ofs(file);
+    ofs << "  foo  \n#comment\nbar\n   \n\t#another\n\tbaz  \n";
+    ofs.close();
+    auto entries = ignore::read_ignore_file(file);
+    std::vector<fs::path> expected{"foo", "bar", "baz"};
+    REQUIRE(entries == expected);
+    fs::remove_all(dir);
+}
+
+TEST_CASE("write_ignore_file skips blanks and preserves newline") {
+    fs::path dir = fs::temp_directory_path() / "ign_test_write";
+    fs::create_directories(dir);
+    fs::path file = dir / ".autogitpull.ignore";
+    std::vector<fs::path> entries{"foo", "", "bar", "  ", "baz"};
     ignore::write_ignore_file(file, entries);
+    std::ifstream ifs(file, std::ios::binary);
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    REQUIRE(content == "foo\nbar\nbaz\n");
     auto read = ignore::read_ignore_file(file);
-    REQUIRE(read == entries);
+    std::vector<fs::path> expected{"foo", "bar", "baz"};
+    REQUIRE(read == expected);
     fs::remove_all(dir);
 }


### PR DESCRIPTION
## Summary
- trim whitespace and skip comment lines when reading ignore files
- omit blank entries and keep trailing newline when writing ignore files
- test comment parsing, whitespace handling, and round-trip writing

## Testing
- `make format`
- `make lint`
- `make test` *(fails: libgit2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7569c32a083259f42479b69de45c1