### PR TITLE
fix: link FSEvents framework on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(ZLIB REQUIRED)
 if(APPLE)
     find_library(COREFOUNDATION_FRAMEWORK CoreFoundation REQUIRED)
     find_library(CORESERVICES_FRAMEWORK CoreServices REQUIRED)
+    find_library(FSEVENTS_FRAMEWORK FSEvents REQUIRED)
 endif()
 
 add_library(autogitpull_lib STATIC
@@ -75,7 +76,8 @@ target_link_libraries(autogitpull_lib
 if(APPLE)
     target_link_libraries(autogitpull_lib PUBLIC
         ${COREFOUNDATION_FRAMEWORK}
-        ${CORESERVICES_FRAMEWORK})
+        ${CORESERVICES_FRAMEWORK}
+        ${FSEVENTS_FRAMEWORK})
 endif()
 
 add_executable(autogitpull
@@ -87,7 +89,8 @@ if(MSVC)
 elseif(APPLE)
     target_link_libraries(autogitpull PRIVATE
         ${COREFOUNDATION_FRAMEWORK}
-        ${CORESERVICES_FRAMEWORK})
+        ${CORESERVICES_FRAMEWORK}
+        ${FSEVENTS_FRAMEWORK})
     # macOS does not support fully static binaries
 else()
     # Link dynamically on platforms where static libgit2 is unavailable
@@ -120,7 +123,8 @@ endif()
 if(APPLE)
     target_link_libraries(autogitpull_tests PRIVATE
         ${COREFOUNDATION_FRAMEWORK}
-        ${CORESERVICES_FRAMEWORK})
+        ${CORESERVICES_FRAMEWORK}
+        ${FSEVENTS_FRAMEWORK})
 endif()
 add_test(NAME autogitpull_tests COMMAND autogitpull_tests)
 
@@ -159,5 +163,6 @@ add_test(NAME memory_leak_test COMMAND memory_leak_test)
 if(APPLE)
     target_link_libraries(memory_leak_test PRIVATE
         ${COREFOUNDATION_FRAMEWORK}
-        ${CORESERVICES_FRAMEWORK})
+        ${CORESERVICES_FRAMEWORK}
+        ${FSEVENTS_FRAMEWORK})
 endif()

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifeq ($(UNAME_S),Darwin)
     LDFLAGS = $(shell pkg-config --libs libgit2 2>/dev/null || echo -lgit2) \
               $(shell pkg-config --libs yaml-cpp 2>/dev/null || echo -lyaml-cpp) \
               $(shell pkg-config --libs zlib 2>/dev/null || echo -lz) \
-               -framework CoreFoundation -framework CoreServices
+               -framework CoreFoundation -framework CoreServices -framework FSEvents
 else
 ifeq ($(LIBGIT2_STATIC_AVAILABLE),yes)
     LDFLAGS = $(shell pkg-config --static --libs libgit2) $(shell pkg-config --libs yaml-cpp 2>/dev/null || echo -lyaml-cpp) $(shell pkg-config --libs zlib 2>/dev/null || echo -lz) -static


### PR DESCRIPTION
## Summary
- link CoreFoundation, CoreServices, and FSEvents frameworks in CMake
- ensure Makefile also links FSEvents for macOS builds

## Testing
- `make format`
- `make lint`
- `make test` *(fails: libgit2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b56dddf9508325abc8b8fbcdde7825