### PR TITLE
Fix rolling preset macro expansion

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,6 @@
     {
       "name": "base",
       "hidden": true,
-      "binaryDir": "${sourceDir}/build/${presetName}/${hostSystemName}-${hostSystemProcessor}",
       "cacheVariables": {
         "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
         "CMAKE_INSTALL_RPATH_USE_LINK_PATH": "ON",
@@ -21,6 +20,7 @@
       "displayName": "Release",
       "description": "Optimized release build with stripped binaries on Unix platforms.",
       "inherits": ["base"],
+      "binaryDir": "${sourceDir}/build/${presetName}/${hostSystemName}",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
@@ -30,6 +30,7 @@
       "displayName": "RelWithDebInfo",
       "description": "Rolling release build with debug symbols.",
       "inherits": ["base"],
+      "binaryDir": "${sourceDir}/build/${presetName}/${hostSystemName}",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }


### PR DESCRIPTION
## Summary
- define the binary directory on the release and rolling presets instead of the hidden base preset
- drop the unsupported hostSystemProcessor macro so the rolling preset works across cmake versions while still grouping outputs by host OS

## Testing
- cmake --preset rolling -DCODEX_FORCE_NO_NSEC=ON

------
https://chatgpt.com/codex/tasks/task_e_68de649e4b7c83258d299bc4056e5664