### PR TITLE
Add rolling release CI badge to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 # autogitpull
 
 [![CI](https://github.com/supermarsx/autogitpull/actions/workflows/ci.yml/badge.svg)](https://github.com/supermarsx/autogitpull/actions/workflows/ci.yml)
+[![Rolling Release](https://github.com/supermarsx/autogitpull/actions/workflows/rolling-release.yml/badge.svg)](https://github.com/supermarsx/autogitpull/actions/workflows/rolling-release.yml)
 [![Coverage](https://raw.githubusercontent.com/supermarsx/autogitpull/badges/coverage.svg)](https://github.com/supermarsx/autogitpull/actions/workflows/ci.yml)
 [![Downloads](https://img.shields.io/github/downloads/supermarsx/autogitpull/total)](https://github.com/supermarsx/autogitpull/releases)
 [![Stars](https://img.shields.io/github/stars/supermarsx/autogitpull?style=social)](https://github.com/supermarsx/autogitpull/stargazers)


### PR DESCRIPTION
## Summary
- add a status badge for the rolling release workflow to the README alongside existing badges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd8c5353dc83258aa750228ab26775