### PR TITLE
chore: format source files

### DIFF
--- a/src/cli_commands.cpp
+++ b/src/cli_commands.cpp
@@ -65,10 +65,12 @@ std::optional<int> handle_service_control(const Options& opts, const std::string
     if (opts.service.install_service) {
         std::string exec = fs::absolute(exec_path).string();
 #ifdef _WIN32
-        char* user_dup = nullptr; size_t user_len = 0;
+        char* user_dup = nullptr;
+        size_t user_len = 0;
         (void)_dupenv_s(&user_dup, &user_len, "USER");
         std::string usr = user_dup ? user_dup : "root";
-        if (user_dup) free(user_dup);
+        if (user_dup)
+            free(user_dup);
 #else
         const char* user_env = std::getenv("USER");
         std::string usr = user_env ? user_env : "root";
@@ -103,10 +105,12 @@ std::optional<int> handle_daemon_control(const Options& opts, const std::string&
     if (opts.service.install_daemon) {
         std::string exec = fs::absolute(exec_path).string();
 #ifdef _WIN32
-        char* user_dup = nullptr; size_t user_len = 0;
+        char* user_dup = nullptr;
+        size_t user_len = 0;
         (void)_dupenv_s(&user_dup, &user_len, "USER");
         std::string usr = user_dup ? user_dup : "root";
-        if (user_dup) free(user_dup);
+        if (user_dup)
+            free(user_dup);
 #else
         const char* user_env = std::getenv("USER");
         std::string usr = user_env ? user_env : "root";

--- a/src/git_utils.cpp
+++ b/src/git_utils.cpp
@@ -176,10 +176,10 @@ int credential_cb(git_credential** out, const char* url, const char* username_fr
     if (opts && !opts->credential_file.empty())
         read_credential_file(opts->credential_file, file_user,
                              file_pass); // load file credentials when provided
-    const char* user = username_from_url
-                           ? username_from_url
-                           : (!file_user.empty() ? file_user.c_str()
-                                                 : (env_user ? env_user->c_str() : nullptr));
+    const char* user =
+        username_from_url
+            ? username_from_url
+            : (!file_user.empty() ? file_user.c_str() : (env_user ? env_user->c_str() : nullptr));
     if ((allowed_types & GIT_CREDENTIAL_SSH_KEY) && opts && !opts->ssh_private_key.empty() &&
         user) {
         const char* pub = nullptr;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -202,7 +202,7 @@ void parse_tracker_options(Options& opts, ArgParser& parser,
 void parse_limits(Options& opts, ArgParser& parser,
                   const std::function<std::string(const std::string&)>& cfg_opt,
                   const std::map<std::string, std::string>& cfg_opts) {
-        bool ok = false;
+    bool ok = false;
     if (cfg_opts.count("--cpu-percent")) {
         std::string v = cfg_opt("--cpu-percent");
         if (!v.empty() && v.back() == '%')
@@ -630,7 +630,7 @@ Options parse_options(int argc, char* argv[]) {
         if (val.empty() && cfg_opts.count("--rescan-new"))
             val = cfg_opt("--rescan-new");
         if (!val.empty()) {
-        bool ok2 = false;
+            bool ok2 = false;
             int mins = parse_int(val, 1, INT_MAX, ok);
             if (!ok)
                 throw std::runtime_error("Invalid value for --rescan-new");
@@ -682,7 +682,7 @@ Options parse_options(int argc, char* argv[]) {
         if (val.empty() && cfg_opts.count("--wait-empty"))
             val = cfg_opt("--wait-empty");
         if (!val.empty()) {
-        bool ok2 = false;
+            bool ok2 = false;
             opts.wait_empty_limit = parse_int(val, 1, INT_MAX, ok);
             if (!ok)
                 throw std::runtime_error("Invalid value for --wait-empty");
@@ -777,7 +777,7 @@ Options parse_options(int argc, char* argv[]) {
     opts.limits.concurrency = std::thread::hardware_concurrency();
     if (opts.limits.concurrency == 0)
         opts.limits.concurrency = 1;
-        bool ok2 = false;
+    bool ok2 = false;
     if (cfg_opts.count("--threads")) {
         opts.limits.concurrency = parse_size_t(cfg_opt("--threads"), 1, SIZE_MAX, ok);
         if (!ok)


### PR DESCRIPTION
## Summary
- run clang-format on service/daemon control helpers
- normalize credential user selection formatting
- clean up indentation in option parsers

## Testing
- `make format`
- `make lint`
- `make test` *(fails: libgit2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c57479be5c83259fb470c23bf4feeb