### PR TITLE
fix(file_watch): guard thread creation on inotify

### DIFF
--- a/src/file_watch.cpp
+++ b/src/file_watch.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <system_error>
 #include <array>
+#include <cerrno>
 
 #include "logger.hpp"
 
@@ -54,10 +55,14 @@ FileWatcher::FileWatcher(const std::filesystem::path& path, std::function<void()
                 }
             });
         } else {
-            log_warning("inotify_add_watch failed; monitoring disabled");
+            std::error_code ec(errno, std::system_category());
+            log_warning("inotify_add_watch failed; monitoring disabled: " + ec.message());
+            close(inotify_fd_);
+            inotify_fd_ = -1;
         }
     } else {
-        log_warning("inotify_init1 failed; monitoring disabled");
+        std::error_code ec(errno, std::system_category());
+        log_warning("inotify_init1 failed; monitoring disabled: " + ec.message());
     }
 #elif defined(__APPLE__)
     running_.store(true);

--- a/tests/file_watch_tests.cpp
+++ b/tests/file_watch_tests.cpp
@@ -54,7 +54,9 @@ TEST_CASE("FileWatcher detects file modifications using " WATCH_BACKEND) {
 }
 
 #if defined(__linux__)
-TEST_CASE("FileWatcher does not spawn thread on inotify failure") {
+// When inotify_init1 fails the watcher should not start its background thread
+// and the callback must never be invoked.
+TEST_CASE("FileWatcher remains inactive when inotify_init1 fails") {
     auto tmp = fs::temp_directory_path() / "watch_fail.txt";
     {
         std::ofstream os(tmp);


### PR DESCRIPTION
## Summary
- avoid starting Linux watcher thread unless inotify setup succeeds
- log the inotify failure reason for easier debugging
- test that watcher stays inactive when inotify_init1 fails

## Testing
- `make format`
- `make lint`
- `make test` *(fails: libgit2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76b2633d88325bce77f1ad8bedace