### PR TITLE
feat: add post-pull hook support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ if(NOT Catch2_FOUND)
 endif()
 add_executable(autogitpull_tests
   tests/arg_parser_tests.cpp tests/utils_tests.cpp tests/options_tests.cpp tests/config_tests.cpp tests/repo_tests.cpp tests/process_tests.cpp tests/ui_output_tests.cpp tests/history_tests.cpp tests/ignore_utils_tests.cpp tests/timeout_tests.cpp tests/git_remote_tests.cpp tests/mutant_timeout_tests.cpp tests/windows_attach_tests.cpp tests/macos_daemon_tests.cpp tests/cli_commands_tests.cpp tests/resource_limit_tests.cpp tests/logger_tests.cpp tests/dry_run_tests.cpp src/autogitpull.cpp src/tui.cpp src/ignore_utils.cpp)
+target_sources(autogitpull_tests PRIVATE tests/post_pull_hook_tests.cpp)
 target_sources(autogitpull_tests PRIVATE tests/file_watch_tests.cpp)
 target_include_directories(autogitpull_tests PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(autogitpull_tests PRIVATE AUTOGITPULL_NO_MAIN)

--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -32,6 +32,7 @@ overrides. Scalar keys outside this list are rejected.
 | `--list-instances` | false (disabled) | List running instance names and PIDs |
 | `--no-hash-check` | false (feature enabled) | Always pull without hash check |
 | `--sudo-su` | false (disabled) | Suppress confirmation alerts |
+| `--post-pull-hook` |  | Command to execute after successful pull |
 | `--confirm-mutant` | false (disabled) | Confirm enabling mutant mode |
 
 ### Destructive Actions

--- a/examples/example-config.json
+++ b/examples/example-config.json
@@ -77,7 +77,8 @@
         "hard-reset": false,
         "confirm-reset": false,
         "confirm-alert": false,
-        "sudo-su": false
+        "sudo-su": false,
+        "post-pull-hook": ""
     },
     "Daemon": {
         "install-daemon": false,

--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -72,6 +72,7 @@ Actions:
   confirm-reset: False
   confirm-alert: False
   sudo-su: False
+  post-pull-hook:
 Daemon:
   install-daemon: False
   uninstall-daemon: False

--- a/include/options.hpp
+++ b/include/options.hpp
@@ -153,6 +153,7 @@ struct Options {
     bool retry_skipped = false;
     bool reset_skipped = false;
     bool cli_print_skipped = false;
+    std::filesystem::path post_pull_hook;
     bool show_help = false;
     bool print_version = false;
     bool hard_reset = false;

--- a/include/repo_options.hpp
+++ b/include/repo_options.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <chrono>
 #include <cstddef>
+#include <filesystem>
 
 struct RepoOptions {
     std::optional<bool> force_pull;
@@ -15,6 +16,7 @@ struct RepoOptions {
     std::optional<size_t> disk_limit;
     std::optional<std::chrono::seconds> max_runtime;
     std::optional<std::chrono::seconds> pull_timeout;
+    std::optional<std::filesystem::path> post_pull_hook;
 };
 
 #endif // REPO_OPTIONS_HPP

--- a/include/scanner.hpp
+++ b/include/scanner.hpp
@@ -26,8 +26,9 @@ void process_repo(const std::filesystem::path& p,
                   const std::filesystem::path& log_dir, bool check_only, bool hash_check,
                   size_t down_limit, size_t up_limit, size_t disk_limit, bool silent, bool cli_mode,
                   bool dry_run, bool force_pull, bool skip_timeout, bool skip_unavailable,
-                  bool skip_accessible_errors, std::chrono::seconds updated_since,
-                  bool show_pull_author, std::chrono::seconds pull_timeout, bool mutant_mode);
+                  bool skip_accessible_errors, const std::filesystem::path& post_pull_hook,
+                  std::chrono::seconds updated_since, bool show_pull_author,
+                  std::chrono::seconds pull_timeout, bool mutant_mode);
 
 void scan_repos(const std::vector<std::filesystem::path>& all_repos,
                 std::map<std::filesystem::path, RepoInfo>& repo_infos,
@@ -38,10 +39,12 @@ void scan_repos(const std::vector<std::filesystem::path>& all_repos,
                 size_t concurrency, double cpu_percent_limit, size_t mem_limit, size_t down_limit,
                 size_t up_limit, size_t disk_limit, bool silent, bool cli_mode, bool dry_run,
                 bool force_pull, bool skip_timeout, bool skip_unavailable,
-                bool skip_accessible_errors, std::chrono::seconds updated_since,
-                bool show_pull_author, std::chrono::seconds pull_timeout, bool retry_skipped,
-                bool reset_skipped,
+                bool skip_accessible_errors, const std::filesystem::path& post_pull_hook,
+                std::chrono::seconds updated_since, bool show_pull_author,
+                std::chrono::seconds pull_timeout, bool retry_skipped, bool reset_skipped,
                 const std::map<std::filesystem::path, RepoOptions>& repo_settings,
                 bool mutant_mode);
+
+void run_post_pull_hook(const std::filesystem::path& hook);
 
 #endif // SCANNER_HPP

--- a/src/help_text.cpp
+++ b/src/help_text.cpp
@@ -120,6 +120,7 @@ void print_help(const char* prog) {
         {"--confirm-alert", "", "", "Confirm unsafe options", "Actions"},
         {"--confirm-mutant", "", "", "Confirm enabling mutant mode", "Actions"},
         {"--sudo-su", "", "", "Suppress confirmation alerts", "Actions"},
+        {"--post-pull-hook", "", "<file>", "Run command after successful pull", "Actions"},
         {"--add-ignore", "", "<repo>", "Add path to .autogitpull.ignore", "Ignores"},
         {"--remove-ignore", "", "<repo>", "Remove path from ignore file", "Ignores"},
         {"--clear-ignores", "", "", "Delete all ignore entries", "Ignores"},

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -405,6 +405,7 @@ Options parse_options(int argc, char* argv[]) {
                                       "--force-pull",
                                       "--exclude",
                                       "--discard-dirty",
+                                      "--post-pull-hook",
                                       "--debug-memory",
                                       "--dump-state",
                                       "--dump-large",
@@ -928,6 +929,14 @@ Options parse_options(int argc, char* argv[]) {
             throw std::runtime_error("--proxy requires a URL");
         opts.proxy_url = val;
     }
+    if (parser.has_flag("--post-pull-hook") || cfg_opts.count("--post-pull-hook")) {
+        std::string val = parser.get_option("--post-pull-hook");
+        if (val.empty())
+            val = cfg_opt("--post-pull-hook");
+        if (val.empty())
+            throw std::runtime_error("--post-pull-hook requires a path");
+        opts.post_pull_hook = val;
+    }
     if (parser.has_flag("--max-log-size") || cfg_opts.count("--max-log-size")) {
         std::string val = parser.get_option("--max-log-size");
         if (val.empty())
@@ -1103,6 +1112,9 @@ Options parse_options(int argc, char* argv[]) {
             if (!ok || dur.count() < 1 || dur.count() > INT_MAX)
                 throw std::runtime_error("Invalid per-repo pull-timeout");
             ro.pull_timeout = dur;
+        }
+        if (values.count("--post-pull-hook")) {
+            ro.post_pull_hook = fs::path(ropt("--post-pull-hook"));
         }
         opts.repo_settings[fs::path(repo)] = ro;
     }

--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -608,9 +608,9 @@ int run_event_loop(Options opts) {
                 opts.limits.cpu_percent_limit, opts.limits.mem_limit, opts.limits.download_limit,
                 opts.limits.upload_limit, opts.limits.disk_limit, opts.silent, opts.cli,
                 opts.dry_run, opts.force_pull, opts.limits.skip_timeout, opts.skip_unavailable,
-                opts.skip_accessible_errors, opts.updated_since, opts.show_pull_author,
-                opts.limits.pull_timeout, opts.retry_skipped, opts.reset_skipped,
-                opts.repo_settings, opts.mutant_mode);
+                opts.skip_accessible_errors, opts.post_pull_hook, opts.updated_since,
+                opts.show_pull_author, opts.limits.pull_timeout, opts.retry_skipped,
+                opts.reset_skipped, opts.repo_settings, opts.mutant_mode);
             countdown_ms = std::chrono::seconds(interval);
         }
 #ifndef _WIN32

--- a/tests/dry_run_tests.cpp
+++ b/tests/dry_run_tests.cpp
@@ -39,7 +39,7 @@ TEST_CASE("scan_repos honors dry run") {
 
     scan_repos(repos, infos, skip, mtx, scanning, running, action, action_mtx, false,
                "origin", fs::path(), false, true, 1, 0, 0, 0, 0, 0, false, false, true,
-               false, false, false, false, std::chrono::seconds(0), false,
+               false, false, false, false, fs::path(), std::chrono::seconds(0), false,
                std::chrono::seconds(0), false, false, {}, false);
 
     REQUIRE(infos[repo].status != RS_PULL_OK);

--- a/tests/memory_leak.cpp
+++ b/tests/memory_leak.cpp
@@ -41,7 +41,7 @@ TEST_CASE("scan_repos memory stability") {
         running = true;
         scan_repos(repos, infos, skip, mtx, scanning, running, action, action_mtx, false,
                    "origin", fs::path(), true, true, 1, 0, 0, 0, 0, 0, false, false, false,
-                   false, true, true, false, std::chrono::seconds(0), false,
+                   false, false, false, true, fs::path(), std::chrono::seconds(0), false,
                    std::chrono::seconds(0), false, false, {}, false);
         size_t mem = procutil::get_memory_usage_mb();
         if (i == 0)

--- a/tests/options_tests.cpp
+++ b/tests/options_tests.cpp
@@ -401,7 +401,7 @@ TEST_CASE("parse_options repo overrides") {
         std::ofstream ofs(cfg);
         ofs << "{\n  \"root\": \"/tmp\",\n  \"repositories\": {\n    \"/tmp/repo\": {\n      "
                "\"force-pull\": true,\n      \"exclude\": true,\n      \"check-only\": true,\n     "
-               " \"cpu-limit\": 25.5\n    }\n  }\n}";
+               " \"cpu-limit\": 25.5,\n      \"post-pull-hook\": \"/tmp/hook\"\n    }\n  }\n}";
     }
     std::string p = cfg.string();
     char* path_c = strdup(p.c_str());
@@ -415,7 +415,14 @@ TEST_CASE("parse_options repo overrides") {
     REQUIRE(ro.exclude.value_or(false));
     REQUIRE(ro.check_only.value_or(false));
     REQUIRE(ro.cpu_limit.value_or(0.0) == 25.5);
+    REQUIRE(ro.post_pull_hook.value() == fs::path("/tmp/hook"));
     fs::remove(cfg);
+}
+
+TEST_CASE("parse_options post pull hook flag") {
+    const char* argv[] = {"prog", "path", "--post-pull-hook", "/tmp/hook"};
+    Options opts = parse_options(4, const_cast<char**>(argv));
+    REQUIRE(opts.post_pull_hook == fs::path("/tmp/hook"));
 }
 
 struct DirGuard {

--- a/tests/post_pull_hook_tests.cpp
+++ b/tests/post_pull_hook_tests.cpp
@@ -1,0 +1,21 @@
+#include "test_common.hpp"
+#include "scanner.hpp"
+
+namespace fs = std::filesystem;
+
+TEST_CASE("run_post_pull_hook executes script") {
+    fs::path hook = fs::temp_directory_path() / "post_hook.sh";
+    fs::path marker = fs::temp_directory_path() / "hook_marker";
+    {
+        std::ofstream ofs(hook);
+        ofs << "#!/bin/sh\n";
+        ofs << "echo ran > \"" << marker.string() << "\"\n";
+    }
+    fs::permissions(hook, fs::perms::owner_exec | fs::perms::owner_write |
+                               fs::perms::owner_read);
+    run_post_pull_hook(hook);
+    REQUIRE(fs::exists(marker));
+    fs::remove(hook);
+    fs::remove(marker);
+}
+

--- a/tests/repo_tests.cpp
+++ b/tests/repo_tests.cpp
@@ -270,8 +270,9 @@ TEST_CASE("scan_repos respects concurrency limit") {
     std::thread t([&]() {
         scan_repos(repos, infos, skip, mtx, scanning, running, act, act_mtx, false,
                    "origin", fs::path(), true, true, concurrency, 0, 0, 0, 0, 0, true,
-                   false, false, false, true, true, false, std::chrono::seconds(0),
-                   false, std::chrono::seconds(0), false, false, {}, false);
+                   false, false, false, true, true, false, fs::path(),
+                   std::chrono::seconds(0), false, std::chrono::seconds(0), false, false, {},
+                   false);
     });
     while (scanning) {
         max_seen = std::max(max_seen, read_thread_count());
@@ -353,8 +354,8 @@ TEST_CASE("scan_repos resets statuses to pending") {
 
     scan_repos({}, infos, skip, mtx, scanning, running, act, act_mtx, false, "origin",
                fs::path(), true, true, 1, 0, 0, 0, 0, 0, true, false, false, false, true,
-               true, false, std::chrono::seconds(0), false, std::chrono::seconds(0), false,
-               false, {}, false);
+               true, false, fs::path(), std::chrono::seconds(0), false, std::chrono::seconds(0),
+               false, false, {}, false);
 
     REQUIRE(infos[p].status == RS_PENDING);
     REQUIRE(infos[p].progress == 0);


### PR DESCRIPTION
## Summary
- support `post_pull_hook` option with per-repo overrides
- execute configured hook after successful pull without shell interpolation
- document hook option and cover execution with integration test

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ace32b2754832582561b349742b30f