### PR TITLE
fix(logger): drop entries when sink unavailable

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -310,6 +310,10 @@ static void write_log_entry(LogLevel level, const std::string& label, const std:
 
 static void enqueue_message(LogLevel level, const std::string& label, const std::string& msg,
                             const std::map<std::string, std::string>& fields) {
+    // Drop messages if the worker thread isn't running to avoid unbounded queue growth
+    if (!g_running.load())
+        return;
+
     auto* entry = new LogMessage{level, label, msg, fields};
     {
         std::lock_guard<std::mutex> lk(g_queue_mtx);


### PR DESCRIPTION
## Summary
- discard log messages when logger worker is inactive to avoid queue growth

## Testing
- `make format`
- `make lint`
- `make test` *(fails: libgit2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b61d8a4f28832582f7c9a66a4f2f1d