### PR TITLE
Handle inotify failures gracefully in FileWatcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,9 @@ target_sources(autogitpull_tests PRIVATE tests/file_watch_tests.cpp)
 target_include_directories(autogitpull_tests PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(autogitpull_tests PRIVATE AUTOGITPULL_NO_MAIN)
 target_link_libraries(autogitpull_tests PRIVATE Catch2::Catch2WithMain autogitpull_lib ZLIB::ZLIB)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(autogitpull_tests PRIVATE dl)
+endif()
 add_test(NAME autogitpull_tests COMMAND autogitpull_tests)
 
 # Address sanitizer memory leak test

--- a/include/file_watch.hpp
+++ b/include/file_watch.hpp
@@ -35,6 +35,11 @@ class FileWatcher {
      */
     void notify_change();
 
+    /**
+     * @brief Check if the watcher thread is active.
+     */
+    bool active() const;
+
     FileWatcher(const FileWatcher&) = delete;
     FileWatcher& operator=(const FileWatcher&) = delete;
 


### PR DESCRIPTION
## Summary
- log and skip watcher thread when `inotify_init1` or `inotify_add_watch` fails
- expose `FileWatcher::active()` for monitoring status
- test inotify failure path to ensure no thread is spawned

## Testing
- `./autogitpull_tests "FileWatcher does not spawn thread on inotify failure"`

------
https://chatgpt.com/codex/tasks/task_e_68b0d6ffcf3c8325afd34cb96d8e2c83