### PR TITLE
Fix install_deps.sh failure due to unbound array variable

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 echo "[autogitpull] Dependency install script is deprecated."
 echo "CMake (FetchContent) now builds third-party libs automatically."
 
-declare -a missing
+missing=()
 for tool in cmake git; do
   if ! command -v "$tool" >/dev/null 2>&1; then
     missing+=("$tool")


### PR DESCRIPTION
## Summary
- initialize the dependency tracking array to avoid nounset errors when no tools are missing

## Testing
- bash scripts/install_deps.sh

------
https://chatgpt.com/codex/tasks/task_e_68de4d934c9083259c5b5818d0655e43