### PR TITLE
fix(logger): synchronize sink check to avoid data race

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -317,8 +317,11 @@ static void write_log_entry(LogLevel level, const std::string& label, const std:
 static void enqueue_message(LogLevel level, const std::string& label, const std::string& msg,
                             const std::map<std::string, std::string>& fields) {
     // If no file sink is configured, drop messages immediately to avoid queue buildup.
-    if (g_log_path.empty())
-        return;
+    {
+        std::lock_guard<std::mutex> lk(g_init_mtx);
+        if (g_log_path.empty())
+            return;
+    }
 
     auto* entry = new LogMessage{level, label, msg, fields};
     {


### PR DESCRIPTION
## Summary
- guard sink availability check with `g_init_mtx`

## Testing
- `make format`
- `make lint`
- `make test` *(fails: libgit2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6284e0e2c83259206cd089033fb52