### PR TITLE
chore(ui): reflow interval output

### DIFF
--- a/src/ui_loop.cpp
+++ b/src/ui_loop.cpp
@@ -365,8 +365,8 @@ int run_event_loop(Options opts) {
         return 0;
     }
     if (opts.cli && !opts.silent) {
-        std::cout << "Interval: " << interval << "s"
-                  << " Refresh: " << opts.refresh_ms.count() << "ms";
+        std::cout << "Interval: " << interval << "s" << " Refresh: " << opts.refresh_ms.count()
+                  << "ms";
         if (opts.limits.pull_timeout.count() > 0)
             std::cout << " Timeout: " << opts.limits.pull_timeout.count() << "s";
         std::cout << " SkipTimeouts: " << (opts.limits.skip_timeout ? "yes" : "no");


### PR DESCRIPTION
## Summary
- reflow interval and refresh logging onto a single formatted line

## Testing
- `make format`
- `make lint`
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c49b2aace8832595b21017d499d605