### PR TITLE
fix(build): include FileWatcher source in manual builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SRC = \
     src/debug_utils.cpp \
     src/scanner.cpp \
     src/ui_loop.cpp \
+    src/file_watch.cpp \
     src/options.cpp \
     src/parse_utils.cpp \
     src/history_utils.cpp \

--- a/scripts/compile-cl.bat
+++ b/scripts/compile-cl.bat
@@ -18,7 +18,7 @@ if not exist dist mkdir dist
 
 cl /nologo /std:c++20 /EHsc /O2 /DNDEBUG /D YAML_CPP_STATIC_DEFINE ^
  /I "%INC%" /I include ^
- src\autogitpull.cpp src\scanner.cpp src\ui_loop.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp ^
+ src\autogitpull.cpp src\scanner.cpp src\ui_loop.cpp src\file_watch.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp ^
 src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\ignore_utils.cpp src\debug_utils.cpp ^
 src\options.cpp src\parse_utils.cpp src\history_utils.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^
 src\cli_commands.cpp src\mutant_mode.cpp src\linux_daemon.cpp src\windows_service.cpp ^

--- a/scripts/compile-debug-cl.bat
+++ b/scripts/compile-debug-cl.bat
@@ -19,7 +19,7 @@ if not exist dist mkdir dist
 
 cl /nologo /std:c++20 /EHsc /Zi /D YAML_CPP_STATIC_DEFINE ^
  /I "%INC%" /I include ^
- src\autogitpull.cpp src\scanner.cpp src\ui_loop.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp ^
+ src\autogitpull.cpp src\scanner.cpp src\ui_loop.cpp src\file_watch.cpp src\git_utils.cpp src\tui.cpp src\logger.cpp ^
  src\resource_utils.cpp src\system_utils.cpp src\time_utils.cpp src\config_utils.cpp src\debug_utils.cpp ^
  src\ignore_utils.cpp ^
  src\options.cpp src\parse_utils.cpp src\mutant_mode.cpp src\lock_utils_windows.cpp src\process_monitor.cpp src\help_text.cpp ^

--- a/scripts/compile-debug.bat
+++ b/scripts/compile-debug.bat
@@ -34,6 +34,7 @@ if exist "%LIBSSH2_LIB%\libssh2.a" (
 
 %CXX% %CXXFLAGS% -I"%INC%" -I"%LIBGIT2_INC%" -I"%YAMLCPP_INC%" -I"%JSON_INC%" ^
     "%ROOT_DIR%\src\autogitpull.cpp" "%ROOT_DIR%\src\scanner.cpp" "%ROOT_DIR%\src\ui_loop.cpp" ^
+    "%ROOT_DIR%\src\file_watch.cpp" ^
     "%ROOT_DIR%\src\git_utils.cpp" "%ROOT_DIR%\src\tui.cpp" "%ROOT_DIR%\src\logger.cpp" ^
     "%ROOT_DIR%\src\resource_utils.cpp" "%ROOT_DIR%\src\system_utils.cpp" "%ROOT_DIR%\src\time_utils.cpp" ^
     "%ROOT_DIR%\src\config_utils.cpp" "%ROOT_DIR%\src\ignore_utils.cpp" "%ROOT_DIR%\src\debug_utils.cpp" "%ROOT_DIR%\src\options.cpp" ^

--- a/scripts/compile-debug.sh
+++ b/scripts/compile-debug.sh
@@ -19,6 +19,7 @@ mkdir -p "${ROOT_DIR}/dist"
     ${ROOT_DIR}/src/autogitpull.cpp \
     ${ROOT_DIR}/src/scanner.cpp \
     ${ROOT_DIR}/src/ui_loop.cpp \
+    ${ROOT_DIR}/src/file_watch.cpp \
     ${ROOT_DIR}/src/git_utils.cpp \
     ${ROOT_DIR}/src/tui.cpp \
     ${ROOT_DIR}/src/logger.cpp \

--- a/scripts/compile.bat
+++ b/scripts/compile.bat
@@ -114,6 +114,7 @@ for %%F in (
     "%ROOT_DIR%\src\autogitpull.cpp"
     "%ROOT_DIR%\src\scanner.cpp"
     "%ROOT_DIR%\src\ui_loop.cpp"
+    "%ROOT_DIR%\src\file_watch.cpp"
     "%ROOT_DIR%\src\git_utils.cpp"
     "%ROOT_DIR%\src\tui.cpp" 
     "%ROOT_DIR%\src\logger.cpp" 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -51,6 +51,7 @@ SRCS=(
     "${ROOT_DIR}/src/autogitpull.cpp"
     "${ROOT_DIR}/src/scanner.cpp"
     "${ROOT_DIR}/src/ui_loop.cpp"
+    "${ROOT_DIR}/src/file_watch.cpp"
     "${ROOT_DIR}/src/git_utils.cpp"
     "${ROOT_DIR}/src/tui.cpp"
     "${ROOT_DIR}/src/logger.cpp"


### PR DESCRIPTION
## Summary
- add `src/file_watch.cpp` to Makefile and build scripts so FileWatcher links on macOS

## Testing
- `make format`
- `make lint`
- `make test` *(fails: resource_limit_tests.cpp:76 REQUIRE( limited_ms - base_ms >= 5 ))*

------
https://chatgpt.com/codex/tasks/task_e_68a7627506088325b07cf2a6e3525ced