### PR TITLE
ci: add coverage job and badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
             coverage.svg
 
       - name: Publish coverage badge
+        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,58 @@ jobs:
       - name: Auto Test
         run: make test
 
-  build:
+  coverage:
     needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up build environment
+        uses: aminya/setup-cpp@v1
+
+      - name: Install dependencies
+        run: ./scripts/install_deps.sh
+
+      - name: Build with coverage
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
+          cmake --build build
+
+      - name: Run tests
+        run: |
+          cd build
+          ctest --output-on-failure
+
+      - name: Generate coverage report
+        run: |
+          pip install gcovr genbadge[coverage]
+          gcovr -r . --xml coverage.xml
+          genbadge coverage -i coverage.xml -o coverage.svg
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: |
+            coverage.xml
+            coverage.svg
+
+      - name: Publish coverage badge
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: badges
+          publish_dir: .
+          destination_dir: .
+          keep_files: true
+          user_name: github-actions
+          user_email: github-actions@github.com
+          commit_message: 'chore: update coverage badge'
+          enable_jekyll: false
+
+  build:
+    needs: coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,17 @@
 
 # autogitpull
 
+[![CI](https://github.com/aminya/autogitpull/actions/workflows/ci.yml/badge.svg)](https://github.com/aminya/autogitpull/actions/workflows/ci.yml)
+[![Coverage](https://raw.githubusercontent.com/aminya/autogitpull/badges/coverage.svg)](https://github.com/aminya/autogitpull/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/github/downloads/aminya/autogitpull/total)](https://github.com/aminya/autogitpull/releases)
+[![Stars](https://img.shields.io/github/stars/aminya/autogitpull?style=social)](https://github.com/aminya/autogitpull/stargazers)
+[![Forks](https://img.shields.io/github/forks/aminya/autogitpull?style=social)](https://github.com/aminya/autogitpull/network/members)
+[![Watchers](https://img.shields.io/github/watchers/aminya/autogitpull?style=social)](https://github.com/aminya/autogitpull/watchers)
+[![Commit activity](https://img.shields.io/github/commit-activity/m/aminya/autogitpull)](https://github.com/aminya/autogitpull/graphs/commit-activity)
+[![Commit total](https://img.shields.io/github/commit-activity/t/aminya/autogitpull)](https://github.com/aminya/autogitpull/graphs/commit-activity)
+[![Made with C++](https://img.shields.io/badge/Made%20with-C%2B%2B-1f425f.svg)](https://isocpp.org/)
+[![License](https://img.shields.io/github/license/aminya/autogitpull)](license.md)
+
 Automatic Git Puller & Monitor
 
 Tested and working on MacOS, Ubuntu and Windows


### PR DESCRIPTION
## Summary
- add repository badges for status, metrics, and metadata
- generate and publish coverage badge in CI

## Testing
- `make format`
- `make lint`
- `make test` *(fails: libgit2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a539de8c832590388b3cad2d5426